### PR TITLE
Reorganize connection creation

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/Environment.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/Environment.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+/**
+ * Helper class for reading environment variables and system properties.
+ *
+ * @author Gorkem Ercan
+ *
+ */
+public final class Environment {
+
+	/**
+	 * Retrieves environment variable value for given name.
+	 *
+	 * @return value or null
+	 */
+	public static String getEnvironment(final String name){
+		if(name == null || name.isEmpty())
+			return null;
+		return System.getenv(name);
+	}
+
+	/**
+	 * Retrieves system property value for given name.
+	 *
+	 * @return value or null
+	 */
+	public static String getProperty(final String name){
+		if(name == null || name.isEmpty())
+			return null;
+		return System.getProperty(name);
+	}
+
+	/**
+	 * Retrieves environment variable or system property value for given name.
+	 * Checks the environment value first.
+	 *
+	 * @return value or null
+	 */
+	public static String get(final String name){
+		String value = getEnvironment(name);
+		if(value == null)
+			value = getProperty(name);
+		return value;
+	}
+
+	/**
+	 * Retrieves environment variable or system property value for given name.
+	 * Checks the environment value first.
+	 *
+	 * @return value or null
+	 */
+	public static String get(final String name, final String defaultValue){
+		String value = get(name);
+		if(value == null)
+			value = defaultValue;
+		return value;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -64,9 +64,10 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 
 	private void startConnection() throws IOException {
 		protocol = new JDTLanguageServer(projectsManager, preferenceManager);
+		ConnectionStreamFactory connectionFactory = new ConnectionStreamFactory();
 		Launcher<JavaLanguageClient> launcher = Launcher.createLauncher(protocol, JavaLanguageClient.class,
-				ConnectionStreamFactory.getInputStream(),
-				ConnectionStreamFactory.getOutputStream());
+				connectionFactory.getInputStream(),
+				connectionFactory.getOutputStream());
 		protocol.connectClient(launcher.getRemoteProxy());
 		launcher.startListening();
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactoryTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactoryTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.NamedPipeStreamProvider;
+import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.SocketStreamProvider;
+import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StdIOStreamProvider;
+import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StreamProvider;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class ConnectionStreamFactoryTest {
+
+	@Test
+	public void testStdIOSelection(){
+		checkStreamProvider(StdIOStreamProvider.class);
+	}
+
+	@Test
+	public void testNamedPipeSelection(){
+		System.setProperty("STDIN_PIPE_NAME", "test_pipe_in");
+		System.setProperty("STDOUT_PIPE_NAME", "test_pipe_out");
+		checkStreamProvider(NamedPipeStreamProvider.class);
+		System.clearProperty("STDIN_PIPE_NAME");
+		System.clearProperty("STDOUT_PIPE_NAME");
+	}
+
+	@Test
+	public void testSocketSelection(){
+		System.setProperty("STDIN_PORT", "10001");
+		System.setProperty("STDOUT_PORT", "10002");
+		checkStreamProvider(SocketStreamProvider.class);
+		System.clearProperty("STDIN_PORT");
+		System.clearProperty("STDOUT_PORT");
+	}
+
+	private void checkStreamProvider(Class<? extends StreamProvider> providerClass){
+		ConnectionStreamFactory tested = new ConnectionStreamFactory();
+		StreamProvider provider = tested.getSelectedStream();
+		Assert.assertSame(providerClass, provider.getClass());
+	}
+
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/EnvironmentTests.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/EnvironmentTests.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class EnvironmentTests {
+
+	@Test
+	public void testEnvironmentVars(){
+		assertNull(Environment.getEnvironment(null));
+	}
+
+	@Test
+	public void testProperty(){
+		assertNull(Environment.getProperty(null));
+		assertNull(Environment.getProperty("madeup.property"));
+		assertNotNull(Environment.getProperty("os.name"));
+	}
+
+	@Test
+	public void testAll(){
+		assertNull(Environment.get(null));
+		assertNull(Environment.get("madeup.property"));
+		assertNotNull(Environment.get("os.name"));
+		assertEquals("defaultValue", Environment.get("madeup.property", "defaultValue"));
+	}
+
+}


### PR DESCRIPTION
Removes the static instance for connection creation since
the connection is created only once. Adds tests for
connection selection. Adds a helper for reading environment
and System properties.