### PR TITLE
Support for SnippetString API

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -11,11 +11,13 @@
 package org.eclipse.jdt.ls.core.internal;
 
 import java.io.IOException;
+import java.util.Hashtable;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
@@ -55,6 +57,7 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		JavaLanguageServerPlugin.context = bundleContext;
 		JavaLanguageServerPlugin.pluginInstance = this;
 		preferenceManager = new PreferenceManager();
+		initializeJDTOptions();
 		projectsManager = new ProjectsManager(preferenceManager);
 		logInfo(getClass()+" is started");
 	}
@@ -81,7 +84,6 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		projectsManager = null;
 		languageServer = null;
 	}
-
 	private String getThreadDump() {
 		String lineSep = System.getProperty("line.separator");
 		StringBuilder sb = new StringBuilder();
@@ -140,6 +142,16 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		}
 	}
 
+	/**
+	 * Initialize default preference values of used bundles to match
+	 * server functionality.
+	 */
+	private void initializeJDTOptions() {
+		// Update JavaCore options
+		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
+		javaCoreOptions.put(JavaCore.CODEASSIST_VISIBILITY_CHECK, JavaCore.ENABLED);
+		JavaCore.setOptions(javaCoreOptions);
+	}
 
 	/**
 	 * @return

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -46,6 +46,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.text.edits.TextEdit;
 
@@ -72,12 +73,14 @@ public class CompletionProposalReplacementProvider {
 	private final int offset;
 	private final CompletionContext context;
 	private ImportRewrite importRewrite;
+	private boolean supportSnippets;
 
-	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset) {
+	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset, boolean snippetsSupported) {
 		super();
 		this.compilationUnit = compilationUnit;
 		this.context = context;
 		this.offset = offset;
+		this.supportSnippets = snippetsSupported;
 	}
 
 
@@ -128,7 +131,14 @@ public class CompletionProposalReplacementProvider {
 			}
 		}
 
+
+
 		appendReplacementString(completionBuffer, proposal);
+		if(supportSnippets && hasParameters(proposal)){
+			item.setInsertTextFormat(InsertTextFormat.Snippet);
+		}else{
+			item.setInsertTextFormat(InsertTextFormat.PlainText);
+		}
 		if (range == null) {
 			range = toReplacementRange(proposal);
 		}
@@ -240,10 +250,15 @@ public class CompletionProposalReplacementProvider {
 			}
 
 			char[] argument = parameterNames[i];
-
-			buffer.append("{{");
+			if(supportSnippets){
+				buffer.append("${");
+				buffer.append(Integer.toString(i+1));
+				buffer.append(":");
+			}
 			buffer.append(argument);
-			buffer.append("}}");
+			if(supportSnippets){
+				buffer.append("}");
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -129,7 +129,8 @@ public class CompletionResolveHandler {
 	 * @return
 	 */
 	private boolean isSnippetSupported() {
-		if(this.manager.getClientCapabilities().getTextDocument() != null){
+		if(this.manager.getClientCapabilities() != null &&
+				this.manager.getClientCapabilities().getTextDocument() != null){
 			return this.manager.getClientCapabilities().getTextDocument().getCompletion().getCompletionItem().getSnippetSupport().booleanValue();
 		}
 		return false;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -35,7 +35,14 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.osgi.util.NLS;
 
 import com.google.common.io.CharStreams;
-
+/**
+ * Adds the completion string and documentation.
+ * It checks the client capabilities.
+ * If a client supports both SnippetStrings and SignatureHelp
+ * SnippetStrings are prioritized for handling parameters.
+ *
+ *
+ */
 @SuppressWarnings("restriction")
 public class CompletionResolveHandler {
 
@@ -76,7 +83,7 @@ public class CompletionResolveHandler {
 		CompletionProposalReplacementProvider proposalProvider = new CompletionProposalReplacementProvider(unit,
 				completionResponse.getContext(),
 				completionResponse.getOffset(),
-				isSnippetSupported());
+				this.manager.getClientPreferences());
 		proposalProvider.updateReplacement(completionResponse.getProposals().get(proposalId), param, '\0');
 
 		if (data.containsKey(DATA_FIELD_DECLARATION_SIGNATURE)) {
@@ -123,16 +130,5 @@ public class CompletionResolveHandler {
 			}
 		}
 		return param;
-	}
-
-	/**
-	 * @return
-	 */
-	private boolean isSnippetSupported() {
-		if(this.manager.getClientCapabilities() != null &&
-				this.manager.getClientCapabilities().getTextDocument() != null){
-			return this.manager.getClientCapabilities().getTextDocument().getCompletion().getCompletionItem().getSnippetSupport().booleanValue();
-		}
-		return false;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ServiceStatus;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
@@ -57,6 +58,11 @@ final public class InitHandler {
 
 	InitializeResult initialize(InitializeParams param){
 		logInfo("Initializing Java Language Server "+JavaLanguageServerPlugin.getVersion());
+		if(param.getCapabilities()==null){
+			preferenceManager.setClientCapabilities(new ClientCapabilities());
+		}else{
+			preferenceManager.setClientCapabilities(param.getCapabilities());
+		}
 		triggerInitialization(param.getRootUri() == null? param.getRootPath():param.getRootUri());
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new WorkspaceDiagnosticsHandler(connection, projectsManager), IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.POST_CHANGE);
 		JavaLanguageServerPlugin.getLanguageServer().setParentProcessId(param.getProcessId().longValue());
@@ -79,8 +85,6 @@ final public class InitHandler {
 	}
 
 	private void triggerInitialization(String root) {
-		// Adjust any default preferences to server use
-		preferenceManager.initialize();
 
 		Job job = new Job("Initialize Workspace") {
 			@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -59,9 +59,9 @@ final public class InitHandler {
 	InitializeResult initialize(InitializeParams param){
 		logInfo("Initializing Java Language Server "+JavaLanguageServerPlugin.getVersion());
 		if(param.getCapabilities()==null){
-			preferenceManager.setClientCapabilities(new ClientCapabilities());
+			preferenceManager.updateClientPrefences(new ClientCapabilities());
 		}else{
-			preferenceManager.setClientCapabilities(param.getCapabilities());
+			preferenceManager.updateClientPrefences(param.getCapabilities());
 		}
 		triggerInitialization(param.getRootUri() == null? param.getRootPath():param.getRootUri());
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new WorkspaceDiagnosticsHandler(connection, projectsManager), IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.POST_CHANGE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -191,7 +191,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
 		logInfo(">> document/resolveCompletionItem");
-		CompletionResolveHandler handler = new CompletionResolveHandler();
+		CompletionResolveHandler handler = new CompletionResolveHandler(preferenceManager);
 		return CompletableFuture.supplyAsync(()->handler.resolve(unresolved));
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.preferences;
+
+import org.eclipse.lsp4j.ClientCapabilities;
+
+/**
+ * A wrapper around {@link ClientCapabilities}
+ *
+ * @author Gorkem Ercan
+ *
+ */
+public class ClientPreferences {
+
+	private final ClientCapabilities capabilities;
+	private final boolean v3supported;
+
+	public ClientPreferences(ClientCapabilities caps) {
+		if(caps == null ) throw new IllegalArgumentException("ClientCapabilities can not be null");
+		this.capabilities = caps;
+		this.v3supported = capabilities.getTextDocument() !=null;
+	}
+
+	public boolean isSignatureHelpSupported(){
+		return v3supported && capabilities.getTextDocument().getSignatureHelp() !=null;
+	}
+
+	public boolean isCompletionSnippetsSupported() {
+		return v3supported && capabilities.getTextDocument().getCompletion().getCompletionItem().getSnippetSupport().booleanValue();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -10,9 +10,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.preferences;
 
-import java.util.Hashtable;
+import org.eclipse.lsp4j.ClientCapabilities;
 
-import org.eclipse.jdt.core.JavaCore;
 /**
  * Preference manager
  *
@@ -23,29 +22,36 @@ import org.eclipse.jdt.core.JavaCore;
 public class PreferenceManager {
 
 	private Preferences preferences ;
+	private ClientCapabilities clientCapabilities;
 
 	public PreferenceManager() {
 		preferences = new Preferences();
 	}
 
-	/**
-	 * Initialize default preference values of used bundles to match
-	 * server functionality.
-	 */
-	public void initialize() {
-		// Update JavaCore options
-		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
-		javaCoreOptions.put(JavaCore.CODEASSIST_VISIBILITY_CHECK, JavaCore.ENABLED);
-		JavaCore.setOptions(javaCoreOptions);
-	}
-
 	public void update(Preferences preferences) {
+		if(preferences == null){
+			throw new IllegalArgumentException("Preferences can not be null");
+		}
 		this.preferences = preferences;
 		//TODO serialize preferences
 	}
 
 	public Preferences getPreferences() {
 		return preferences;
+	}
+
+	/**
+	 * @return the clientCapabilities
+	 */
+	public ClientCapabilities getClientCapabilities() {
+		return clientCapabilities;
+	}
+
+	/**
+	 * @param clientCapabilities the clientCapabilities to set
+	 */
+	public void setClientCapabilities(ClientCapabilities clientCapabilities) {
+		this.clientCapabilities = clientCapabilities;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -22,7 +22,7 @@ import org.eclipse.lsp4j.ClientCapabilities;
 public class PreferenceManager {
 
 	private Preferences preferences ;
-	private ClientCapabilities clientCapabilities;
+	private ClientPreferences clientPreferences;
 
 	public PreferenceManager() {
 		preferences = new Preferences();
@@ -40,18 +40,15 @@ public class PreferenceManager {
 		return preferences;
 	}
 
-	/**
-	 * @return the clientCapabilities
-	 */
-	public ClientCapabilities getClientCapabilities() {
-		return clientCapabilities;
+	public ClientPreferences getClientPreferences() {
+		return clientPreferences;
 	}
 
 	/**
 	 * @param clientCapabilities the clientCapabilities to set
 	 */
-	public void setClientCapabilities(ClientCapabilities clientCapabilities) {
-		this.clientCapabilities = clientCapabilities;
+	public void updateClientPrefences(ClientCapabilities clientCapabilities) {
+		this.clientPreferences = new ClientPreferences(clientCapabilities);
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractCompletionBasedTest extends AbstractProjectsManage
 		importProjects("eclipse/hello");
 		project = WorkspaceHelper.getProject("hello");
 		wcOwner = new LanguageServerWorkingCopyOwner(connection);
-		server= new JDTLanguageServer(projectsManager, null);
+		server= new JDTLanguageServer(projectsManager, preferenceManager);
 	}
 
 	protected ICompilationUnit getWorkingCopy(String path, String source) throws JavaModelException {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -29,12 +29,11 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
-import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
@@ -105,6 +104,10 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 
 	@Test
 	public void testCompletion_constructor() throws Exception{
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionSnippetsSupported()).thenReturn(Boolean.TRUE);
+
 		ICompilationUnit unit = getWorkingCopy(
 				"src/java/Foo.java",
 				"public class Foo {\n"+
@@ -142,7 +145,10 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 
 
 	@Test
-	public void testCompletion_2() throws JavaModelException{
+	public void testCompletion_import_package() throws JavaModelException{
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+
 		ICompilationUnit unit = getWorkingCopy(
 				"src/java/Foo.java",
 				"import java.sq \n" +
@@ -180,11 +186,13 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 	}
 
 	@Test
-	public void testCompletion_3_withLSPV2() throws JavaModelException{
+	public void testCompletion_method_withLSPV2() throws JavaModelException{
 
-		ClientCapabilities mockCapabilies = Mockito.mock(ClientCapabilities.class);
-		Mockito.when(preferenceManager.getClientCapabilities()).thenReturn(mockCapabilies);
-		Mockito.when(mockCapabilies.getTextDocument()).thenReturn(null);//return null to force LSP V2
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionSnippetsSupported()).thenReturn(Boolean.FALSE);
+		Mockito.when(mockCapabilies.isSignatureHelpSupported()).thenReturn(Boolean.FALSE);
+
 
 		ICompilationUnit unit = getWorkingCopy(
 				"src/java/Foo.java",
@@ -214,21 +222,22 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
 		assertNotNull(resolvedItem.getTextEdit());
-		assertTextEdit(5, 4, 6, "put(key, value)", resolvedItem.getTextEdit());
+		assertTextEdit(5, 4, 6, "put", resolvedItem.getTextEdit());
 		assertNotNull(resolvedItem.getAdditionalTextEdits());
 		List<TextEdit> edits = resolvedItem.getAdditionalTextEdits();
 		assertEquals(3, edits.size());
 	}
 
 	@Test
-	public void testCompletion_3_withLSPV3() throws JavaModelException{
+	public void testCompletion_method_withLSPV3() throws JavaModelException{
 
 		//Mock the preference manager to use LSP v3 support.
-		ClientCapabilities mockCapabilies = Mockito.mock(ClientCapabilities.class);//null checks
-		Mockito.when(preferenceManager.getClientCapabilities()).thenReturn(mockCapabilies); //needed for null checks
-		TextDocumentClientCapabilities mockTextDocs = Mockito.mock(TextDocumentClientCapabilities.class,Mockito.RETURNS_DEEP_STUBS);
-		Mockito.when(mockCapabilies.getTextDocument()).thenReturn(mockTextDocs);
-		Mockito.when(mockTextDocs.getCompletion().getCompletionItem().getSnippetSupport().booleanValue()).thenReturn(Boolean.TRUE);
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionSnippetsSupported()).thenReturn(Boolean.TRUE);
+		Mockito.when(mockCapabilies.isSignatureHelpSupported()).thenReturn(Boolean.TRUE);
+
+
 		ICompilationUnit unit = getWorkingCopy(
 				"src/java/Foo.java",
 				"public class Foo {\n"+
@@ -269,7 +278,43 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 	}
 
 	@Test
-	public void testCompletion_4() throws JavaModelException{
+	public void testCompletion_field() throws JavaModelException{
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"import java.sq \n" +
+						"public class Foo {\n"+
+						"private String myTestString;\n"+
+						"	void foo() {\n"+
+						"   this.myTestS\n"+
+						"	}\n"+
+				"}\n");
+
+		int[] loc = findCompletionLocation(unit, "this.myTestS");
+
+		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+
+		assertNotNull(list);
+		assertEquals(1, list.getItems().size());
+		CompletionItem item = list.getItems().get(0);
+		assertEquals(CompletionItemKind.Field, item.getKind());
+		assertNull(item.getInsertText());
+		assertNull(item.getAdditionalTextEdits());
+		assertNull(item.getTextEdit());
+
+		CompletionItem resolvedItem = server.resolveCompletionItem(item).join();
+		assertNotNull(resolvedItem.getTextEdit());
+		assertTextEdit(4,8,15,"myTestString",resolvedItem.getTextEdit());
+		//Not checking the range end character
+	}
+
+	@Test
+	public void testCompletion_import_type() throws JavaModelException{
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+
 		ICompilationUnit unit = getWorkingCopy(
 				"src/java/Foo.java",
 				"import java.sq \n" +

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.Mock;
 
 /**
  * @author Fred Bricon
@@ -39,10 +40,12 @@ public abstract class AbstractProjectsManagerBasedTest {
 
 	protected IProgressMonitor monitor = new NullProgressMonitor();
 	protected ProjectsManager projectsManager;
+	@Mock
+	protected PreferenceManager preferenceManager;
 
 	@Before
 	public void initProjectManager() {
-		projectsManager = new ProjectsManager(new PreferenceManager());
+		projectsManager = new ProjectsManager(preferenceManager);
 	}
 
 	protected List<IProject> importProjects(String path) throws Exception {


### PR DESCRIPTION
Removes the older VS Code specific way of marking tab stops
Uses the new SnippetStrings as defined by the protocol.
The snippetStrings are used if the client indicates via
ClientCapabilities that it supports SnippetStrings otherwise
they are not used. Also adds ClientCapabilities to
PreferenceManager.

Fixes #159, fixes redhat-developer/vscode-java#99