### PR TITLE
Ensure default package classes don't break completion. Fixes redhat-developer/vscode-java#166

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -396,8 +396,10 @@ public class CompletionProposalDescriptionProvider {
 
 		StringBuilder nameBuffer= new StringBuilder();
 		nameBuffer.append(new String(fullName, qIndex, fullName.length - qIndex));
-		nameBuffer.append(PACKAGE_NAME_SEPARATOR);
-		nameBuffer.append(new String(fullName,0,qIndex-1));
+		if (qIndex > 0) {
+			nameBuffer.append(PACKAGE_NAME_SEPARATOR);
+			nameBuffer.append(new String(fullName,0,qIndex-1));
+		}
 		item.setLabel(nameBuffer.toString());
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -348,6 +348,21 @@ public class CompletionHandlerTest extends AbstractCompletionBasedTest {
 		//Not checking the range end character
 	}
 
+	@Test
+	public void testCompletion_noPackage() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/NoPackage.java",
+				"public class NoPackage {\n"
+						+ "    NoP"
+						+"}\n");
+		int[] loc = findCompletionLocation(unit, "    NoP");
+		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+		assertNotNull(list);
+		assertFalse("No proposals were found", list.getItems().isEmpty());
+		assertEquals("NoPackage", list.getItems().get(0).getLabel());
+	}
+
+
 
 	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {
 		return COMPLETION_TEMPLATE.replace("${file}", JDTUtils.getFileURI(unit))


### PR DESCRIPTION
See https://github.com/redhat-developer/vscode-java/issues/166

Signed-off-by: Fred Bricon <fbricon@gmail.com>