### PR TITLE
Empty statement quick fix

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/TextEditConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/TextEditConverter.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.text.edits.DeleteEdit;
 import org.eclipse.text.edits.InsertEdit;
+import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditVisitor;
 
@@ -80,6 +81,19 @@ public class TextEditConverter extends TextEditVisitor{
 		return super.visit(edit);
 	}
 
-
-
+	/* (non-Javadoc)
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.ReplaceEdit)
+	 */
+	@Override
+	public boolean visit(ReplaceEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setNewText(edit.getText());
+			te.setRange(JDTUtils.toRange(compilationUnit,edit.getOffset(),edit.getLength()));
+			converted.add(te);
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException("Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/DiagnosticsHelper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/DiagnosticsHelper.java
@@ -52,6 +52,18 @@ public class DiagnosticsHelper {
 			return -1;
 		}
 	}
+	/**
+	 * Returns the length of the diagnostic
+	 *
+	 * @param unit
+	 * @param diagnostic
+	 * @return length of the diagnostics range.
+	 */
+	public static int getLength(ICompilationUnit unit, Diagnostic diagnostic){
+		int start = DiagnosticsHelper.getStartOffset(unit, diagnostic);
+		int end = DiagnosticsHelper.getEndOffset(unit, diagnostic);
+		return end-start;
+	}
 
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/UnusedCodeCorrections.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/UnusedCodeCorrections.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditGroup;
 
@@ -38,6 +39,9 @@ public class UnusedCodeCorrections {
 		}
 	}
 
+	public static TextEdit createSuperfluousSemicolonTextEdit(CompilationUnit cu, int problemStart, int problemLength){
+		return new ReplaceEdit(problemStart, problemLength, "");
+	}
 
 	private static ImportDeclaration getImportDeclaration(CompilationUnit compilationUnit, int start, int length) {
 		NodeFinder finder = new NodeFinder(compilationUnit, start, length);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -70,6 +70,7 @@ public class CodeActionHandler {
 		case IProblem.CannotImportPackage:
 		case IProblem.ConflictingImport:
 		case IProblem.ImportNotFound:
+		case IProblem.SuperfluousSemicolon:
 			return true;
 		default:
 			return false;
@@ -98,10 +99,14 @@ public class CodeActionHandler {
 		case IProblem.ConflictingImport:
 		case IProblem.ImportNotFound:
 			//TODO: Add Organize imports command when/if we support it
-			int start = DiagnosticsHelper.getStartOffset(unit, diagnostic);
-			int end = DiagnosticsHelper.getEndOffset(unit, diagnostic);
-			org.eclipse.text.edits.TextEdit te = UnusedCodeCorrections.createUnusedImportTextEdit(getASTRoot(unit), start, end-start-1);
-			return Arrays.asList(textEditToCommand(unit, uri, "Remove unused import", te));
+			return Arrays.asList(textEditToCommand(unit, uri, "Remove unused import", UnusedCodeCorrections.createUnusedImportTextEdit(getASTRoot(unit),
+					DiagnosticsHelper.getStartOffset(unit, diagnostic),
+					DiagnosticsHelper.getLength(unit, diagnostic))));
+		case IProblem.SuperfluousSemicolon:
+			return Arrays.asList(textEditToCommand(unit, uri, "Remove semicolon", UnusedCodeCorrections.createSuperfluousSemicolonTextEdit(getASTRoot(unit),
+					DiagnosticsHelper.getStartOffset(unit, diagnostic),
+					DiagnosticsHelper.getLength(unit, diagnostic))));
+
 		default:
 			return Collections.emptyList();
 		}


### PR DESCRIPTION
Implements a quick fix for SuperfluousSemicolon. Improves
DiagnosticsHelper and TextEditConverter.

Signed-off-by: Gorkem Ercan <gorkem.ercan@gmail.com>