### PR TITLE
Support for standard streams as transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,17 @@ java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044 -Declips
 
 Managing connection types
 -------------------------
-Java Language server supports socket and named pipes to communicate with the client.
-Client can communicate its preferred connection methods by setting up environment
-variables
-* For using named pipes set the following environment variables before starting
+Java Language server supports sockets, named pipes, and standard streams of the server process
+to communicate with the client. Client can communicate its preferred connection methods 
+by setting up environment variables. 
+
+* To use **name pipes**  set the following environment variables before starting
 the server.
 ```
 STDIN_PIPE_NAME --> where client reads from
 STDOUT_PIPE_NAME --> where client writes to
 ```
-* For using plain sockets set the following environment variables before starting the
+* To use **plain sockets** set the following environment variables before starting the
 server.
 ```
 STDIN_PORT --> client reads
@@ -94,7 +95,10 @@ optionally you can set host values for socket connections
 STDIN_HOST
 STDOUT_HOST
 ```
-For both connection types the client is expected to create the connections
+* To use standard streams(stdin, stdout) of the server process do not set any 
+of the above environment variables and the server will fall back to standard streams. 
+
+For socket and named pipes the client is expected to create the connections
 and wait for server the connect.
 
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory.java
@@ -105,6 +105,26 @@ public class ConnectionStreamFactory {
 
 	}
 
+	private final class StdIOStreamProvider implements StreamProvider{
+
+		/* (non-Javadoc)
+		 * @see org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StreamProvider#getInputStream()
+		 */
+		@Override
+		public InputStream getInputStream() throws IOException {
+			return System.in;
+		}
+
+		/* (non-Javadoc)
+		 * @see org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StreamProvider#getOutputStream()
+		 */
+		@Override
+		public OutputStream getOutputStream() throws IOException {
+			return System.out;
+		}
+
+	}
+
 	private static String OS = System.getProperty("os.name").toLowerCase();
 	private StreamProvider provider;
 	private static ConnectionStreamFactory instance;
@@ -122,6 +142,9 @@ public class ConnectionStreamFactory {
 			final String rPort = System.getenv().get("STDOUT_PORT");
 			if (rPort != null && wPort != null) {
 				provider = new SocketStreamProvider(rHost, Integer.parseInt(rPort), wHost, Integer.parseInt(wPort));
+			}
+			if(provider == null ){//Fall back to std io
+				provider = new StdIOStreamProvider();
 			}
 		}
 		return provider;


### PR DESCRIPTION
Falls back to using standard streams of the process for
transport. Closes #130 
