### PR TITLE
Fix for method overrides completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/SharedASTProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/SharedASTProvider.java
@@ -70,6 +70,9 @@ public final class SharedASTProvider {
 		}
 	}
 
+	public void invalidateAll() {
+		cache.clear();
+	}
 
 	/**
 	 * Creates a new compilation unit AST.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Stephan Herrmann - Contribution for Bug 463360 - [override method][null] generating method override should not create redundant null annotations
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.contentassist;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ITrackedNodePosition;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.core.formatter.IndentManipulation;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.SharedASTProvider;
+import org.eclipse.jdt.ls.core.internal.corext.codemanipulation.CodeGenerationSettings;
+import org.eclipse.jdt.ls.core.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
+import org.eclipse.jdt.ls.core.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.TextUtilities;
+import org.eclipse.text.edits.MalformedTreeException;
+
+/**
+ * Generates Override completion proposals.
+ *
+ * Code copied from
+ * org.eclipse.jdt.internal.ui.text.java.OverrideCompletionProposal
+ */
+public class OverrideCompletionProposal {
+
+	private IJavaProject fJavaProject;
+	private String fMethodName;
+	private String[] fParamTypes;
+	private ICompilationUnit fCompilationUnit;
+
+	public OverrideCompletionProposal(ICompilationUnit cu, String methodName, String[] paramTypes, String completionProposal) {
+		this.fCompilationUnit = cu;
+		Assert.isNotNull(cu.getJavaProject());
+		Assert.isNotNull(methodName);
+		Assert.isNotNull(paramTypes);
+		Assert.isNotNull(cu);
+
+		fParamTypes= paramTypes;
+		fMethodName= methodName;
+		fJavaProject= cu.getJavaProject();
+	}
+
+	private CompilationUnit getRecoveredAST(IDocument document, int offset, Document recoveredDocument) {
+		CompilationUnit ast = SharedASTProvider.getInstance().getAST(fCompilationUnit, null);
+		if (ast != null) {
+			recoveredDocument.set(document.get());
+			return ast;
+		}
+
+		char[] content= document.get().toCharArray();
+
+		// clear prefix to avoid compile errors
+		int index= offset - 1;
+		while (index >= 0 && Character.isJavaIdentifierPart(content[index])) {
+			content[index]= ' ';
+			index--;
+		}
+
+		recoveredDocument.set(new String(content));
+
+		final ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setSource(content);
+		parser.setUnitName(fCompilationUnit.getElementName());
+		parser.setProject(fCompilationUnit.getJavaProject());
+		return (CompilationUnit) parser.createAST(new NullProgressMonitor());
+	}
+
+	/*
+	 * @see JavaTypeCompletionProposal#updateReplacementString(IDocument,char,int,ImportRewrite)
+	 */
+	public String updateReplacementString(IDocument document, int offset, ImportRewrite importRewrite,
+			boolean snippetStringSupport)
+					throws CoreException, BadLocationException {
+		Document recoveredDocument= new Document();
+		CompilationUnit unit= getRecoveredAST(document, offset, recoveredDocument);
+		ImportRewriteContext context = new ContextSensitiveImportRewriteContext(unit, offset, importRewrite);
+
+		ITypeBinding declaringType= null;
+		ChildListPropertyDescriptor descriptor= null;
+		ASTNode node= NodeFinder.perform(unit, offset, 1);
+		node= ASTResolving.findParentType(node);
+		String result = null;
+		if (node instanceof AnonymousClassDeclaration) {
+			declaringType= ((AnonymousClassDeclaration) node).resolveBinding();
+			descriptor= AnonymousClassDeclaration.BODY_DECLARATIONS_PROPERTY;
+		} else if (node instanceof AbstractTypeDeclaration) {
+			AbstractTypeDeclaration declaration= (AbstractTypeDeclaration) node;
+			descriptor= declaration.getBodyDeclarationsProperty();
+			declaringType= declaration.resolveBinding();
+		}
+		if (declaringType != null) {
+			ASTRewrite rewrite= ASTRewrite.create(unit.getAST());
+			IMethodBinding methodToOverride= Bindings.findMethodInHierarchy(declaringType, fMethodName, fParamTypes);
+			if (methodToOverride == null && declaringType.isInterface()) {
+				methodToOverride= Bindings.findMethodInType(node.getAST().resolveWellKnownType("java.lang.Object"), fMethodName, fParamTypes); //$NON-NLS-1$
+			}
+			if (methodToOverride != null) {
+				CodeGenerationSettings settings = getCodeGenerationSettings(fJavaProject);
+				MethodDeclaration stub = StubUtility2.createImplementationStub(fCompilationUnit, rewrite, importRewrite,
+						context, methodToOverride, declaringType, settings, declaringType.isInterface(), declaringType,
+						snippetStringSupport);
+				ListRewrite rewriter= rewrite.getListRewrite(node, descriptor);
+				rewriter.insertFirst(stub, null);
+
+				ITrackedNodePosition position= rewrite.track(stub);
+				try {
+					Map<String, String> options = fJavaProject.getOptions(true);
+
+					rewrite.rewriteAST(recoveredDocument, options).apply(recoveredDocument);
+
+					String generatedCode = recoveredDocument.get(position.getStartPosition(), position.getLength());
+
+					String indentAt = getIndentAt(recoveredDocument, position.getStartPosition(), settings);
+					int generatedIndent = IndentManipulation.measureIndentUnits(indentAt, settings.tabWidth,
+							settings.indentWidth);
+					// Kinda fishy but empirical data shows Override needs to change indent by at
+					// least 1
+					generatedIndent = Math.max(1, generatedIndent);
+
+					// Cancel generated code indent
+					String delimiter = TextUtilities.getDefaultLineDelimiter(document);
+					result = IndentManipulation.changeIndent(generatedCode, generatedIndent, settings.tabWidth,
+							settings.indentWidth, "", delimiter);
+
+				} catch (MalformedTreeException | BadLocationException exception) {
+					JavaLanguageServerPlugin.logException("Unable to compute override proposal", exception);
+				}
+			}
+		}
+		return result;
+	}
+
+	private static String getIndentAt(IDocument document, int offset, CodeGenerationSettings settings) {
+		try {
+			IRegion region= document.getLineInformationOfOffset(offset);
+			return IndentManipulation.extractIndentString(document.get(region.getOffset(), region.getLength()), settings.tabWidth, settings.indentWidth);
+		} catch (BadLocationException e) {
+			return ""; //$NON-NLS-1$
+		}
+	}
+
+	private static CodeGenerationSettings getCodeGenerationSettings(IJavaProject project) {
+		CodeGenerationSettings res = new CodeGenerationSettings();
+		// TODO indentation settings should be retrieved from client/external settings?
+		res.tabWidth = CodeFormatterUtil.getTabWidth(project);
+		res.indentWidth = CodeFormatterUtil.getIndentWidth(project);
+		return res;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/CodeGenerationSettings.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/CodeGenerationSettings.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+/**
+ * Code copied from
+ * org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings
+ */
+public class CodeGenerationSettings {
+	public boolean overrideAnnotation = true;
+	public int tabWidth;
+	public int indentWidth;
+}
+

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/ContextSensitiveImportRewriteContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/ContextSensitiveImportRewriteContext.java
@@ -1,0 +1,256 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
+import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+
+/**
+ * This <code>ImportRewriteContext</code> is aware of all the types visible in
+ * <code>compilationUnit</code> at <code>position</code>.
+ * <p>
+ * <b>Note:</b> This context only works if the AST was created with bindings!
+ * </p>
+ *
+ * Code copied from
+ * org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext
+ */
+public class ContextSensitiveImportRewriteContext extends ImportRewriteContext {
+
+	private final CompilationUnit fCompilationUnit;
+	private final int fPosition;
+	private IBinding[] fDeclarationsInScope;
+	private Name[] fImportedNames;
+	private final ImportRewrite fImportRewrite;
+	private RedundantNullnessTypeAnnotationsFilter fRedundantTypeAnnotationsFilter;
+
+	/**
+	 * Creates an import rewrite context at the given node's start position.
+	 *
+	 * @param node the node to use as context
+	 * @param importRewrite the import rewrite
+	 *
+	 * @since 3.6
+	 */
+	public ContextSensitiveImportRewriteContext(ASTNode node, ImportRewrite importRewrite) {
+		this((CompilationUnit) node.getRoot(), node.getStartPosition(), importRewrite, RedundantNullnessTypeAnnotationsFilter.createIfConfigured(node));
+	}
+
+	/**
+	 * Creates an import rewrite context at the given start position.
+	 *
+	 * @param compilationUnit the root (must have resolved bindings)
+	 * @param position the context position
+	 * @param importRewrite the import rewrite
+	 */
+	public ContextSensitiveImportRewriteContext(CompilationUnit compilationUnit, int position, ImportRewrite importRewrite) {
+		this(compilationUnit, position, importRewrite, RedundantNullnessTypeAnnotationsFilter.createIfConfigured(new NodeFinder(compilationUnit, position, 0).getCoveringNode()));
+	}
+
+	private ContextSensitiveImportRewriteContext(CompilationUnit compilationUnit, int position, ImportRewrite importRewrite,
+			RedundantNullnessTypeAnnotationsFilter redundantNullnessTypeAnnotationsFilter) {
+		fCompilationUnit= compilationUnit;
+		fPosition= position;
+		fImportRewrite= importRewrite;
+		fDeclarationsInScope= null;
+		fImportedNames= null;
+		fRedundantTypeAnnotationsFilter= redundantNullnessTypeAnnotationsFilter;
+	}
+
+	@Override
+	public int findInContext(String qualifier, String name, int kind) {
+		IBinding[] declarationsInScope= getDeclarationsInScope();
+		for (int i= 0; i < declarationsInScope.length; i++) {
+			if (declarationsInScope[i] instanceof ITypeBinding) {
+				ITypeBinding typeBinding= (ITypeBinding)declarationsInScope[i];
+				if (isSameType(typeBinding, qualifier, name)) {
+					return RES_NAME_FOUND;
+				} else if (isConflicting(typeBinding, name)) {
+					return RES_NAME_CONFLICT;
+				}
+			} else if (declarationsInScope[i] != null) {
+				if (isConflicting(declarationsInScope[i], name)) {
+					return RES_NAME_CONFLICT;
+				}
+			}
+		}
+
+
+		Name[] names= getImportedNames();
+		for (int i= 0; i < names.length; i++) {
+			IBinding binding= names[i].resolveBinding();
+			if (binding instanceof ITypeBinding && !binding.isRecovered()) {
+				ITypeBinding typeBinding= (ITypeBinding)binding;
+				if (isConflictingType(typeBinding, qualifier, name)) {
+					return RES_NAME_CONFLICT;
+				}
+			}
+		}
+
+		List<AbstractTypeDeclaration> list= fCompilationUnit.types();
+		for (Iterator<AbstractTypeDeclaration> iter= list.iterator(); iter.hasNext();) {
+			AbstractTypeDeclaration type= iter.next();
+			ITypeBinding binding= type.resolveBinding();
+			if (binding != null) {
+				if (isSameType(binding, qualifier, name)) {
+					return RES_NAME_FOUND;
+				} else {
+					ITypeBinding decl= containingDeclaration(binding, qualifier, name);
+					while (decl != null && !decl.equals(binding)) {
+						int modifiers= decl.getModifiers();
+						if (Modifier.isPrivate(modifiers)) {
+							return RES_NAME_CONFLICT;
+						}
+						decl= decl.getDeclaringClass();
+					}
+				}
+			}
+		}
+
+		String[] addedImports= fImportRewrite.getAddedImports();
+		String qualifiedName= JavaModelUtil.concatenateName(qualifier, name);
+		for (int i= 0; i < addedImports.length; i++) {
+			String addedImport= addedImports[i];
+			if (qualifiedName.equals(addedImport)) {
+				return RES_NAME_FOUND;
+			} else {
+				if (isConflicting(name, addedImport)) {
+					return RES_NAME_CONFLICT;
+				}
+			}
+		}
+
+		if (qualifier.equals("java.lang")) { //$NON-NLS-1$
+			//No explicit import statement required
+			ITypeRoot typeRoot= fCompilationUnit.getTypeRoot();
+			if (typeRoot != null) {
+				IPackageFragment packageFragment= (IPackageFragment) typeRoot.getParent();
+				try {
+					ICompilationUnit[] compilationUnits= packageFragment.getCompilationUnits();
+					for (int i= 0; i < compilationUnits.length; i++) {
+						ICompilationUnit cu= compilationUnits[i];
+						IType[] allTypes= cu.getAllTypes();
+						for (int j= 0; j < allTypes.length; j++) {
+							IType type= allTypes[j];
+							String packageTypeName= type.getFullyQualifiedName();
+							if (isConflicting(name, packageTypeName)) {
+								return RES_NAME_CONFLICT;
+							}
+						}
+					}
+				} catch (JavaModelException e) {
+				}
+			}
+		}
+
+		return fImportRewrite.getDefaultImportRewriteContext().findInContext(qualifier, name, kind);
+	}
+
+	private boolean isConflicting(String name, String importt) {
+		int index= importt.lastIndexOf('.');
+		String importedName;
+		if (index == -1) {
+			importedName= importt;
+		} else {
+			importedName= importt.substring(index + 1, importt.length());
+		}
+		if (importedName.equals(name)) {
+			return true;
+		}
+		return false;
+	}
+
+	private ITypeBinding containingDeclaration(ITypeBinding binding, String qualifier, String name) {
+		ITypeBinding[] declaredTypes= binding.getDeclaredTypes();
+		for (int i= 0; i < declaredTypes.length; i++) {
+			ITypeBinding childBinding= declaredTypes[i];
+			if (isSameType(childBinding, qualifier, name)) {
+				return childBinding;
+			} else {
+				ITypeBinding result= containingDeclaration(childBinding, qualifier, name);
+				if (result != null) {
+					return result;
+				}
+			}
+		}
+		return null;
+	}
+
+	private boolean isConflicting(IBinding binding, String name) {
+		return binding.getName().equals(name);
+	}
+
+	private boolean isSameType(ITypeBinding binding, String qualifier, String name) {
+		String qualifiedName= JavaModelUtil.concatenateName(qualifier, name);
+		return binding.getQualifiedName().equals(qualifiedName);
+	}
+
+	private boolean isConflictingType(ITypeBinding binding, String qualifier, String name) {
+		binding= binding.getTypeDeclaration();
+		return !isSameType(binding, qualifier, name) && isConflicting(binding, name);
+	}
+
+	private IBinding[] getDeclarationsInScope() {
+		if (fDeclarationsInScope == null) {
+			ScopeAnalyzer analyzer= new ScopeAnalyzer(fCompilationUnit);
+			fDeclarationsInScope= analyzer.getDeclarationsInScope(fPosition, ScopeAnalyzer.METHODS | ScopeAnalyzer.TYPES | ScopeAnalyzer.VARIABLES);
+		}
+		return fDeclarationsInScope;
+	}
+
+	private Name[] getImportedNames() {
+		if (fImportedNames == null) {
+			IJavaProject project= null;
+			IJavaElement javaElement= fCompilationUnit.getJavaElement();
+			if (javaElement != null) {
+				project= javaElement.getJavaProject();
+			}
+
+			List<SimpleName> imports= new ArrayList<>();
+			ImportReferencesCollector.collect(fCompilationUnit, project, null, imports, null);
+			fImportedNames= imports.toArray(new Name[imports.size()]);
+		}
+		return fImportedNames;
+	}
+
+	@Override
+	public IAnnotationBinding[] removeRedundantTypeAnnotations(IAnnotationBinding[] annotations, TypeLocation location, ITypeBinding type) {
+		RedundantNullnessTypeAnnotationsFilter redundantTypeAnnotationsFilter= fRedundantTypeAnnotationsFilter;
+		if (redundantTypeAnnotationsFilter != null) {
+			annotations= redundantTypeAnnotationsFilter.removeUnwantedTypeAnnotations(annotations, location, type);
+		}
+		return super.removeRedundantTypeAnnotations(annotations, location, type);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/ImportReferencesCollector.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/ImportReferencesCollector.java
@@ -1,0 +1,533 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AnnotatableType;
+import org.eclipse.jdt.core.dom.BreakStatement;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ContinueStatement;
+import org.eclipse.jdt.core.dom.CreationReference;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionMethodReference;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.LabeledStatement;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MemberRef;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodRef;
+import org.eclipse.jdt.core.dom.MethodRefParameter;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NameQualifiedType;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.SuperMethodReference;
+import org.eclipse.jdt.core.dom.TagElement;
+import org.eclipse.jdt.core.dom.ThisExpression;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeMethodReference;
+import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
+import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jface.text.Region;
+
+/**
+ * Code copied from
+ * org.eclipse.jdt.internal.corext.codemanipulation.ImportReferencesCollector
+ */
+public class ImportReferencesCollector extends GenericVisitor {
+
+	public static void collect(ASTNode node, IJavaProject project, Region rangeLimit, Collection<SimpleName> resultingTypeImports, Collection<SimpleName> resultingStaticImports) {
+		collect(node, project, rangeLimit, false, resultingTypeImports, resultingStaticImports);
+	}
+
+	public static void collect(ASTNode node, IJavaProject project, Region rangeLimit, boolean skipMethodBodies, Collection<SimpleName> resultingTypeImports, Collection<SimpleName> resultingStaticImports) {
+		ASTNode root= node.getRoot();
+		CompilationUnit astRoot= root instanceof CompilationUnit ? (CompilationUnit) root : null;
+		node.accept(new ImportReferencesCollector(project, astRoot, rangeLimit, skipMethodBodies, resultingTypeImports, resultingStaticImports));
+	}
+
+	private CompilationUnit fASTRoot;
+	private Region fSubRange;
+	private Collection<SimpleName> fTypeImports;
+	private Collection<SimpleName> fStaticImports;
+	private boolean fSkipMethodBodies;
+
+	private ImportReferencesCollector(IJavaProject project, CompilationUnit astRoot, Region rangeLimit, boolean skipMethodBodies, Collection<SimpleName> resultingTypeImports, Collection<SimpleName> resultingStaticImports) {
+		super(processJavadocComments(astRoot));
+		fTypeImports= resultingTypeImports;
+		fStaticImports= resultingStaticImports;
+		fSubRange= rangeLimit;
+		if (project == null || !JavaModelUtil.is50OrHigher(project)) {
+			fStaticImports= null; // do not collect
+		}
+		fASTRoot= astRoot; // can be null
+		fSkipMethodBodies= skipMethodBodies;
+	}
+
+	private static boolean processJavadocComments(CompilationUnit astRoot) {
+		// don't visit Javadoc for 'package-info' (bug 216432)
+		if (astRoot != null && astRoot.getTypeRoot() != null) {
+			return !JavaModelUtil.PACKAGE_INFO_JAVA.equals(astRoot.getTypeRoot().getElementName());
+		}
+		return true;
+	}
+
+	private boolean isAffected(ASTNode node) {
+		if (fSubRange == null) {
+			return true;
+		}
+		int nodeStart= node.getStartPosition();
+		int offset= fSubRange.getOffset();
+		return nodeStart + node.getLength() > offset && offset + fSubRange.getLength() >  nodeStart;
+	}
+
+
+	private void addReference(SimpleName name) {
+		if (isAffected(name)) {
+			fTypeImports.add(name);
+		}
+	}
+
+	private void typeRefFound(Name node) {
+		if (node != null) {
+			while (node.isQualifiedName()) {
+				node= ((QualifiedName) node).getQualifier();
+			}
+			addReference((SimpleName) node);
+		}
+	}
+
+	private void possibleTypeRefFound(Name node) {
+		while (node.isQualifiedName()) {
+			node= ((QualifiedName) node).getQualifier();
+		}
+		IBinding binding= node.resolveBinding();
+		if (binding == null || binding.getKind() == IBinding.TYPE) {
+			// if the binding is null, we cannot determine if
+			// we have a type binding or not, so we will assume
+			// we do.
+			addReference((SimpleName) node);
+		}
+	}
+
+	private void possibleStaticImportFound(Name name) {
+		if (fStaticImports == null || fASTRoot == null) {
+			return;
+		}
+
+		while (name.isQualifiedName()) {
+			name= ((QualifiedName) name).getQualifier();
+		}
+		if (!isAffected(name)) {
+			return;
+		}
+
+		IBinding binding= name.resolveBinding();
+		SimpleName simpleName= (SimpleName)name;
+		if (binding == null) {
+			// This may be a currently unresolvable reference to a static member.
+			fStaticImports.add(simpleName);
+		} else if (binding instanceof ITypeBinding || !Modifier.isStatic(binding.getModifiers()) || simpleName.isDeclaration()) {
+			return;
+		} else if (binding instanceof IVariableBinding) {
+			IVariableBinding varBinding= (IVariableBinding) binding;
+			if (varBinding.isField()) {
+				varBinding= varBinding.getVariableDeclaration();
+				ITypeBinding declaringClass= varBinding.getDeclaringClass();
+				if (declaringClass != null && !declaringClass.isLocal()) {
+					if (new ScopeAnalyzer(fASTRoot).isDeclaredInScope(varBinding, simpleName, ScopeAnalyzer.VARIABLES | ScopeAnalyzer.CHECK_VISIBILITY)) {
+						return;
+					}
+					fStaticImports.add(simpleName);
+				}
+			}
+		} else if (binding instanceof IMethodBinding) {
+			IMethodBinding methodBinding= ((IMethodBinding) binding).getMethodDeclaration();
+			ITypeBinding declaringClass= methodBinding.getDeclaringClass();
+			if (declaringClass != null && !declaringClass.isLocal()) {
+				if (new ScopeAnalyzer(fASTRoot).isDeclaredInScope(methodBinding, simpleName, ScopeAnalyzer.METHODS | ScopeAnalyzer.CHECK_VISIBILITY)) {
+					return;
+				}
+				fStaticImports.add(simpleName);
+			}
+		}
+
+	}
+
+	private void doVisitChildren(List<? extends ASTNode> elements) {
+		int nElements= elements.size();
+		for (int i= 0; i < nElements; i++) {
+			((ASTNode) elements.get(i)).accept(this);
+		}
+	}
+
+	private void doVisitNode(ASTNode node) {
+		if (node != null) {
+			node.accept(this);
+		}
+	}
+
+	@Override
+	protected boolean visitNode(ASTNode node) {
+		return isAffected(node);
+	}
+
+	/*
+	 * @see ASTVisitor#visit(SimpleType)
+	 */
+	@Override
+	public boolean visit(SimpleType node) {
+		typeRefFound(node.getName());
+		visitAnnotations(node);
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(NameQualifiedType)
+	 */
+	@Override
+	public boolean visit(NameQualifiedType node) {
+		possibleTypeRefFound(node.getQualifier());
+		visitAnnotations(node);
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(QualifiedType)
+	 */
+	@Override
+	public boolean visit(QualifiedType node) {
+		doVisitNode(node.getQualifier());
+		visitAnnotations(node);
+		return false;
+	}
+
+	private void visitAnnotations(AnnotatableType node) {
+		if (node.getAST().apiLevel() >= AST.JLS8) {
+			doVisitChildren(node.annotations());
+		}
+	}
+
+	/*
+	 * @see ASTVisitor#visit(QualifiedName)
+	 */
+	@Override
+	public boolean visit(QualifiedName node) {
+		possibleTypeRefFound(node); // possible ref
+		possibleStaticImportFound(node);
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(ImportDeclaration)
+	 */
+	@Override
+	public boolean visit(ImportDeclaration node) {
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(PackageDeclaration)
+	 */
+	@Override
+	public boolean visit(PackageDeclaration node) {
+		doVisitNode(node.getJavadoc());
+		doVisitChildren(node.annotations());
+		return false;
+	}
+
+	@Override
+	public boolean visit(LabeledStatement node) {
+		doVisitNode(node.getBody());
+		return false;
+	}
+
+	@Override
+	public boolean visit(ContinueStatement node) {
+		return false;
+	}
+
+	@Override
+	public boolean visit(BreakStatement node) {
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(ThisExpression)
+	 */
+	@Override
+	public boolean visit(ThisExpression node) {
+		typeRefFound(node.getQualifier());
+		return false;
+	}
+
+	@Override
+	public boolean visit(SuperFieldAccess node) {
+		typeRefFound(node.getQualifier());
+		return false;
+	}
+
+	private void evalQualifyingExpression(Expression expr, Name selector) {
+		if (expr != null) {
+			if (expr instanceof Name) {
+				Name name= (Name) expr;
+				possibleTypeRefFound(name);
+				possibleStaticImportFound(name);
+			} else {
+				expr.accept(this);
+			}
+		} else if (selector != null) {
+			possibleStaticImportFound(selector);
+		}
+	}
+
+	/*
+	 * @see ASTVisitor#visit(ClassInstanceCreation)
+	 */
+	@Override
+	public boolean visit(ClassInstanceCreation node) {
+		doVisitChildren(node.typeArguments());
+		doVisitNode(node.getType());
+		evalQualifyingExpression(node.getExpression(), null);
+		if (node.getAnonymousClassDeclaration() != null) {
+			node.getAnonymousClassDeclaration().accept(this);
+		}
+		doVisitChildren(node.arguments());
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#endVisit(MethodInvocation)
+	 */
+	@Override
+	public boolean visit(MethodInvocation node) {
+		evalQualifyingExpression(node.getExpression(), node.getName());
+		doVisitChildren(node.typeArguments());
+		doVisitChildren(node.arguments());
+		return false;
+	}
+
+	@Override
+	public boolean visit(CreationReference node) {
+		doVisitNode(node.getType());
+		doVisitChildren(node.typeArguments());
+		return false;
+	}
+
+	@Override
+	public boolean visit(ExpressionMethodReference node) {
+		evalQualifyingExpression(node.getExpression(), node.getName());
+		doVisitChildren(node.typeArguments());
+		return false;
+	}
+
+	@Override
+	public boolean visit(SuperMethodReference node) {
+		doVisitNode(node.getQualifier());
+		doVisitChildren(node.typeArguments());
+		return false;
+	}
+
+	@Override
+	public boolean visit(TypeMethodReference node) {
+		doVisitNode(node.getType());
+		doVisitChildren(node.typeArguments());
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(SuperConstructorInvocation)
+	 */
+	@Override
+	public boolean visit(SuperConstructorInvocation node) {
+		if (!isAffected(node)) {
+			return false;
+		}
+
+		evalQualifyingExpression(node.getExpression(), null);
+		doVisitChildren(node.typeArguments());
+		doVisitChildren(node.arguments());
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(FieldAccess)
+	 */
+	@Override
+	public boolean visit(FieldAccess node) {
+		evalQualifyingExpression(node.getExpression(), node.getName());
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(SimpleName)
+	 */
+	@Override
+	public boolean visit(SimpleName node) {
+		// if the call gets here, it can only be a variable reference
+		possibleStaticImportFound(node);
+		return false;
+	}
+
+	@Override
+	public boolean visit(MarkerAnnotation node) {
+		typeRefFound(node.getTypeName());
+		return false;
+	}
+
+	@Override
+	public boolean visit(NormalAnnotation node) {
+		typeRefFound(node.getTypeName());
+		doVisitChildren(node.values());
+		return false;
+	}
+
+	@Override
+	public boolean visit(SingleMemberAnnotation node) {
+		typeRefFound(node.getTypeName());
+		doVisitNode(node.getValue());
+		return false;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(TypeDeclaration)
+	 */
+	@Override
+	public boolean visit(TypeDeclaration node) {
+		if (!isAffected(node)) {
+			return false;
+		}
+		return true;
+	}
+
+	/*
+	 * @see ASTVisitor#visit(MethodDeclaration)
+	 */
+	@Override
+	public boolean visit(MethodDeclaration node) {
+		if (!isAffected(node)) {
+			return false;
+		}
+		doVisitNode(node.getJavadoc());
+
+		doVisitChildren(node.modifiers());
+		doVisitChildren(node.typeParameters());
+
+		if (!node.isConstructor()) {
+			doVisitNode(node.getReturnType2());
+		}
+		// name not visited
+
+		int apiLevel= node.getAST().apiLevel();
+		if (apiLevel >= AST.JLS8) {
+			doVisitNode(node.getReceiverType());
+		}
+		// receiverQualifier not visited:
+		//   Enclosing class names cannot be shadowed by an import (qualification is always redundant).
+		doVisitChildren(node.parameters());
+		if (apiLevel >= AST.JLS8) {
+			doVisitChildren(node.extraDimensions());
+			doVisitChildren(node.thrownExceptionTypes());
+		} else {
+			Iterator<Name> iter= getThrownExceptions(node).iterator();
+			while (iter.hasNext()) {
+				typeRefFound(iter.next());
+			}
+		}
+		if (!fSkipMethodBodies) {
+			doVisitNode(node.getBody());
+		}
+		return false;
+	}
+
+	/**
+	 * @param decl method declaration
+	 * @return thrown exception names
+	 * @deprecated to avoid deprecation warnings
+	 */
+	@Deprecated
+	private static List<Name> getThrownExceptions(MethodDeclaration decl) {
+		return decl.thrownExceptions();
+	}
+
+	@Override
+	public boolean visit(TagElement node) {
+		String tagName= node.getTagName();
+		List<? extends ASTNode> list= node.fragments();
+		int idx= 0;
+		if (tagName != null && !list.isEmpty()) {
+			Object first= list.get(0);
+			if (first instanceof Name) {
+				if ("@throws".equals(tagName) || "@exception".equals(tagName)) {  //$NON-NLS-1$//$NON-NLS-2$
+					typeRefFound((Name) first);
+				} else if ("@see".equals(tagName) || "@link".equals(tagName) || "@linkplain".equals(tagName)) {  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+					Name name= (Name) first;
+					possibleTypeRefFound(name);
+				}
+				idx++;
+			}
+		}
+		for (int i= idx; i < list.size(); i++) {
+			doVisitNode(list.get(i));
+		}
+		return false;
+	}
+
+	@Override
+	public boolean visit(MemberRef node) {
+		Name qualifier= node.getQualifier();
+		if (qualifier != null) {
+			typeRefFound(qualifier);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean visit(MethodRef node) {
+		Name qualifier= node.getQualifier();
+		if (qualifier != null) {
+			typeRefFound(qualifier);
+		}
+		List<MethodRefParameter> list= node.parameters();
+		if (list != null) {
+			doVisitChildren(list); // visit MethodRefParameter with Type
+		}
+		return false;
+	}
+
+	@Override
+	public boolean visit(MethodRefParameter node) {
+		doVisitNode(node.getType());
+		return false;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/RedundantNullnessTypeAnnotationsFilter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/RedundantNullnessTypeAnnotationsFilter.java
@@ -1,0 +1,237 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Till Brychcy and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Till Brychcy - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
+import org.eclipse.jdt.core.dom.IPackageBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
+
+/**
+ * Code copied from
+ * org.eclipse.jdt.internal.corext.codemanipulation.RedundantNullnessTypeAnnotationsFilter
+ */
+/* @NonNullByDefault */
+public class RedundantNullnessTypeAnnotationsFilter {
+
+	private static final IAnnotationBinding[] NO_ANNOTATIONS= new IAnnotationBinding[0];
+
+	/**
+	 * Locations where both {@code @NonNull} and {@code @Nullable} should always be filtered:
+	 * <ul>
+	 * <li>for local variables, nullity is inferred by flow analysis.
+	 * <li>casts with null annotation would always be unchecked.
+	 * <li>for exceptions, and {@code new} expressions non-null is implied.
+	 * <li>in other mentioned locations null annotations are not supported for other reasons.
+	 * </ul>
+	 */
+	private static final EnumSet<TypeLocation> NEVER_NULLNESS_LOCATIONS= EnumSet.of(
+			TypeLocation.LOCAL_VARIABLE, TypeLocation.CAST,
+			TypeLocation.EXCEPTION, TypeLocation.NEW,
+			TypeLocation.INSTANCEOF, TypeLocation.RECEIVER);
+
+	public static /* @Nullable */ RedundantNullnessTypeAnnotationsFilter createIfConfigured(/* @Nullable */ ASTNode node) {
+		if (node == null) {
+			return null;
+		}
+		final ASTNode root= node.getRoot();
+		if (root instanceof CompilationUnit) {
+			CompilationUnit compilationUnit= (CompilationUnit) root;
+			IJavaElement javaElement= compilationUnit.getJavaElement();
+			IJavaProject javaProject= javaElement == null ? null : javaElement.getJavaProject();
+			if (javaProject != null) {
+				if (JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, true))) {
+					String nonNullAnnotationName= javaProject.getOption(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, true);
+					String nullableAnnotationName= javaProject.getOption(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, true);
+					String nonNullByDefaultName= javaProject.getOption(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, true);
+					if (nonNullAnnotationName == null || nullableAnnotationName == null || nonNullByDefaultName == null) {
+						return null;
+					}
+					EnumSet<TypeLocation> nonNullByDefaultLocations= determineNonNullByDefaultLocations(node, nonNullByDefaultName);
+					return new RedundantNullnessTypeAnnotationsFilter(nonNullAnnotationName, nullableAnnotationName, nonNullByDefaultLocations);
+				}
+			}
+		}
+		return null;
+	}
+
+	public static EnumSet<TypeLocation> determineNonNullByDefaultLocations(ASTNode astNode, String nonNullByDefaultName) {
+		// look for first @NonNullByDefault
+		while (astNode != null) {
+			IAnnotationBinding annot= getNNBDAnnotation(astNode, nonNullByDefaultName);
+			if (annot != null) {
+				return determineNNBDValue(annot);
+			}
+			astNode= astNode.getParent();
+		}
+		return EnumSet.noneOf(TypeLocation.class);
+	}
+
+	private static EnumSet<TypeLocation> determineNNBDValue(IAnnotationBinding annot) {
+		EnumSet<TypeLocation> result= EnumSet.noneOf(TypeLocation.class);
+		IMemberValuePairBinding[] pairs= annot.getAllMemberValuePairs();
+		for (final IMemberValuePairBinding pair : pairs) {
+			if (pair.getKey() == null || pair.getKey().equals("value")) { //$NON-NLS-1$
+				Object value= pair.getValue();
+				if (value instanceof Object[]) {
+					Object[] values= (Object[]) value;
+					for (int k= 0; k < values.length; k++) {
+						if (values[k] instanceof IVariableBinding) {
+							String name= ((IVariableBinding) values[k]).getName();
+							try {
+								result.add(TypeLocation.valueOf(name));
+							} catch (IllegalArgumentException e) {
+								// ignore
+							}
+						}
+					}
+				} else if (value instanceof IVariableBinding) {
+					String name= ((IVariableBinding) value).getName();
+					try {
+						result.add(TypeLocation.valueOf(name));
+					} catch (IllegalArgumentException e) {
+						// ignore
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	// based on org.eclipse.jdt.apt.core.internal.declaration.ASTBasedDeclarationImpl.getAnnotationInstancesFromAST()
+	private static /* @Nullable */ IAnnotationBinding getNNBDAnnotation(ASTNode astNode, String nonNullByDefaultName) {
+		List<IExtendedModifier> extendsMods= null;
+		switch (astNode.getNodeType()) {
+		case ASTNode.COMPILATION_UNIT: {
+			// special case: when reaching the root of the ast, check the package annotations.
+			PackageDeclaration packageDeclaration= ((CompilationUnit) astNode).getPackage();
+			if (packageDeclaration != null) {
+				IPackageBinding packageBinding= packageDeclaration.resolveBinding();
+				if (packageBinding != null) {
+					for (IAnnotationBinding annotationBinding : packageBinding.getAnnotations()) {
+						ITypeBinding annotationType= annotationBinding.getAnnotationType();
+						if (annotationType != null && annotationType.getQualifiedName().equals(nonNullByDefaultName)) {
+							return annotationBinding;
+						}
+					}
+				}
+			}
+			return null;
+		}
+		case ASTNode.TYPE_DECLARATION:
+		case ASTNode.ANNOTATION_TYPE_DECLARATION:
+		case ASTNode.ENUM_DECLARATION:
+		case ASTNode.ANNOTATION_TYPE_MEMBER_DECLARATION:
+		case ASTNode.METHOD_DECLARATION:
+		case ASTNode.FIELD_DECLARATION:
+		case ASTNode.ENUM_CONSTANT_DECLARATION:
+			extendsMods= ((BodyDeclaration) astNode).modifiers();
+			break;
+
+		case ASTNode.VARIABLE_DECLARATION_STATEMENT:
+			extendsMods= ((VariableDeclarationStatement) astNode).modifiers();
+			break;
+
+		case ASTNode.VARIABLE_DECLARATION_EXPRESSION:
+			extendsMods= ((VariableDeclarationExpression) astNode).modifiers();
+			break;
+
+		case ASTNode.SINGLE_VARIABLE_DECLARATION:
+			extendsMods= ((SingleVariableDeclaration) astNode).modifiers();
+			break;
+		case ASTNode.VARIABLE_DECLARATION_FRAGMENT:
+			final ASTNode parent= ((VariableDeclarationFragment) astNode).getParent();
+			if (parent instanceof BodyDeclaration) {
+				extendsMods= ((BodyDeclaration) parent).modifiers();
+			}
+			break;
+
+		default:
+			return null;
+		}
+		if (extendsMods != null) {
+			for (IExtendedModifier extMod : extendsMods) {
+				if (extMod.isAnnotation()) {
+					Annotation annotation= (Annotation) extMod;
+					IAnnotationBinding annotationBinding= annotation.resolveAnnotationBinding();
+					if (annotationBinding != null) {
+						ITypeBinding annotationType= annotationBinding.getAnnotationType();
+						if (annotationType != null && annotationType.getQualifiedName().equals(nonNullByDefaultName)) {
+							return annotationBinding;
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private final String fNonNullAnnotationName;
+
+	private final String fNullableAnnotationName;
+
+	private final EnumSet<TypeLocation> fNonNullByDefaultLocations;
+
+	public RedundantNullnessTypeAnnotationsFilter(String nonNullAnnotationName, String nullableAnnotationName, EnumSet<TypeLocation> nonNullByDefaultLocations) {
+		fNonNullAnnotationName= nonNullAnnotationName;
+		fNullableAnnotationName= nullableAnnotationName;
+		fNonNullByDefaultLocations= nonNullByDefaultLocations;
+	}
+
+	public IAnnotationBinding[] removeUnwantedTypeAnnotations(IAnnotationBinding[] annotations, TypeLocation location, ITypeBinding type) {
+		if (location == TypeLocation.OTHER) {
+			return NO_ANNOTATIONS;
+		}
+		if(type.isTypeVariable() || type.isWildcardType()) {
+			return annotations;
+		}
+		boolean excludeAllNullAnnotations = NEVER_NULLNESS_LOCATIONS.contains(location);
+		if (excludeAllNullAnnotations || fNonNullByDefaultLocations.contains(location)) {
+			ArrayList<IAnnotationBinding> list= new ArrayList<>(annotations.length);
+			for (IAnnotationBinding annotation : annotations) {
+				ITypeBinding annotationType= annotation.getAnnotationType();
+				if (annotationType != null) {
+					if (annotationType.getQualifiedName().equals(fNonNullAnnotationName)) {
+						// ignore @NonNull
+					} else if (excludeAllNullAnnotations && annotationType.getQualifiedName().equals(fNullableAnnotationName)) {
+						// also ignore @Nullable
+					} else {
+						list.add(annotation);
+					}
+				} else {
+					list.add(annotation);
+				}
+			}
+			return list.size() == annotations.length ? annotations : list.toArray(new IAnnotationBinding[list.size()]);
+		} else {
+			return annotations;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/StubUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/StubUtility.java
@@ -1,0 +1,1485 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     John Kaplan, johnkaplantech@gmail.com - 108071 [code templates] template for body of newly created class
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.NamingConventions;
+import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.CastExpression;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.ConstructorInvocation;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+
+/**
+ * Implementations for {@link CodeGeneration} APIs, and other helper methods to
+ * create source code stubs based on {@link IJavaElement}s.
+ *
+ * Code copied from org.eclipse.jdt.internal.corext.codemanipulation.StubUtility
+ *
+ * @see StubUtility2
+ * @see JDTUIHelperClasses
+ */
+public class StubUtility {
+
+	private static final String[] EMPTY = new String[0];
+	//
+	//	private static final Set<String> VALID_TYPE_BODY_TEMPLATES;
+	//	static {
+	//		VALID_TYPE_BODY_TEMPLATES= new HashSet<>();
+	//		VALID_TYPE_BODY_TEMPLATES.add(CodeTemplateContextType.CLASSBODY_ID);
+	//		VALID_TYPE_BODY_TEMPLATES.add(CodeTemplateContextType.INTERFACEBODY_ID);
+	//		VALID_TYPE_BODY_TEMPLATES.add(CodeTemplateContextType.ENUMBODY_ID);
+	//		VALID_TYPE_BODY_TEMPLATES.add(CodeTemplateContextType.ANNOTATIONBODY_ID);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 */
+	//	public static String getMethodBodyContent(boolean isConstructor, IJavaProject project, String destTypeName, String methodName, String bodyStatement, String lineDelimiter) throws CoreException {
+	//		String templateName= isConstructor ? CodeTemplateContextType.CONSTRUCTORSTUB_ID : CodeTemplateContextType.METHODSTUB_ID;
+	//		Template template= getCodeTemplate(templateName, project);
+	//		if (template == null) {
+	//			return bodyStatement;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), project, lineDelimiter);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, destTypeName);
+	//		context.setVariable(CodeTemplateContextType.BODY_STATEMENT, bodyStatement);
+	//		String str= evaluateTemplate(context, template, new String[] { CodeTemplateContextType.BODY_STATEMENT });
+	//		if (str == null && !Strings.containsOnlyWhitespaces(bodyStatement)) {
+	//			return bodyStatement;
+	//		}
+	//		return str;
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 */
+	//	public static String getGetterMethodBodyContent(IJavaProject project, String destTypeName, String methodName, String fieldName, String lineDelimiter) throws CoreException {
+	//		String templateName= CodeTemplateContextType.GETTERSTUB_ID;
+	//		Template template= getCodeTemplate(templateName, project);
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), project, lineDelimiter);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, destTypeName);
+	//		context.setVariable(CodeTemplateContextType.FIELD, fieldName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 */
+	//	public static String getSetterMethodBodyContent(IJavaProject project, String destTypeName, String methodName, String fieldName, String paramName, String lineDelimiter) throws CoreException {
+	//		String templateName= CodeTemplateContextType.SETTERSTUB_ID;
+	//		Template template= getCodeTemplate(templateName, project);
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), project, lineDelimiter);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, destTypeName);
+	//		context.setVariable(CodeTemplateContextType.FIELD, fieldName);
+	//		context.setVariable(CodeTemplateContextType.FIELD_TYPE, fieldName);
+	//		context.setVariable(CodeTemplateContextType.PARAM, paramName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	public static String getCatchBodyContent(ICompilationUnit cu, String exceptionType, String variableName, ASTNode locationInAST, String lineDelimiter) throws CoreException {
+	//		String enclosingType= ""; //$NON-NLS-1$
+	//		String enclosingMethod= ""; //$NON-NLS-1$
+	//
+	//		if (locationInAST != null) {
+	//			MethodDeclaration parentMethod= ASTResolving.findParentMethodDeclaration(locationInAST);
+	//			if (parentMethod != null) {
+	//				enclosingMethod= parentMethod.getName().getIdentifier();
+	//				locationInAST= parentMethod;
+	//			}
+	//			ASTNode parentType= ASTResolving.findParentType(locationInAST);
+	//			if (parentType instanceof AbstractTypeDeclaration) {
+	//				enclosingType= ((AbstractTypeDeclaration)parentType).getName().getIdentifier();
+	//			}
+	//		}
+	//		return getCatchBodyContent(cu, exceptionType, variableName, enclosingType, enclosingMethod, lineDelimiter);
+	//	}
+	//
+	//
+	//	public static String getCatchBodyContent(ICompilationUnit cu, String exceptionType, String variableName, String enclosingType, String enclosingMethod, String lineDelimiter) throws CoreException {
+	//		Template template= getCodeTemplate(CodeTemplateContextType.CATCHBLOCK_ID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, enclosingType);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, enclosingMethod);
+	//		context.setVariable(CodeTemplateContextType.EXCEPTION_TYPE, exceptionType);
+	//		context.setVariable(CodeTemplateContextType.EXCEPTION_VAR, variableName);
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getCompilationUnitContent(ICompilationUnit, String, String, String, String)
+	//	 */
+	//	public static String getCompilationUnitContent(ICompilationUnit cu, String fileComment, String typeComment, String typeContent, String lineDelimiter) throws CoreException {
+	//		IPackageFragment pack= (IPackageFragment)cu.getParent();
+	//		String packDecl= pack.isDefaultPackage() ? "" : "package " + pack.getElementName() + ';'; //$NON-NLS-1$ //$NON-NLS-2$
+	//		return getCompilationUnitContent(cu, packDecl, fileComment, typeComment, typeContent, lineDelimiter);
+	//	}
+	//
+	//	public static String getCompilationUnitContent(ICompilationUnit cu, String packDecl, String fileComment, String typeComment, String typeContent, String lineDelimiter) throws CoreException {
+	//		Template template= getCodeTemplate(CodeTemplateContextType.NEWTYPE_ID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//
+	//		IJavaProject project= cu.getJavaProject();
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), project, lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.PACKAGE_DECLARATION, packDecl);
+	//		context.setVariable(CodeTemplateContextType.TYPE_COMMENT, typeComment != null ? typeComment : ""); //$NON-NLS-1$
+	//		context.setVariable(CodeTemplateContextType.FILE_COMMENT, fileComment != null ? fileComment : ""); //$NON-NLS-1$
+	//		context.setVariable(CodeTemplateContextType.TYPE_DECLARATION, typeContent);
+	//		context.setVariable(CodeTemplateContextType.TYPENAME, JavaCore.removeJavaLikeExtension(cu.getElementName()));
+	//
+	//		String[] fullLine= { CodeTemplateContextType.PACKAGE_DECLARATION, CodeTemplateContextType.FILE_COMMENT, CodeTemplateContextType.TYPE_COMMENT };
+	//		return evaluateTemplate(context, template, fullLine);
+	//	}
+	//
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getFileComment(ICompilationUnit, String)
+	//	 */
+	//	public static String getFileComment(ICompilationUnit cu, String lineDelimiter) throws CoreException {
+	//		Template template= getCodeTemplate(CodeTemplateContextType.FILECOMMENT_ID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//
+	//		IJavaProject project= cu.getJavaProject();
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), project, lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.TYPENAME, JavaCore.removeJavaLikeExtension(cu.getElementName()));
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getTypeComment(ICompilationUnit, String, String[], String)
+	//	 */
+	//	public static String getTypeComment(ICompilationUnit cu, String typeQualifiedName, String[] typeParameterNames, String lineDelim) throws CoreException {
+	//		Template template= getCodeTemplate(CodeTemplateContextType.TYPECOMMENT_ID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelim);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, Signature.getQualifier(typeQualifiedName));
+	//		context.setVariable(CodeTemplateContextType.TYPENAME, Signature.getSimpleName(typeQualifiedName));
+	//
+	//		TemplateBuffer buffer;
+	//		try {
+	//			buffer= context.evaluate(template);
+	//		} catch (BadLocationException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		} catch (TemplateException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		}
+	//		String str= buffer.getString();
+	//		if (Strings.containsOnlyWhitespaces(str)) {
+	//			return null;
+	//		}
+	//
+	//		TemplateVariable position= findVariable(buffer, CodeTemplateContextType.TAGS); // look if Javadoc tags have to be added
+	//		if (position == null) {
+	//			return str;
+	//		}
+	//
+	//		IDocument document= new Document(str);
+	//		int[] tagOffsets= position.getOffsets();
+	//		for (int i= tagOffsets.length - 1; i >= 0; i--) { // from last to first
+	//			try {
+	//				insertTag(document, tagOffsets[i], position.getLength(), EMPTY, EMPTY, null, typeParameterNames, false, lineDelim);
+	//			} catch (BadLocationException e) {
+	//				throw new CoreException(JavaUIStatus.createError(IStatus.ERROR, e));
+	//			}
+	//		}
+	//		return document.get();
+	//	}
+	//
+	//	/*
+	//	 * Returns the parameters type names used in see tags. Currently, these are always fully qualified.
+	//	 */
+	//	public static String[] getParameterTypeNamesForSeeTag(IMethodBinding binding) {
+	//		ITypeBinding[] typeBindings= binding.getParameterTypes();
+	//		String[] result= new String[typeBindings.length];
+	//		for (int i= 0; i < result.length; i++) {
+	//			ITypeBinding curr= typeBindings[i];
+	//			curr= curr.getErasure(); // Javadoc references use erased type
+	//			result[i]= curr.getQualifiedName();
+	//		}
+	//		return result;
+	//	}
+	//
+	//	/*
+	//	 * Returns the parameters type names used in see tags. Currently, these are always fully qualified.
+	//	 */
+	//	private static String[] getParameterTypeNamesForSeeTag(IMethod overridden) {
+	//		try {
+	//			ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+	//			parser.setProject(overridden.getJavaProject());
+	//			IBinding[] bindings= parser.createBindings(new IJavaElement[] { overridden }, null);
+	//			if (bindings.length == 1 && bindings[0] instanceof IMethodBinding) {
+	//				return getParameterTypeNamesForSeeTag((IMethodBinding)bindings[0]);
+	//			}
+	//		} catch (IllegalStateException e) {
+	//			// method does not exist
+	//		}
+	//		// fall back code. Not good for generic methods!
+	//		String[] paramTypes= overridden.getParameterTypes();
+	//		String[] paramTypeNames= new String[paramTypes.length];
+	//		for (int i= 0; i < paramTypes.length; i++) {
+	//			paramTypeNames[i]= Signature.toString(Signature.getTypeErasure(paramTypes[i]));
+	//		}
+	//		return paramTypeNames;
+	//	}
+	//
+	//	private static String getSeeTag(String declaringClassQualifiedName, String methodName, String[] parameterTypesQualifiedNames) {
+	//		StringBuffer buf= new StringBuffer();
+	//		buf.append("@see "); //$NON-NLS-1$
+	//		buf.append(declaringClassQualifiedName);
+	//		buf.append('#');
+	//		buf.append(methodName);
+	//		buf.append('(');
+	//		for (int i= 0; i < parameterTypesQualifiedNames.length; i++) {
+	//			if (i > 0) {
+	//				buf.append(", "); //$NON-NLS-1$
+	//			}
+	//			buf.append(parameterTypesQualifiedNames[i]);
+	//		}
+	//		buf.append(')');
+	//		return buf.toString();
+	//	}
+	//
+	//	public static String[] getTypeParameterNames(ITypeParameter[] typeParameters) {
+	//		String[] typeParametersNames= new String[typeParameters.length];
+	//		for (int i= 0; i < typeParameters.length; i++) {
+	//			typeParametersNames[i]= typeParameters[i].getElementName();
+	//		}
+	//		return typeParametersNames;
+	//	}
+	//
+	//	/**
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 *
+	//	 * @param templateID the template id of the type body to get. Valid id's are
+	//	 *            {@link CodeTemplateContextType#CLASSBODY_ID},
+	//	 *            {@link CodeTemplateContextType#INTERFACEBODY_ID},
+	//	 *            {@link CodeTemplateContextType#ENUMBODY_ID},
+	//	 *            {@link CodeTemplateContextType#ANNOTATIONBODY_ID},
+	//	 * @param cu the compilation unit to which the template is added
+	//	 * @param typeName the type name
+	//	 * @param lineDelim the line delimiter to use
+	//	 * @return return the type body template or <code>null</code>
+	//	 * @throws CoreException thrown if the template could not be evaluated
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getTypeBody(String, ICompilationUnit, String, String)
+	//	 */
+	//	public static String getTypeBody(String templateID, ICompilationUnit cu, String typeName, String lineDelim) throws CoreException {
+	//		if (!VALID_TYPE_BODY_TEMPLATES.contains(templateID)) {
+	//			throw new IllegalArgumentException("Invalid code template ID: " + templateID); //$NON-NLS-1$
+	//		}
+	//
+	//		Template template= getCodeTemplate(templateID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelim);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.TYPENAME, typeName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getMethodComment(ICompilationUnit, String, String, String[], String[], String, String[], IMethod, String)
+	//	 */
+	//	public static String getMethodComment(ICompilationUnit cu, String typeName, String methodName, String[] paramNames, String[] excTypeSig, String retTypeSig, String[] typeParameterNames,
+	//			IMethod target, boolean delegate, String lineDelimiter) throws CoreException {
+	//		String templateName= CodeTemplateContextType.METHODCOMMENT_ID;
+	//		if (retTypeSig == null) {
+	//			templateName= CodeTemplateContextType.CONSTRUCTORCOMMENT_ID;
+	//		} else if (target != null) {
+	//			if (delegate) {
+	//				templateName= CodeTemplateContextType.DELEGATECOMMENT_ID;
+	//			} else {
+	//				templateName= CodeTemplateContextType.OVERRIDECOMMENT_ID;
+	//			}
+	//		}
+	//		Template template= getCodeTemplate(templateName, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, typeName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//
+	//		if (retTypeSig != null) {
+	//			context.setVariable(CodeTemplateContextType.RETURN_TYPE, Signature.toString(retTypeSig));
+	//		}
+	//		if (target != null) {
+	//			String targetTypeName= target.getDeclaringType().getFullyQualifiedName('.');
+	//			String[] targetParamTypeNames= getParameterTypeNamesForSeeTag(target);
+	//			if (delegate) {
+	//				context.setVariable(CodeTemplateContextType.SEE_TO_TARGET_TAG, getSeeTag(targetTypeName, methodName, targetParamTypeNames));
+	//			} else {
+	//				context.setVariable(CodeTemplateContextType.SEE_TO_OVERRIDDEN_TAG, getSeeTag(targetTypeName, methodName, targetParamTypeNames));
+	//			}
+	//		}
+	//		TemplateBuffer buffer;
+	//		try {
+	//			buffer= context.evaluate(template);
+	//		} catch (BadLocationException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		} catch (TemplateException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		}
+	//		if (buffer == null) {
+	//			return null;
+	//		}
+	//
+	//		String str= buffer.getString();
+	//		if (Strings.containsOnlyWhitespaces(str)) {
+	//			return null;
+	//		}
+	//		TemplateVariable position= findVariable(buffer, CodeTemplateContextType.TAGS); // look if Javadoc tags have to be added
+	//		if (position == null) {
+	//			return str;
+	//		}
+	//
+	//		IDocument document= new Document(str);
+	//		String[] exceptionNames= new String[excTypeSig.length];
+	//		for (int i= 0; i < excTypeSig.length; i++) {
+	//			exceptionNames[i]= Signature.toString(excTypeSig[i]);
+	//		}
+	//		String returnType= retTypeSig != null ? Signature.toString(retTypeSig) : null;
+	//		int[] tagOffsets= position.getOffsets();
+	//		for (int i= tagOffsets.length - 1; i >= 0; i--) { // from last to first
+	//			try {
+	//				insertTag(document, tagOffsets[i], position.getLength(), paramNames, exceptionNames, returnType, typeParameterNames, false, lineDelimiter);
+	//			} catch (BadLocationException e) {
+	//				throw new CoreException(JavaUIStatus.createError(IStatus.ERROR, e));
+	//			}
+	//		}
+	//		return document.get();
+	//	}
+	//
+	//	// remove lines for empty variables
+	//	private static String fixEmptyVariables(TemplateBuffer buffer, String[] variables) throws MalformedTreeException, BadLocationException {
+	//		IDocument doc= new Document(buffer.getString());
+	//		int nLines= doc.getNumberOfLines();
+	//		MultiTextEdit edit= new MultiTextEdit();
+	//		HashSet<Integer> removedLines= new HashSet<>();
+	//		for (int i= 0; i < variables.length; i++) {
+	//			TemplateVariable position= findVariable(buffer, variables[i]); // look if Javadoc tags have to be added
+	//			if (position == null || position.getLength() > 0) {
+	//				continue;
+	//			}
+	//			int[] offsets= position.getOffsets();
+	//			for (int k= 0; k < offsets.length; k++) {
+	//				int line= doc.getLineOfOffset(offsets[k]);
+	//				IRegion lineInfo= doc.getLineInformation(line);
+	//				int offset= lineInfo.getOffset();
+	//				String str= doc.get(offset, lineInfo.getLength());
+	//				if (Strings.containsOnlyWhitespaces(str) && nLines > line + 1 && removedLines.add(new Integer(line))) {
+	//					int nextStart= doc.getLineOffset(line + 1);
+	//					edit.addChild(new DeleteEdit(offset, nextStart - offset));
+	//				}
+	//			}
+	//		}
+	//		edit.apply(doc, 0);
+	//		return doc.get();
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 */
+	//	public static String getFieldComment(ICompilationUnit cu, String typeName, String fieldName, String lineDelimiter) throws CoreException {
+	//		Template template= getCodeTemplate(CodeTemplateContextType.FIELDCOMMENT_ID, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.FIELD_TYPE, typeName);
+	//		context.setVariable(CodeTemplateContextType.FIELD, fieldName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getSetterComment(ICompilationUnit, String, String, String, String, String, String, String)
+	//	 */
+	//	public static String getSetterComment(ICompilationUnit cu, String typeName, String methodName, String fieldName, String fieldType, String paramName, String bareFieldName, String lineDelimiter)
+	//			throws CoreException {
+	//		String templateName= CodeTemplateContextType.SETTERCOMMENT_ID;
+	//		Template template= getCodeTemplate(templateName, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, typeName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//		context.setVariable(CodeTemplateContextType.FIELD, fieldName);
+	//		context.setVariable(CodeTemplateContextType.FIELD_TYPE, fieldType);
+	//		context.setVariable(CodeTemplateContextType.BARE_FIELD_NAME, bareFieldName);
+	//		context.setVariable(CodeTemplateContextType.PARAM, paramName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getGetterComment(ICompilationUnit, String, String, String, String, String, String)
+	//	 */
+	//	public static String getGetterComment(ICompilationUnit cu, String typeName, String methodName, String fieldName, String fieldType, String bareFieldName, String lineDelimiter) throws CoreException {
+	//		String templateName= CodeTemplateContextType.GETTERCOMMENT_ID;
+	//		Template template= getCodeTemplate(templateName, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, typeName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, methodName);
+	//		context.setVariable(CodeTemplateContextType.FIELD, fieldName);
+	//		context.setVariable(CodeTemplateContextType.FIELD_TYPE, fieldType);
+	//		context.setVariable(CodeTemplateContextType.BARE_FIELD_NAME, bareFieldName);
+	//
+	//		return evaluateTemplate(context, template);
+	//	}
+	//
+	//	private static String evaluateTemplate(CodeTemplateContext context, Template template) throws CoreException {
+	//		TemplateBuffer buffer;
+	//		try {
+	//			buffer= context.evaluate(template);
+	//		} catch (BadLocationException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		} catch (TemplateException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		}
+	//		if (buffer == null) {
+	//			return null;
+	//		}
+	//		String str= buffer.getString();
+	//		if (Strings.containsOnlyWhitespaces(str)) {
+	//			return null;
+	//		}
+	//		return str;
+	//	}
+	//
+	//	private static String evaluateTemplate(CodeTemplateContext context, Template template, String[] fullLineVariables) throws CoreException {
+	//		TemplateBuffer buffer;
+	//		try {
+	//			buffer= context.evaluate(template);
+	//			if (buffer == null) {
+	//				return null;
+	//			}
+	//			String str= fixEmptyVariables(buffer, fullLineVariables);
+	//			if (Strings.containsOnlyWhitespaces(str)) {
+	//				return null;
+	//			}
+	//			return str;
+	//		} catch (BadLocationException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		} catch (TemplateException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		}
+	//	}
+	//
+	//
+	//	/*
+	//	 * Don't use this method directly, use CodeGeneration.
+	//	 * This method should work with all AST levels.
+	//	 * @see org.eclipse.jdt.ui.CodeGeneration#getMethodComment(ICompilationUnit, String, MethodDeclaration, boolean, String, String[], String)
+	//	 */
+	//	public static String getMethodComment(ICompilationUnit cu, String typeName, MethodDeclaration decl, boolean isDeprecated, String targetName, String targetMethodDeclaringTypeName,
+	//			String[] targetMethodParameterTypeNames, boolean delegate, String lineDelimiter) throws CoreException {
+	//		boolean needsTarget= targetMethodDeclaringTypeName != null && targetMethodParameterTypeNames != null;
+	//		String templateName= CodeTemplateContextType.METHODCOMMENT_ID;
+	//		if (decl.isConstructor()) {
+	//			templateName= CodeTemplateContextType.CONSTRUCTORCOMMENT_ID;
+	//		} else if (needsTarget) {
+	//			if (delegate) {
+	//				templateName= CodeTemplateContextType.DELEGATECOMMENT_ID;
+	//			} else {
+	//				templateName= CodeTemplateContextType.OVERRIDECOMMENT_ID;
+	//			}
+	//		}
+	//		Template template= getCodeTemplate(templateName, cu.getJavaProject());
+	//		if (template == null) {
+	//			return null;
+	//		}
+	//		CodeTemplateContext context= new CodeTemplateContext(template.getContextTypeId(), cu.getJavaProject(), lineDelimiter);
+	//		context.setCompilationUnitVariables(cu);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, typeName);
+	//		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, decl.getName().getIdentifier());
+	//		if (!decl.isConstructor()) {
+	//			context.setVariable(CodeTemplateContextType.RETURN_TYPE, ASTNodes.asString(getReturnType(decl)));
+	//		}
+	//		if (needsTarget) {
+	//			if (delegate) {
+	//				context.setVariable(CodeTemplateContextType.SEE_TO_TARGET_TAG, getSeeTag(targetMethodDeclaringTypeName, targetName, targetMethodParameterTypeNames));
+	//			} else {
+	//				context.setVariable(CodeTemplateContextType.SEE_TO_OVERRIDDEN_TAG, getSeeTag(targetMethodDeclaringTypeName, targetName, targetMethodParameterTypeNames));
+	//			}
+	//		}
+	//
+	//		TemplateBuffer buffer;
+	//		try {
+	//			buffer= context.evaluate(template);
+	//		} catch (BadLocationException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		} catch (TemplateException e) {
+	//			throw new CoreException(Status.CANCEL_STATUS);
+	//		}
+	//		if (buffer == null) {
+	//			return null;
+	//		}
+	//		String str= buffer.getString();
+	//		if (Strings.containsOnlyWhitespaces(str)) {
+	//			return null;
+	//		}
+	//		TemplateVariable position= findVariable(buffer, CodeTemplateContextType.TAGS); // look if Javadoc tags have to be added
+	//		if (position == null) {
+	//			return str;
+	//		}
+	//
+	//		IDocument textBuffer= new Document(str);
+	//		List<TypeParameter> typeParams= shouldGenerateMethodTypeParameterTags(cu.getJavaProject()) ? decl.typeParameters() : Collections.emptyList();
+	//		String[] typeParamNames= new String[typeParams.size()];
+	//		for (int i= 0; i < typeParamNames.length; i++) {
+	//			TypeParameter elem= typeParams.get(i);
+	//			typeParamNames[i]= elem.getName().getIdentifier();
+	//		}
+	//		List<SingleVariableDeclaration> params= decl.parameters();
+	//		String[] paramNames= new String[params.size()];
+	//		for (int i= 0; i < paramNames.length; i++) {
+	//			SingleVariableDeclaration elem= params.get(i);
+	//			paramNames[i]= elem.getName().getIdentifier();
+	//		}
+	//		String[] exceptionNames= getExceptionNames(decl);
+	//
+	//		String returnType= null;
+	//		if (!decl.isConstructor()) {
+	//			returnType= ASTNodes.asString(getReturnType(decl));
+	//		}
+	//		int[] tagOffsets= position.getOffsets();
+	//		for (int i= tagOffsets.length - 1; i >= 0; i--) { // from last to first
+	//			try {
+	//				insertTag(textBuffer, tagOffsets[i], position.getLength(), paramNames, exceptionNames, returnType, typeParamNames, isDeprecated, lineDelimiter);
+	//			} catch (BadLocationException e) {
+	//				throw new CoreException(JavaUIStatus.createError(IStatus.ERROR, e));
+	//			}
+	//		}
+	//		return textBuffer.get();
+	//	}
+	//
+	//	/**
+	//	 * @param decl the method declaration
+	//	 * @return the exception names
+	//	 * @deprecated to avoid deprecation warnings
+	//	 */
+	//	@Deprecated
+	//	private static String[] getExceptionNames(MethodDeclaration decl) {
+	//		String[] exceptionNames;
+	//		if (decl.getAST().apiLevel() >= AST.JLS8) {
+	//			List<Type> exceptions= decl.thrownExceptionTypes();
+	//			exceptionNames= new String[exceptions.size()];
+	//			for (int i= 0; i < exceptionNames.length; i++) {
+	//				exceptionNames[i]= ASTNodes.getTypeName(exceptions.get(i));
+	//			}
+	//		} else {
+	//			List<Name> exceptions= decl.thrownExceptions();
+	//			exceptionNames= new String[exceptions.size()];
+	//			for (int i= 0; i < exceptionNames.length; i++) {
+	//				exceptionNames[i]= ASTNodes.getSimpleNameIdentifier(exceptions.get(i));
+	//			}
+	//		}
+	//		return exceptionNames;
+	//	}
+	//
+	//	public static boolean shouldGenerateMethodTypeParameterTags(IJavaProject project) {
+	//		return JavaCore.ENABLED.equals(project.getOption(JavaCore.COMPILER_PB_MISSING_JAVADOC_TAGS_METHOD_TYPE_PARAMETERS, true));
+	//	}
+	//
+	//	/**
+	//	 * @param decl the method declaration
+	//	 * @return the return type
+	//	 * @deprecated Deprecated to avoid deprecated warnings
+	//	 */
+	//	@Deprecated
+	//	private static ASTNode getReturnType(MethodDeclaration decl) {
+	//		// used from API, can't eliminate
+	//		return decl.getAST().apiLevel() == AST.JLS2 ? decl.getReturnType() : decl.getReturnType2();
+	//	}
+	//
+	//
+	//	private static TemplateVariable findVariable(TemplateBuffer buffer, String variable) {
+	//		TemplateVariable[] positions= buffer.getVariables();
+	//		for (int i= 0; i < positions.length; i++) {
+	//			TemplateVariable curr= positions[i];
+	//			if (variable.equals(curr.getType())) {
+	//				return curr;
+	//			}
+	//		}
+	//		return null;
+	//	}
+	//
+	//	private static void insertTag(IDocument textBuffer, int offset, int length, String[] paramNames, String[] exceptionNames, String returnType, String[] typeParameterNames, boolean isDeprecated,
+	//			String lineDelimiter) throws BadLocationException {
+	//		IRegion region= textBuffer.getLineInformationOfOffset(offset);
+	//		if (region == null) {
+	//			return;
+	//		}
+	//		String lineStart= textBuffer.get(region.getOffset(), offset - region.getOffset());
+	//
+	//		StringBuffer buf= new StringBuffer();
+	//		for (int i= 0; i < typeParameterNames.length; i++) {
+	//			if (buf.length() > 0) {
+	//				buf.append(lineDelimiter).append(lineStart);
+	//			}
+	//			buf.append("@param <").append(typeParameterNames[i]).append('>'); //$NON-NLS-1$
+	//		}
+	//		for (int i= 0; i < paramNames.length; i++) {
+	//			if (buf.length() > 0) {
+	//				buf.append(lineDelimiter).append(lineStart);
+	//			}
+	//			buf.append("@param ").append(paramNames[i]); //$NON-NLS-1$
+	//		}
+	//		if (returnType != null && !returnType.equals("void")) { //$NON-NLS-1$
+	//			if (buf.length() > 0) {
+	//				buf.append(lineDelimiter).append(lineStart);
+	//			}
+	//			buf.append("@return"); //$NON-NLS-1$
+	//		}
+	//		if (exceptionNames != null) {
+	//			for (int i= 0; i < exceptionNames.length; i++) {
+	//				if (buf.length() > 0) {
+	//					buf.append(lineDelimiter).append(lineStart);
+	//				}
+	//				buf.append("@throws ").append(exceptionNames[i]); //$NON-NLS-1$
+	//			}
+	//		}
+	//		if (isDeprecated) {
+	//			if (buf.length() > 0) {
+	//				buf.append(lineDelimiter).append(lineStart);
+	//			}
+	//			buf.append("@deprecated"); //$NON-NLS-1$
+	//		}
+	//		if (buf.length() == 0 && isAllCommentWhitespace(lineStart)) {
+	//			int prevLine= textBuffer.getLineOfOffset(offset) - 1;
+	//			if (prevLine > 0) {
+	//				IRegion prevRegion= textBuffer.getLineInformation(prevLine);
+	//				int prevLineEnd= prevRegion.getOffset() + prevRegion.getLength();
+	//				// clear full line
+	//				textBuffer.replace(prevLineEnd, offset + length - prevLineEnd, ""); //$NON-NLS-1$
+	//				return;
+	//			}
+	//		}
+	//		textBuffer.replace(offset, length, buf.toString());
+	//	}
+	//
+	//	private static boolean isAllCommentWhitespace(String lineStart) {
+	//		for (int i= 0; i < lineStart.length(); i++) {
+	//			char ch= lineStart.charAt(i);
+	//			if (!Character.isWhitespace(ch) && ch != '*') {
+	//				return false;
+	//			}
+	//		}
+	//		return true;
+	//	}
+	//
+	//	/**
+	//	 * Returns the line delimiter which is used in the specified project.
+	//	 *
+	//	 * @param project the java project, or <code>null</code>
+	//	 * @return the used line delimiter
+	//	 */
+	//	public static String getLineDelimiterUsed(IJavaProject project) {
+	//		return getProjectLineDelimiter(project);
+	//	}
+	//
+	//	private static String getProjectLineDelimiter(IJavaProject javaProject) {
+	//		IProject project= null;
+	//		if (javaProject != null) {
+	//			project= javaProject.getProject();
+	//		}
+	//
+	//		String lineDelimiter= getLineDelimiterPreference(project);
+	//		if (lineDelimiter != null) {
+	//			return lineDelimiter;
+	//		}
+	//
+	//		return System.getProperty("line.separator", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+	//	}
+	//
+	//	public static String getLineDelimiterPreference(IProject project) {
+	//		IScopeContext[] scopeContext;
+	//		if (project != null) {
+	//			// project preference
+	//			scopeContext= new IScopeContext[] { new ProjectScope(project) };
+	//			String lineDelimiter= Platform.getPreferencesService().getString(Platform.PI_RUNTIME, Platform.PREF_LINE_SEPARATOR, null, scopeContext);
+	//			if (lineDelimiter != null) {
+	//				return lineDelimiter;
+	//			}
+	//		}
+	//		// workspace preference
+	//		scopeContext= new IScopeContext[] { InstanceScope.INSTANCE };
+	//		String platformDefault= System.getProperty("line.separator", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
+	//		return Platform.getPreferencesService().getString(Platform.PI_RUNTIME, Platform.PREF_LINE_SEPARATOR, platformDefault, scopeContext);
+	//	}
+	//
+	//	/**
+	//	 * @param elem a Java element (doesn't have to exist)
+	//	 * @return the existing or default line delimiter for the element
+	//	 */
+	//	public static String getLineDelimiterUsed(IJavaElement elem) {
+	//		IOpenable openable= elem.getOpenable();
+	//		if (openable instanceof ITypeRoot) {
+	//			try {
+	//				return openable.findRecommendedLineSeparator();
+	//			} catch (JavaModelException exception) {
+	//				// Use project setting
+	//			}
+	//		}
+	//		IJavaProject project= elem.getJavaProject();
+	//		return getProjectLineDelimiter(project.exists() ? project : null);
+	//	}
+	//
+	//	/**
+	//	 * Evaluates the indentation used by a Java element. (in tabulators)
+	//	 *
+	//	 * @param elem the element to get the indent of
+	//	 * @return return the indent unit
+	//	 * @throws JavaModelException thrown if the element could not be accessed
+	//	 */
+	//	public static int getIndentUsed(IJavaElement elem) throws JavaModelException {
+	//		IOpenable openable= elem.getOpenable();
+	//		if (openable instanceof ITypeRoot) {
+	//			IBuffer buf= openable.getBuffer();
+	//			if (buf != null) {
+	//				int offset= ((ISourceReference)elem).getSourceRange().getOffset();
+	//				return getIndentUsed(buf, offset, elem.getJavaProject());
+	//			}
+	//		}
+	//		return 0;
+	//	}
+	//
+	//	public static int getIndentUsed(IBuffer buffer, int offset, IJavaProject project) {
+	//		int i= offset;
+	//		// find beginning of line
+	//		while (i > 0 && !IndentManipulation.isLineDelimiterChar(buffer.getChar(i - 1))) {
+	//			i--;
+	//		}
+	//		return Strings.computeIndentUnits(buffer.getText(i, offset - i), project);
+	//	}
+	//
+	//
+	//
+	//	/**
+	//	 * Returns the element after the give element.
+	//	 *
+	//	 * @param member a Java element
+	//	 * @return the next sibling of the given element or <code>null</code>
+	//	 * @throws JavaModelException thrown if the element could not be accessed
+	//	 */
+	//	public static IJavaElement findNextSibling(IJavaElement member) throws JavaModelException {
+	//		IJavaElement parent= member.getParent();
+	//		if (parent instanceof IParent) {
+	//			IJavaElement[] elements= ((IParent)parent).getChildren();
+	//			for (int i= elements.length - 2; i >= 0; i--) {
+	//				if (member.equals(elements[i])) {
+	//					return elements[i + 1];
+	//				}
+	//			}
+	//		}
+	//		return null;
+	//	}
+	//
+	//	public static String getTodoTaskTag(IJavaProject project) {
+	//		String markers= null;
+	//		if (project == null) {
+	//			markers= JavaCore.getOption(JavaCore.COMPILER_TASK_TAGS);
+	//		} else {
+	//			markers= project.getOption(JavaCore.COMPILER_TASK_TAGS, true);
+	//		}
+	//
+	//		if (markers != null && markers.length() > 0) {
+	//			int idx= markers.indexOf(',');
+	//			if (idx == -1) {
+	//				return markers;
+	//			} else {
+	//				return markers.substring(0, idx);
+	//			}
+	//		}
+	//		return null;
+	//	}
+	//
+	private static String removeTypeArguments(String baseName) {
+		int idx = baseName.indexOf('<');
+		if (idx != -1) {
+			return baseName.substring(0, idx);
+		}
+		return baseName;
+	}
+	//
+	//
+	// --------------------------- name suggestions --------------------------
+
+	public static String[] getVariableNameSuggestions(int variableKind, IJavaProject project, ITypeBinding expectedType, Expression assignedExpression, Collection<String> excluded) {
+		LinkedHashSet<String> res= new LinkedHashSet<>(); // avoid duplicates but keep order
+
+		if (assignedExpression != null) {
+			String nameFromExpression= getBaseNameFromExpression(project, assignedExpression, variableKind);
+			if (nameFromExpression != null) {
+				add(getVariableNameSuggestions(variableKind, project, nameFromExpression, 0, excluded, false), res); // pass 0 as dimension, base name already contains plural.
+			}
+
+			String nameFromParent= getBaseNameFromLocationInParent(assignedExpression);
+			if (nameFromParent != null) {
+				add(getVariableNameSuggestions(variableKind, project, nameFromParent, 0, excluded, false), res); // pass 0 as dimension, base name already contains plural.
+			}
+		}
+		if (expectedType != null) {
+			expectedType= Bindings.normalizeTypeBinding(expectedType);
+			if (expectedType != null) {
+				int dim= 0;
+				if (expectedType.isArray()) {
+					dim= expectedType.getDimensions();
+					expectedType= expectedType.getElementType();
+				}
+				if (expectedType.isParameterizedType()) {
+					expectedType= expectedType.getTypeDeclaration();
+				}
+				String typeName= expectedType.getName();
+				if (typeName.length() > 0) {
+					add(getVariableNameSuggestions(variableKind, project, typeName, dim, excluded, false), res);
+				}
+			}
+		}
+		if (res.isEmpty()) {
+			return getDefaultVariableNameSuggestions(variableKind, excluded);
+		}
+		return res.toArray(new String[res.size()]);
+	}
+
+	public static String[] getVariableNameSuggestions(int variableKind, IJavaProject project, Type expectedType, Expression assignedExpression, Collection<String> excluded) {
+		LinkedHashSet<String> res= new LinkedHashSet<>(); // avoid duplicates but keep order
+
+		if (assignedExpression != null) {
+			String nameFromExpression= getBaseNameFromExpression(project, assignedExpression, variableKind);
+			if (nameFromExpression != null) {
+				add(getVariableNameSuggestions(variableKind, project, nameFromExpression, 0, excluded, false), res); // pass 0 as dimension, base name already contains plural.
+			}
+
+			String nameFromParent= getBaseNameFromLocationInParent(assignedExpression);
+			if (nameFromParent != null) {
+				add(getVariableNameSuggestions(variableKind, project, nameFromParent, 0, excluded, false), res); // pass 0 as dimension, base name already contains plural.
+			}
+		}
+		if (expectedType != null) {
+			String[] names= getVariableNameSuggestions(variableKind, project, expectedType, excluded, false);
+			for (int i= 0; i < names.length; i++) {
+				res.add(names[i]);
+			}
+		}
+		if (res.isEmpty()) {
+			return getDefaultVariableNameSuggestions(variableKind, excluded);
+		}
+		return res.toArray(new String[res.size()]);
+	}
+
+	private static String[] getVariableNameSuggestions(int variableKind, IJavaProject project, Type expectedType, Collection<String> excluded, boolean evaluateDefault) {
+		int dim= 0;
+		if (expectedType.isArrayType()) {
+			ArrayType arrayType= (ArrayType)expectedType;
+			dim= arrayType.getDimensions();
+			expectedType= arrayType.getElementType();
+		}
+		if (expectedType.isParameterizedType()) {
+			expectedType= ((ParameterizedType)expectedType).getType();
+		}
+		String typeName= ASTNodes.getTypeName(expectedType);
+
+		if (typeName.length() > 0) {
+			return getVariableNameSuggestions(variableKind, project, typeName, dim, excluded, evaluateDefault);
+		}
+		return EMPTY;
+	}
+
+	private static String[] getDefaultVariableNameSuggestions(int variableKind, Collection<String> excluded) {
+		String prop= variableKind == NamingConventions.VK_STATIC_FINAL_FIELD ? "X" : "x"; //$NON-NLS-1$//$NON-NLS-2$
+		String name= prop;
+		int i= 1;
+		while (excluded.contains(name)) {
+			name= prop + i++;
+		}
+		return new String[] { name };
+	}
+
+	/**
+	 * Returns variable name suggestions for the given base name. This is a layer over the JDT.Core
+	 * NamingConventions API to fix its shortcomings. JDT UI code should only use this API.
+	 *
+	 * @param variableKind specifies what type the variable is: {@link NamingConventions#VK_LOCAL},
+	 *            {@link NamingConventions#VK_PARAMETER}, {@link NamingConventions#VK_STATIC_FIELD},
+	 *            {@link NamingConventions#VK_INSTANCE_FIELD}, or
+	 *            {@link NamingConventions#VK_STATIC_FINAL_FIELD}.
+	 * @param project the current project
+	 * @param baseName the base name to make a suggestion on. The base name is expected to be a name
+	 *            without any pre- or suffixes in singular form. Type name are accepted as well.
+	 * @param dimensions if greater than 0, the resulting name will be in plural form
+	 * @param excluded a collection containing all excluded names or <code>null</code> if no names
+	 *            are excluded
+	 * @param evaluateDefault if set, the result is guaranteed to contain at least one result. If
+	 *            not, the result can be an empty array.
+	 *
+	 * @return the name suggestions sorted by relevance (best proposal first). If
+	 *         <code>evaluateDefault</code> is set to true, the returned array is never empty. If
+	 *         <code>evaluateDefault</code> is set to false, an empty array is returned if there is
+	 *         no good suggestion for the given base name.
+	 */
+	public static String[] getVariableNameSuggestions(int variableKind, IJavaProject project, String baseName, int dimensions, Collection<String> excluded, boolean evaluateDefault) {
+		return NamingConventions.suggestVariableNames(variableKind, NamingConventions.BK_TYPE_NAME, removeTypeArguments(baseName), project, dimensions, getExcludedArray(excluded), evaluateDefault);
+	}
+
+	private static String[] getExcludedArray(Collection<String> excluded) {
+		if (excluded == null) {
+			return null;
+		} else if (excluded instanceof ExcludedCollection) {
+			return ((ExcludedCollection)excluded).getExcludedArray();
+		}
+		return excluded.toArray(new String[excluded.size()]);
+	}
+
+
+	private static final String[] KNOWN_METHOD_NAME_PREFIXES= { "get", "is", "to" }; //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-1$
+
+
+	private static void add(String[] names, Set<String> result) {
+		for (int i= 0; i < names.length; i++) {
+			result.add(names[i]);
+		}
+	}
+
+	private static String getBaseNameFromExpression(IJavaProject project, Expression assignedExpression, int variableKind) {
+		String name= null;
+		if (assignedExpression instanceof CastExpression) {
+			assignedExpression= ((CastExpression)assignedExpression).getExpression();
+		}
+		if (assignedExpression instanceof Name) {
+			Name simpleNode= (Name)assignedExpression;
+			IBinding binding= simpleNode.resolveBinding();
+			if (binding instanceof IVariableBinding) {
+				return getBaseName((IVariableBinding)binding, project);
+			}
+
+			return ASTNodes.getSimpleNameIdentifier(simpleNode);
+		} else if (assignedExpression instanceof MethodInvocation) {
+			name= ((MethodInvocation)assignedExpression).getName().getIdentifier();
+		} else if (assignedExpression instanceof SuperMethodInvocation) {
+			name= ((SuperMethodInvocation)assignedExpression).getName().getIdentifier();
+		} else if (assignedExpression instanceof FieldAccess) {
+			return ((FieldAccess)assignedExpression).getName().getIdentifier();
+		} else if (variableKind == NamingConventions.VK_STATIC_FINAL_FIELD && (assignedExpression instanceof StringLiteral || assignedExpression instanceof NumberLiteral)) {
+			String string= assignedExpression instanceof StringLiteral ? ((StringLiteral)assignedExpression).getLiteralValue() : ((NumberLiteral)assignedExpression).getToken();
+			StringBuffer res= new StringBuffer();
+			boolean needsUnderscore= false;
+			for (int i= 0; i < string.length(); i++) {
+				char ch= string.charAt(i);
+				if (Character.isJavaIdentifierPart(ch)) {
+					if (res.length() == 0 && !Character.isJavaIdentifierStart(ch) || needsUnderscore) {
+						res.append('_');
+					}
+					res.append(ch);
+					needsUnderscore= false;
+				} else {
+					needsUnderscore= res.length() > 0;
+				}
+			}
+			if (res.length() > 0) {
+				return res.toString();
+			}
+		}
+		if (name != null) {
+			for (int i= 0; i < KNOWN_METHOD_NAME_PREFIXES.length; i++) {
+				String curr= KNOWN_METHOD_NAME_PREFIXES[i];
+				if (name.startsWith(curr)) {
+					if (name.equals(curr)) {
+						return null; // don't suggest 'get' as variable name
+					} else if (Character.isUpperCase(name.charAt(curr.length()))) {
+						return name.substring(curr.length());
+					}
+				}
+			}
+		}
+		return name;
+	}
+
+	private static String getBaseNameFromLocationInParent(Expression assignedExpression, List<Expression> arguments, IMethodBinding binding) {
+		if (binding == null) {
+			return null;
+		}
+
+		ITypeBinding[] parameterTypes= binding.getParameterTypes();
+		if (parameterTypes.length != arguments.size()) {
+			return null;
+		}
+
+		int index= arguments.indexOf(assignedExpression);
+		if (index == -1) {
+			return null;
+		}
+
+		ITypeBinding expressionBinding= assignedExpression.resolveTypeBinding();
+		if (expressionBinding != null && !expressionBinding.isAssignmentCompatible(parameterTypes[index])) {
+			return null;
+		}
+
+		try {
+			IJavaElement javaElement= binding.getJavaElement();
+			if (javaElement instanceof IMethod) {
+				IMethod method= (IMethod)javaElement;
+				if (method.getOpenable().getBuffer() != null) { // avoid dummy names and lookup from Javadoc
+					String[] parameterNames= method.getParameterNames();
+					if (index < parameterNames.length) {
+						return NamingConventions.getBaseName(NamingConventions.VK_PARAMETER, parameterNames[index], method.getJavaProject());
+					}
+				}
+			}
+		} catch (JavaModelException e) {
+			// ignore
+		}
+		return null;
+	}
+
+
+	private static String getBaseNameFromLocationInParent(Expression assignedExpression) {
+		StructuralPropertyDescriptor location= assignedExpression.getLocationInParent();
+		if (location == MethodInvocation.ARGUMENTS_PROPERTY) {
+			MethodInvocation parent= (MethodInvocation)assignedExpression.getParent();
+			return getBaseNameFromLocationInParent(assignedExpression, parent.arguments(), parent.resolveMethodBinding());
+		} else if (location == ClassInstanceCreation.ARGUMENTS_PROPERTY) {
+			ClassInstanceCreation parent= (ClassInstanceCreation)assignedExpression.getParent();
+			return getBaseNameFromLocationInParent(assignedExpression, parent.arguments(), parent.resolveConstructorBinding());
+		} else if (location == SuperMethodInvocation.ARGUMENTS_PROPERTY) {
+			SuperMethodInvocation parent= (SuperMethodInvocation)assignedExpression.getParent();
+			return getBaseNameFromLocationInParent(assignedExpression, parent.arguments(), parent.resolveMethodBinding());
+		} else if (location == ConstructorInvocation.ARGUMENTS_PROPERTY) {
+			ConstructorInvocation parent= (ConstructorInvocation)assignedExpression.getParent();
+			return getBaseNameFromLocationInParent(assignedExpression, parent.arguments(), parent.resolveConstructorBinding());
+		} else if (location == SuperConstructorInvocation.ARGUMENTS_PROPERTY) {
+			SuperConstructorInvocation parent= (SuperConstructorInvocation)assignedExpression.getParent();
+			return getBaseNameFromLocationInParent(assignedExpression, parent.arguments(), parent.resolveConstructorBinding());
+		}
+		return null;
+	}
+
+	public static String[] getArgumentNameSuggestions(IType type, String[] excluded) {
+		return getVariableNameSuggestions(NamingConventions.VK_PARAMETER, type.getJavaProject(), type.getElementName(),
+				0, new ExcludedCollection(excluded), true);
+	}
+
+	public static String[] getArgumentNameSuggestions(IJavaProject project, Type type, String[] excluded) {
+		return getVariableNameSuggestions(NamingConventions.VK_PARAMETER, project, type,
+				new ExcludedCollection(excluded), true);
+	}
+
+	public static String[] getArgumentNameSuggestions(IJavaProject project, ITypeBinding binding, String[] excluded) {
+		return getVariableNameSuggestions(NamingConventions.VK_PARAMETER, project, binding, null,
+				new ExcludedCollection(excluded));
+	}
+
+	public static String[] getArgumentNameSuggestions(IJavaProject project, String baseName, int dimensions,
+			String[] excluded) {
+		return getVariableNameSuggestions(NamingConventions.VK_PARAMETER, project, baseName, dimensions,
+				new ExcludedCollection(excluded), true);
+	}
+
+	public static String[] getFieldNameSuggestions(IType type, int fieldModifiers, String[] excluded) {
+		return getFieldNameSuggestions(type.getJavaProject(), type.getElementName(), 0, fieldModifiers, excluded);
+	}
+
+	public static String[] getFieldNameSuggestions(IJavaProject project, String baseName, int dimensions, int modifiers,
+			String[] excluded) {
+		if (Flags.isFinal(modifiers) && Flags.isStatic(modifiers)) {
+			return getVariableNameSuggestions(NamingConventions.VK_STATIC_FINAL_FIELD, project, baseName, dimensions,
+					new ExcludedCollection(excluded), true);
+		} else if (Flags.isStatic(modifiers)) {
+			return getVariableNameSuggestions(NamingConventions.VK_STATIC_FIELD, project, baseName, dimensions,
+					new ExcludedCollection(excluded), true);
+		}
+		return getVariableNameSuggestions(NamingConventions.VK_INSTANCE_FIELD, project, baseName, dimensions,
+				new ExcludedCollection(excluded), true);
+	}
+
+	public static String[] getLocalNameSuggestions(IJavaProject project, String baseName, int dimensions,
+			String[] excluded) {
+		return getVariableNameSuggestions(NamingConventions.VK_LOCAL, project, baseName, dimensions,
+				new ExcludedCollection(excluded), true);
+	}
+
+	public static String suggestArgumentName(IJavaProject project, String baseName, String[] excluded) {
+		return suggestVariableName(NamingConventions.VK_PARAMETER, project, baseName, 0, excluded);
+	}
+
+	private static String suggestVariableName(int varKind, IJavaProject project, String baseName, int dimension,
+			String[] excluded) {
+		return getVariableNameSuggestions(varKind, project, baseName, dimension, new ExcludedCollection(excluded),
+				true)[0];
+	}
+
+	//	public static String[][] suggestArgumentNamesWithProposals(IJavaProject project, String[] paramNames) {
+	//		String[][] newNames = new String[paramNames.length][];
+	//		ArrayList<String> takenNames = new ArrayList<>();
+	//
+	//		// Ensure that the code generation preferences are respected
+	//		for (int i = 0; i < paramNames.length; i++) {
+	//			String curr = paramNames[i];
+	//			String baseName = NamingConventions.getBaseName(NamingConventions.VK_PARAMETER, curr, project);
+	//
+	//			String[] proposedNames = getVariableNameSuggestions(NamingConventions.VK_PARAMETER, project, curr, 0,
+	//					takenNames, true);
+	//			if (!curr.equals(baseName)) {
+	//				// make the existing name to favorite
+	//				LinkedHashSet<String> updatedNames = new LinkedHashSet<>();
+	//				updatedNames.add(curr);
+	//				for (int k = 0; k < proposedNames.length; k++) {
+	//					updatedNames.add(proposedNames[k]);
+	//				}
+	//				proposedNames = updatedNames.toArray(new String[updatedNames.size()]);
+	//			}
+	//			newNames[i] = proposedNames;
+	//			takenNames.add(proposedNames[0]);
+	//		}
+	//		return newNames;
+	//	}
+
+	//	public static String[][] suggestArgumentNamesWithProposals(IJavaProject project, IMethodBinding binding) {
+	//		int nParams = binding.getParameterTypes().length;
+	//		if (nParams > 0) {
+	//			try {
+	//				IMethod method = (IMethod) binding.getMethodDeclaration().getJavaElement();
+	//				if (method != null) {
+	//					String[] parameterNames = method.getParameterNames();
+	//					if (parameterNames.length == nParams) {
+	//						return suggestArgumentNamesWithProposals(project, parameterNames);
+	//					}
+	//				}
+	//			} catch (JavaModelException e) {
+	//				// ignore
+	//			}
+	//		}
+	//		String[][] names = new String[nParams][];
+	//		for (int i = 0; i < names.length; i++) {
+	//			names[i] = new String[] { "arg" + i }; //$NON-NLS-1$
+	//		}
+	//		return names;
+	//	}
+
+	public static String[] suggestArgumentNames(IJavaProject project, IMethodBinding binding) {
+		int nParams = binding.getParameterTypes().length;
+
+		if (nParams > 0) {
+			try {
+				IMethod method = (IMethod) binding.getMethodDeclaration().getJavaElement();
+				if (method != null) {
+					String[] paramNames = method.getParameterNames();
+					if (paramNames.length == nParams) {
+						String[] namesArray = EMPTY;
+						ArrayList<String> newNames = new ArrayList<>(paramNames.length);
+						// Ensure that the code generation preferences are respected
+						for (int i = 0; i < paramNames.length; i++) {
+							String curr = paramNames[i];
+							String baseName = NamingConventions.getBaseName(NamingConventions.VK_PARAMETER, curr,
+									method.getJavaProject());
+							if (!curr.equals(baseName)) {
+								// make the existing name the favorite
+								newNames.add(curr);
+							} else {
+								newNames.add(suggestArgumentName(project, curr, namesArray));
+							}
+							namesArray = newNames.toArray(new String[newNames.size()]);
+						}
+						return namesArray;
+					}
+				}
+			} catch (JavaModelException e) {
+				// ignore
+			}
+		}
+		String[] names = new String[nParams];
+		for (int i = 0; i < names.length; i++) {
+			names[i] = "arg" + i; //$NON-NLS-1$
+		}
+		return names;
+	}
+
+	public static String getBaseName(IField field) throws JavaModelException {
+		return NamingConventions.getBaseName(getFieldKind(field.getFlags()), field.getElementName(),
+				field.getJavaProject());
+	}
+
+	public static String getBaseName(IVariableBinding binding, IJavaProject project) {
+		return NamingConventions.getBaseName(getKind(binding), binding.getName(), project);
+	}
+
+	/**
+	 * Returns the kind of the given binding.
+	 *
+	 * @param binding
+	 *            variable binding
+	 * @return one of the <code>NamingConventions.VK_*</code> constants
+	 * @since 3.5
+	 */
+	private static int getKind(IVariableBinding binding) {
+		if (binding.isField()) {
+			return getFieldKind(binding.getModifiers());
+		}
+
+		if (binding.isParameter()) {
+			return NamingConventions.VK_PARAMETER;
+		}
+
+		return NamingConventions.VK_LOCAL;
+	}
+
+	private static int getFieldKind(int modifiers) {
+		if (!Modifier.isStatic(modifiers)) {
+			return NamingConventions.VK_INSTANCE_FIELD;
+		}
+
+		if (!Modifier.isFinal(modifiers)) {
+			return NamingConventions.VK_STATIC_FIELD;
+		}
+
+		return NamingConventions.VK_STATIC_FINAL_FIELD;
+	}
+
+	private static class ExcludedCollection extends AbstractList<String> {
+		private String[] fExcluded;
+
+		public ExcludedCollection(String[] excluded) {
+			fExcluded = excluded;
+		}
+
+		public String[] getExcludedArray() {
+			return fExcluded;
+		}
+
+		@Override
+		public int size() {
+			return fExcluded.length;
+		}
+
+		@Override
+		public String get(int index) {
+			return fExcluded[index];
+		}
+
+		@Override
+		public int indexOf(Object o) {
+			if (o instanceof String) {
+				for (int i = 0; i < fExcluded.length; i++) {
+					if (o.equals(fExcluded[i])) {
+						return i;
+					}
+				}
+			}
+			return -1;
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return indexOf(o) != -1;
+		}
+	}
+
+	public static boolean hasFieldName(IJavaProject project, String name) {
+		String prefixes = project.getOption(JavaCore.CODEASSIST_FIELD_PREFIXES, true);
+		String suffixes = project.getOption(JavaCore.CODEASSIST_FIELD_SUFFIXES, true);
+		String staticPrefixes = project.getOption(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, true);
+		String staticSuffixes = project.getOption(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, true);
+
+		return hasPrefixOrSuffix(prefixes, suffixes, name) || hasPrefixOrSuffix(staticPrefixes, staticSuffixes, name);
+	}
+
+	public static boolean hasParameterName(IJavaProject project, String name) {
+		String prefixes = project.getOption(JavaCore.CODEASSIST_ARGUMENT_PREFIXES, true);
+		String suffixes = project.getOption(JavaCore.CODEASSIST_ARGUMENT_SUFFIXES, true);
+		return hasPrefixOrSuffix(prefixes, suffixes, name);
+	}
+
+	public static boolean hasLocalVariableName(IJavaProject project, String name) {
+		String prefixes = project.getOption(JavaCore.CODEASSIST_LOCAL_PREFIXES, true);
+		String suffixes = project.getOption(JavaCore.CODEASSIST_LOCAL_SUFFIXES, true);
+		return hasPrefixOrSuffix(prefixes, suffixes, name);
+	}
+
+	public static boolean hasConstantName(IJavaProject project, String name) {
+		if (Character.isUpperCase(name.charAt(0))) {
+			return true;
+		}
+		String prefixes = project.getOption(JavaCore.CODEASSIST_STATIC_FINAL_FIELD_PREFIXES, true);
+		String suffixes = project.getOption(JavaCore.CODEASSIST_STATIC_FINAL_FIELD_SUFFIXES, true);
+		return hasPrefixOrSuffix(prefixes, suffixes, name);
+	}
+
+	private static boolean hasPrefixOrSuffix(String prefixes, String suffixes, String name) {
+		final String listSeparartor = ","; //$NON-NLS-1$
+
+		StringTokenizer tok = new StringTokenizer(prefixes, listSeparartor);
+		while (tok.hasMoreTokens()) {
+			String curr = tok.nextToken();
+			if (name.startsWith(curr)) {
+				return true;
+			}
+		}
+
+		tok = new StringTokenizer(suffixes, listSeparartor);
+		while (tok.hasMoreTokens()) {
+			String curr = tok.nextToken();
+			if (name.endsWith(curr)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	//
+	//	// -------------------- preference access -----------------------
+	//
+	//	public static boolean useThisForFieldAccess(IJavaProject project) {
+	//		return Boolean.valueOf(PreferenceConstants.getPreference(PreferenceConstants.CODEGEN_KEYWORD_THIS, project)).booleanValue();
+	//	}
+	//
+	//	public static boolean useIsForBooleanGetters(IJavaProject project) {
+	//		return Boolean.valueOf(PreferenceConstants.getPreference(PreferenceConstants.CODEGEN_IS_FOR_GETTERS, project)).booleanValue();
+	//	}
+	//
+	//	public static String getExceptionVariableName(IJavaProject project) {
+	//		return PreferenceConstants.getPreference(PreferenceConstants.CODEGEN_EXCEPTION_VAR_NAME, project);
+	//	}
+	//
+	//	public static boolean doAddComments(IJavaProject project) {
+	//		return Boolean.valueOf(PreferenceConstants.getPreference(PreferenceConstants.CODEGEN_ADD_COMMENTS, project)).booleanValue();
+	//	}
+	//
+	//	/**
+	//	 * Only to be used by tests
+	//	 *
+	//	 * @param templateId the template id
+	//	 * @param pattern the new pattern
+	//	 * @param project not used
+	//	 */
+	//	public static void setCodeTemplate(String templateId, String pattern, IJavaProject project) {
+	//		TemplateStore codeTemplateStore= JavaPlugin.getDefault().getCodeTemplateStore();
+	//		TemplatePersistenceData data= codeTemplateStore.getTemplateData(templateId);
+	//		Template orig= data.getTemplate();
+	//		Template copy= new Template(orig.getName(), orig.getDescription(), orig.getContextTypeId(), pattern, true);
+	//		data.setTemplate(copy);
+	//	}
+	//
+	//	public static Template getCodeTemplate(String id, IJavaProject project) {
+	//		if (project == null) {
+	//			return JavaPlugin.getDefault().getCodeTemplateStore().findTemplateById(id);
+	//		}
+	//		ProjectTemplateStore projectStore= new ProjectTemplateStore(project.getProject());
+	//		try {
+	//			projectStore.load();
+	//		} catch (IOException e) {
+	//			JavaPlugin.log(e);
+	//		}
+	//		return projectStore.findTemplateById(id);
+	//	}
+	//
+	//
+	//	public static ImportRewrite createImportRewrite(ICompilationUnit cu, boolean restoreExistingImports) throws JavaModelException {
+	//		return CodeStyleConfiguration.createImportRewrite(cu, restoreExistingImports);
+	//	}
+	//
+	//	/**
+	//	 * Returns a {@link ImportRewrite} using {@link ImportRewrite#create(CompilationUnit, boolean)} and
+	//	 * configures the rewriter with the settings as specified in the JDT UI preferences.
+	//	 * <p>
+	//	 * This method sets {@link ImportRewrite#setUseContextToFilterImplicitImports(boolean)} to <code>true</code>
+	//	 * iff the given AST has been resolved with bindings. Clients should always supply a context
+	//	 * when they call one of the <code>addImport(...)</code> methods.
+	//	 * </p>
+	//	 *
+	//	 * @param astRoot the AST root to create the rewriter on
+	//	 * @param restoreExistingImports specifies if the existing imports should be kept or removed.
+	//	 * @return the new rewriter configured with the settings as specified in the JDT UI preferences.
+	//	 *
+	//	 * @see ImportRewrite#create(CompilationUnit, boolean)
+	//	 */
+	//	public static ImportRewrite createImportRewrite(CompilationUnit astRoot, boolean restoreExistingImports) {
+	//		ImportRewrite rewrite= CodeStyleConfiguration.createImportRewrite(astRoot, restoreExistingImports);
+	//		if (astRoot.getAST().hasResolvedBindings()) {
+	//			rewrite.setUseContextToFilterImplicitImports(true);
+	//		}
+	//		return rewrite;
+	//	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/StubUtility2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/StubUtility2.java
@@ -1,0 +1,1062 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Stephan Herrmann - Contribution for Bug 463360 - [override method][null] generating method override should not create redundant null annotations
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.codemanipulation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.SourceRange;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Dimension;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.IPackageBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeParameter;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.ls.core.internal.corext.dom.ASTNodeFactory;
+import org.eclipse.text.edits.TextEditGroup;
+
+/**
+ * Utilities for code generation based on AST rewrite.
+ *
+ * Code copied from
+ * org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2
+ *
+ * @see StubUtility
+ * @see JDTUIHelperClasses
+ * @since 3.1
+ */
+public final class StubUtility2 {
+
+	/**
+	 * Adds <code>@Override</code> annotation to <code>methodDecl</code> if not already present and
+	 * if requested by code style settings or compiler errors/warnings settings.
+	 *
+	 * @param settings the code generation style settings, may be <code>null</code>
+	 * @param project the Java project used to access the compiler settings
+	 * @param rewrite the ASTRewrite
+	 * @param imports the ImportRewrite
+	 * @param methodDecl the method declaration to add the annotation to
+	 * @param isDeclaringTypeInterface <code>true</code> if the type declaring the method overridden
+	 *            by <code>methodDecl</code> is an interface
+	 * @param group the text edit group, may be <code>null</code>
+	 */
+	public static void addOverrideAnnotation(CodeGenerationSettings settings, IJavaProject project, ASTRewrite rewrite, ImportRewrite imports, MethodDeclaration methodDecl,
+			boolean isDeclaringTypeInterface, TextEditGroup group) {
+		if (!JavaModelUtil.is50OrHigher(project)) {
+			return;
+		}
+		if (isDeclaringTypeInterface) {
+			String version= project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+			if (JavaModelUtil.isVersionLessThan(version, JavaCore.VERSION_1_6))
+			{
+				return; // not allowed in 1.5
+			}
+			if (JavaCore.DISABLED.equals(project.getOption(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION_FOR_INTERFACE_METHOD_IMPLEMENTATION, true)))
+			{
+				return; // user doesn't want to use 1.6 style
+			}
+		}
+		if ((settings != null && settings.overrideAnnotation) || !JavaCore.IGNORE.equals(project.getOption(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION, true))) {
+			createOverrideAnnotation(rewrite, imports, methodDecl, group);
+		}
+	}
+
+	public static void createOverrideAnnotation(ASTRewrite rewrite, ImportRewrite imports, MethodDeclaration decl, TextEditGroup group) {
+		if (findAnnotation("java.lang.Override", decl.modifiers()) != null) { //$NON-NLS-1$
+			return; // No need to add duplicate annotation
+		}
+		AST ast= rewrite.getAST();
+		ASTNode root= decl.getRoot();
+		ImportRewriteContext context= null;
+		if (root instanceof CompilationUnit) {
+			context= new ContextSensitiveImportRewriteContext((CompilationUnit) root, decl.getStartPosition(), imports);
+		}
+		Annotation marker= ast.newMarkerAnnotation();
+		marker.setTypeName(ast.newName(imports.addImport("java.lang.Override", context))); //$NON-NLS-1$
+		rewrite.getListRewrite(decl, MethodDeclaration.MODIFIERS2_PROPERTY).insertFirst(marker, group);
+	}
+
+	//	/* This method should work with all AST levels. */
+	//	public static MethodDeclaration createConstructorStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, IMethodBinding binding, String type, int modifiers, boolean omitSuperForDefConst, boolean todo, CodeGenerationSettings settings) throws CoreException {
+	//		AST ast= rewrite.getAST();
+	//		MethodDeclaration decl= ast.newMethodDeclaration();
+	//		decl.modifiers().addAll(ASTNodeFactory.newModifiers(ast, modifiers & ~Modifier.ABSTRACT & ~Modifier.NATIVE));
+	//		decl.setName(ast.newSimpleName(type));
+	//		decl.setConstructor(true);
+	//
+	//		createTypeParameters(imports, context, ast, binding, decl);
+	//
+	//		List<SingleVariableDeclaration> parameters= createParameters(unit.getJavaProject(), imports, context, ast, binding, null, decl);
+	//
+	//		createThrownExceptions(decl, binding, imports, context, ast);
+	//
+	//		Block body= ast.newBlock();
+	//		decl.setBody(body);
+	//
+	//		String delimiter= StubUtility.getLineDelimiterUsed(unit);
+	//		String bodyStatement= ""; //$NON-NLS-1$
+	//		if (!omitSuperForDefConst || !parameters.isEmpty()) {
+	//			SuperConstructorInvocation invocation= ast.newSuperConstructorInvocation();
+	//			SingleVariableDeclaration varDecl= null;
+	//			for (Iterator<SingleVariableDeclaration> iterator= parameters.iterator(); iterator.hasNext();) {
+	//				varDecl= iterator.next();
+	//				invocation.arguments().add(ast.newSimpleName(varDecl.getName().getIdentifier()));
+	//			}
+	//			bodyStatement= ASTNodes.asFormattedString(invocation, 0, delimiter, unit.getJavaProject().getOptions(true));
+	//		}
+	//
+	//		if (todo) {
+	//			String placeHolder= CodeGeneration.getMethodBodyContent(unit, type, binding.getName(), true, bodyStatement, delimiter);
+	//			if (placeHolder != null) {
+	//				ReturnStatement todoNode= (ReturnStatement) rewrite.createStringPlaceholder(placeHolder, ASTNode.RETURN_STATEMENT);
+	//				body.statements().add(todoNode);
+	//			}
+	//		} else {
+	//			ReturnStatement statementNode= (ReturnStatement) rewrite.createStringPlaceholder(bodyStatement, ASTNode.RETURN_STATEMENT);
+	//			body.statements().add(statementNode);
+	//		}
+	//
+	//		if (settings != null && settings.createComments) {
+	//			String string= CodeGeneration.getMethodComment(unit, type, decl, binding, delimiter);
+	//			if (string != null) {
+	//				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
+	//				decl.setJavadoc(javadoc);
+	//			}
+	//		}
+	//		return decl;
+	//	}
+	//
+	//	public static MethodDeclaration createConstructorStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, ITypeBinding typeBinding, IMethodBinding superConstructor, IVariableBinding[] variableBindings, int modifiers, CodeGenerationSettings settings) throws CoreException {
+	//		AST ast= rewrite.getAST();
+	//
+	//		MethodDeclaration decl= ast.newMethodDeclaration();
+	//		decl.modifiers().addAll(ASTNodeFactory.newModifiers(ast, modifiers & ~Modifier.ABSTRACT & ~Modifier.NATIVE));
+	//		decl.setName(ast.newSimpleName(typeBinding.getName()));
+	//		decl.setConstructor(true);
+	//
+	//		List<SingleVariableDeclaration> parameters= decl.parameters();
+	//		if (superConstructor != null) {
+	//			createTypeParameters(imports, context, ast, superConstructor, decl);
+	//
+	//			createParameters(unit.getJavaProject(), imports, context, ast, superConstructor, null, decl);
+	//
+	//			createThrownExceptions(decl, superConstructor, imports, context, ast);
+	//		}
+	//
+	//		Block body= ast.newBlock();
+	//		decl.setBody(body);
+	//
+	//		String delimiter= StubUtility.getLineDelimiterUsed(unit);
+	//
+	//		if (superConstructor != null) {
+	//			SuperConstructorInvocation invocation= ast.newSuperConstructorInvocation();
+	//			SingleVariableDeclaration varDecl= null;
+	//			for (Iterator<SingleVariableDeclaration> iterator= parameters.iterator(); iterator.hasNext();) {
+	//				varDecl= iterator.next();
+	//				invocation.arguments().add(ast.newSimpleName(varDecl.getName().getIdentifier()));
+	//			}
+	//			body.statements().add(invocation);
+	//		}
+	//
+	//		List<String> prohibited= new ArrayList<>();
+	//		for (final Iterator<SingleVariableDeclaration> iterator= parameters.iterator(); iterator.hasNext();) {
+	//			prohibited.add(iterator.next().getName().getIdentifier());
+	//		}
+	//		String param= null;
+	//		List<String> list= new ArrayList<>(prohibited);
+	//		String[] excluded= null;
+	//		for (int i= 0; i < variableBindings.length; i++) {
+	//			SingleVariableDeclaration var= ast.newSingleVariableDeclaration();
+	//			var.setType(imports.addImport(variableBindings[i].getType(), ast, context, TypeLocation.PARAMETER));
+	//			excluded= new String[list.size()];
+	//			list.toArray(excluded);
+	//			param= suggestParameterName(unit, variableBindings[i], excluded);
+	//			list.add(param);
+	//			var.setName(ast.newSimpleName(param));
+	//			parameters.add(var);
+	//		}
+	//
+	//		list= new ArrayList<>(prohibited);
+	//		for (int i= 0; i < variableBindings.length; i++) {
+	//			excluded= new String[list.size()];
+	//			list.toArray(excluded);
+	//			final String paramName= suggestParameterName(unit, variableBindings[i], excluded);
+	//			list.add(paramName);
+	//			final String fieldName= variableBindings[i].getName();
+	//			Expression expression= null;
+	//			if (paramName.equals(fieldName) || settings.useKeywordThis) {
+	//				FieldAccess access= ast.newFieldAccess();
+	//				access.setExpression(ast.newThisExpression());
+	//				access.setName(ast.newSimpleName(fieldName));
+	//				expression= access;
+	//			} else {
+	//				expression= ast.newSimpleName(fieldName);
+	//			}
+	//			Assignment assignment= ast.newAssignment();
+	//			assignment.setLeftHandSide(expression);
+	//			assignment.setRightHandSide(ast.newSimpleName(paramName));
+	//			assignment.setOperator(Assignment.Operator.ASSIGN);
+	//			body.statements().add(ast.newExpressionStatement(assignment));
+	//		}
+	//
+	//		if (settings != null && settings.createComments) {
+	//			String string= CodeGeneration.getMethodComment(unit, typeBinding.getName(), decl, superConstructor, delimiter);
+	//			if (string != null) {
+	//				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
+	//				decl.setJavadoc(javadoc);
+	//			}
+	//		}
+	//		return decl;
+	//	}
+	//
+	//	public static MethodDeclaration createDelegationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, IMethodBinding delegate, IVariableBinding delegatingField, CodeGenerationSettings settings) throws CoreException {
+	//		Assert.isNotNull(delegate);
+	//		Assert.isNotNull(delegatingField);
+	//		Assert.isNotNull(settings);
+	//
+	//		AST ast= rewrite.getAST();
+	//
+	//		MethodDeclaration decl= ast.newMethodDeclaration();
+	//		decl.modifiers().addAll(ASTNodeFactory.newModifiers(ast, delegate.getModifiers() & ~Modifier.SYNCHRONIZED & ~Modifier.ABSTRACT & ~Modifier.NATIVE));
+	//
+	//		decl.setName(ast.newSimpleName(delegate.getName()));
+	//		decl.setConstructor(false);
+	//
+	//		createTypeParameters(imports, context, ast, delegate, decl);
+	//
+	//		decl.setReturnType2(imports.addImport(delegate.getReturnType(), ast, context, TypeLocation.RETURN_TYPE));
+	//
+	//		List<SingleVariableDeclaration> params= createParameters(unit.getJavaProject(), imports, context, ast, delegate, null, decl);
+	//
+	//		createThrownExceptions(decl, delegate, imports, context, ast);
+	//
+	//		Block body= ast.newBlock();
+	//		decl.setBody(body);
+	//
+	//		String delimiter= StubUtility.getLineDelimiterUsed(unit);
+	//
+	//		Statement statement= null;
+	//		MethodInvocation invocation= ast.newMethodInvocation();
+	//		invocation.setName(ast.newSimpleName(delegate.getName()));
+	//		List<Expression> arguments= invocation.arguments();
+	//		for (int i= 0; i < params.size(); i++) {
+	//			arguments.add(ast.newSimpleName(params.get(i).getName().getIdentifier()));
+	//		}
+	//		if (settings.useKeywordThis) {
+	//			FieldAccess access= ast.newFieldAccess();
+	//			access.setExpression(ast.newThisExpression());
+	//			access.setName(ast.newSimpleName(delegatingField.getName()));
+	//			invocation.setExpression(access);
+	//		} else {
+	//			invocation.setExpression(ast.newSimpleName(delegatingField.getName()));
+	//		}
+	//		if (delegate.getReturnType().isPrimitive() && delegate.getReturnType().getName().equals("void")) {//$NON-NLS-1$
+	//			statement= ast.newExpressionStatement(invocation);
+	//		} else {
+	//			ReturnStatement returnStatement= ast.newReturnStatement();
+	//			returnStatement.setExpression(invocation);
+	//			statement= returnStatement;
+	//		}
+	//		body.statements().add(statement);
+	//
+	//		ITypeBinding declaringType= delegatingField.getDeclaringClass();
+	//		if (declaringType == null) { // can be null for
+	//			return decl;
+	//		}
+	//
+	//		String qualifiedName= declaringType.getQualifiedName();
+	//		IPackageBinding packageBinding= declaringType.getPackage();
+	//		if (packageBinding != null) {
+	//			if (packageBinding.getName().length() > 0 && qualifiedName.startsWith(packageBinding.getName())) {
+	//				qualifiedName= qualifiedName.substring(packageBinding.getName().length());
+	//			}
+	//		}
+	//
+	//		if (settings.createComments) {
+	//			/*
+	//			 * TODO: have API for delegate method comments This is an inlined
+	//			 * version of
+	//			 * {@link CodeGeneration#getMethodComment(ICompilationUnit, String, MethodDeclaration, IMethodBinding, String)}
+	//			 */
+	//			delegate= delegate.getMethodDeclaration();
+	//			String declaringClassQualifiedName= delegate.getDeclaringClass().getQualifiedName();
+	//			String linkToMethodName= delegate.getName();
+	//			String[] parameterTypesQualifiedNames= StubUtility.getParameterTypeNamesForSeeTag(delegate);
+	//			String string= StubUtility.getMethodComment(unit, qualifiedName, decl, delegate.isDeprecated(), linkToMethodName, declaringClassQualifiedName, parameterTypesQualifiedNames, true, delimiter);
+	//			if (string != null) {
+	//				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
+	//				decl.setJavadoc(javadoc);
+	//			}
+	//		}
+	//		return decl;
+	//	}
+
+	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
+			IMethodBinding binding, ITypeBinding targetType, CodeGenerationSettings settings, boolean inInterface,
+			IBinding contextBinding, boolean snippetStringSupport) throws CoreException {
+		return createImplementationStub(unit, rewrite, imports, context, binding, null, targetType, settings,
+				inInterface, contextBinding, snippetStringSupport);
+	}
+
+	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
+			IMethodBinding binding, String[] parameterNames, ITypeBinding targetType, CodeGenerationSettings settings,
+			boolean inInterface, IBinding contextBinding, boolean snippetStringSupport) throws CoreException {
+		Assert.isNotNull(imports);
+		Assert.isNotNull(rewrite);
+
+		AST ast= rewrite.getAST();
+		String type= Bindings.getTypeQualifiedName(targetType);
+
+		IJavaProject javaProject= unit.getJavaProject();
+		IAnnotationBinding nullnessDefault= null;
+		if (contextBinding != null && JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, true))) {
+			nullnessDefault= Bindings.findNullnessDefault(contextBinding, javaProject);
+		}
+
+		MethodDeclaration decl= ast.newMethodDeclaration();
+		decl.modifiers().addAll(getImplementationModifiers(ast, binding, inInterface, imports, context, nullnessDefault));
+
+		decl.setName(ast.newSimpleName(binding.getName()));
+		decl.setConstructor(false);
+
+		ITypeBinding bindingReturnType= binding.getReturnType();
+		bindingReturnType = StubUtility2.replaceWildcardsAndCaptures(bindingReturnType);
+
+		if (JavaModelUtil.is50OrHigher(javaProject)) {
+			createTypeParameters(imports, context, ast, binding, decl);
+
+		} else {
+			bindingReturnType= bindingReturnType.getErasure();
+		}
+
+		decl.setReturnType2(imports.addImport(bindingReturnType, ast, context, TypeLocation.RETURN_TYPE));
+
+		List<SingleVariableDeclaration> parameters= createParameters(javaProject, imports, context, ast, binding, parameterNames, decl, nullnessDefault);
+
+		createThrownExceptions(decl, binding, imports, context, ast);
+
+		String delimiter= unit.findRecommendedLineSeparator();
+		int modifiers= binding.getModifiers();
+		ITypeBinding declaringType= binding.getDeclaringClass();
+		ITypeBinding typeObject= ast.resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
+		if (!inInterface || (declaringType != typeObject && JavaModelUtil.is18OrHigher(javaProject))) {
+			// generate a method body
+
+			Map<String, String> options= javaProject.getOptions(true);
+
+			Block body= ast.newBlock();
+			decl.setBody(body);
+
+			String bodyStatement= ""; //$NON-NLS-1$
+			if (Modifier.isAbstract(modifiers)) {
+				Expression expression= ASTNodeFactory.newDefaultExpression(ast, decl.getReturnType2(), decl.getExtraDimensions());
+				if (expression != null) {
+					ReturnStatement returnStatement= ast.newReturnStatement();
+					returnStatement.setExpression(expression);
+					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
+				}
+			} else {
+				SuperMethodInvocation invocation= ast.newSuperMethodInvocation();
+				if (declaringType.isInterface()) {
+					ITypeBinding supertype= Bindings.findImmediateSuperTypeInHierarchy(targetType, declaringType.getTypeDeclaration().getQualifiedName());
+					if (supertype == null) { // should not happen, but better use the type we have rather than failing
+						supertype= declaringType;
+					}
+					if (supertype.isInterface()) {
+						String qualifier= imports.addImport(supertype.getTypeDeclaration(), context);
+						Name name= ASTNodeFactory.newName(ast, qualifier);
+						invocation.setQualifier(name);
+					}
+				}
+				invocation.setName(ast.newSimpleName(binding.getName()));
+
+				for (SingleVariableDeclaration varDecl : parameters) {
+					invocation.arguments().add(ast.newSimpleName(varDecl.getName().getIdentifier()));
+				}
+				Expression expression= invocation;
+				Type returnType= decl.getReturnType2();
+				if (returnType instanceof PrimitiveType && ((PrimitiveType) returnType).getPrimitiveTypeCode().equals(PrimitiveType.VOID)) {
+					bodyStatement= ASTNodes.asFormattedString(ast.newExpressionStatement(expression), 0, delimiter, options);
+				} else {
+					ReturnStatement returnStatement= ast.newReturnStatement();
+					returnStatement.setExpression(expression);
+					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
+				}
+			}
+
+			if (bodyStatement != null) {
+				StringBuilder placeHolder = new StringBuilder();
+				if (snippetStringSupport) {
+					placeHolder.append("${0");
+					if (!bodyStatement.isEmpty()) {
+						placeHolder.append(":");
+					}
+				}
+				placeHolder.append(bodyStatement);
+				if (snippetStringSupport) {
+					placeHolder.append("}");
+				}
+				ReturnStatement todoNode = (ReturnStatement) rewrite.createStringPlaceholder(placeHolder.toString(),
+						ASTNode.RETURN_STATEMENT);
+				body.statements().add(todoNode);
+			}
+		}
+
+		/* jdt.ls doesn't create comments at that point
+		if (settings != null && settings.createComments) {
+			String string= CodeGeneration.getMethodComment(unit, type, decl, binding, delimiter);
+			if (string != null) {
+				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
+				decl.setJavadoc(javadoc);
+			}
+		}
+		 */
+
+		// According to JLS8 9.2, an interface doesn't implicitly declare non-public members of Object,
+		// and JLS8 9.6.4.4 doesn't allow @Override for these methods (clone and finalize).
+		boolean skipOverride= inInterface && declaringType == typeObject && !Modifier.isPublic(modifiers);
+
+		if (!skipOverride) {
+			addOverrideAnnotation(settings, javaProject, rewrite, imports, decl, binding.getDeclaringClass().isInterface(), null);
+		}
+
+		return decl;
+	}
+
+	private static void createTypeParameters(ImportRewrite imports, ImportRewriteContext context, AST ast, IMethodBinding binding, MethodDeclaration decl) {
+		ITypeBinding[] typeParams= binding.getTypeParameters();
+		List<TypeParameter> typeParameters= decl.typeParameters();
+		for (int i= 0; i < typeParams.length; i++) {
+			ITypeBinding curr= typeParams[i];
+			TypeParameter newTypeParam= ast.newTypeParameter();
+			newTypeParam.setName(ast.newSimpleName(curr.getName()));
+			ITypeBinding[] typeBounds= curr.getTypeBounds();
+			if (typeBounds.length != 1 || !"java.lang.Object".equals(typeBounds[0].getQualifiedName())) {//$NON-NLS-1$
+				List<Type> newTypeBounds= newTypeParam.typeBounds();
+				for (int k= 0; k < typeBounds.length; k++) {
+					newTypeBounds.add(imports.addImport(typeBounds[k], ast, context, TypeLocation.TYPE_BOUND));
+				}
+			}
+			typeParameters.add(newTypeParam);
+		}
+	}
+
+	//	private static List<SingleVariableDeclaration> createParameters(IJavaProject project, ImportRewrite imports, ImportRewriteContext context, AST ast, IMethodBinding binding, String[] paramNames, MethodDeclaration decl) {
+	//		return createParameters(project, imports, context, ast, binding, paramNames, decl, null);
+	//	}
+	private static List<SingleVariableDeclaration> createParameters(IJavaProject project, ImportRewrite imports, ImportRewriteContext context, AST ast,
+			IMethodBinding binding, String[] paramNames, MethodDeclaration decl, IAnnotationBinding defaultNullness) {
+		boolean is50OrHigher= JavaModelUtil.is50OrHigher(project);
+		List<SingleVariableDeclaration> parameters= decl.parameters();
+		ITypeBinding[] params= binding.getParameterTypes();
+		if (paramNames == null || paramNames.length < params.length) {
+			paramNames= StubUtility.suggestArgumentNames(project, binding);
+		}
+		for (int i= 0; i < params.length; i++) {
+			SingleVariableDeclaration var= ast.newSingleVariableDeclaration();
+			ITypeBinding type= params[i];
+			type=replaceWildcardsAndCaptures(type);
+			if (!is50OrHigher) {
+				type= type.getErasure();
+				var.setType(imports.addImport(type, ast, context, TypeLocation.PARAMETER));
+			} else if (binding.isVarargs() && type.isArray() && i == params.length - 1) {
+				var.setVarargs(true);
+				/*
+				 * Varargs annotations are special.
+				 * Example:
+				 *     foo(@O Object @A [] @B ... arg)
+				 * => @B is not an annotation on the array dimension that constitutes the vararg.
+				 * It's the type annotation of the *innermost* array dimension.
+				 */
+				int dimensions= type.getDimensions();
+				@SuppressWarnings("unchecked")
+				List<Annotation>[] dimensionAnnotations= (List<Annotation>[]) new List<?>[dimensions];
+				for (int dim= 0; dim < dimensions; dim++) {
+					dimensionAnnotations[dim]= new ArrayList<>();
+					for (IAnnotationBinding annotation : type.getTypeAnnotations()) {
+						dimensionAnnotations[dim].add(imports.addAnnotation(annotation, ast, context));
+					}
+					type= type.getComponentType();
+				}
+
+				Type elementType= imports.addImport(type, ast, context);
+				if (dimensions == 1) {
+					var.setType(elementType);
+				} else {
+					ArrayType arrayType= ast.newArrayType(elementType, dimensions - 1);
+					List<Dimension> dimensionNodes= arrayType.dimensions();
+					for (int dim= 0; dim < dimensions - 1; dim++) { // all except the innermost dimension
+						Dimension dimension= dimensionNodes.get(dim);
+						dimension.annotations().addAll(dimensionAnnotations[dim]);
+					}
+					var.setType(arrayType);
+				}
+				List<Annotation> varargTypeAnnotations= dimensionAnnotations[dimensions - 1];
+				var.varargsAnnotations().addAll(varargTypeAnnotations);
+			} else {
+				var.setType(imports.addImport(type, ast, context, TypeLocation.PARAMETER));
+			}
+			var.setName(ast.newSimpleName(paramNames[i]));
+			IAnnotationBinding[] annotations= binding.getParameterAnnotations(i);
+			for (IAnnotationBinding annotation : annotations) {
+				if (StubUtility2.isCopyOnInheritAnnotation(annotation.getAnnotationType(), project, defaultNullness)) {
+					var.modifiers().add(imports.addAnnotation(annotation, ast, context));
+				}
+			}
+			parameters.add(var);
+		}
+		return parameters;
+	}
+
+	private static void createThrownExceptions(MethodDeclaration decl, IMethodBinding method, ImportRewrite imports, ImportRewriteContext context, AST ast) {
+		ITypeBinding[] excTypes= method.getExceptionTypes();
+		if (ast.apiLevel() >= AST.JLS8) {
+			List<Type> thrownExceptions= decl.thrownExceptionTypes();
+			for (int i= 0; i < excTypes.length; i++) {
+				Type excType= imports.addImport(excTypes[i], ast, context, TypeLocation.EXCEPTION);
+				thrownExceptions.add(excType);
+			}
+		} else {
+			List<Name> thrownExceptions= getThrownExceptions(decl);
+			for (int i= 0; i < excTypes.length; i++) {
+				String excTypeName= imports.addImport(excTypes[i], context);
+				thrownExceptions.add(ASTNodeFactory.newName(ast, excTypeName));
+			}
+		}
+	}
+
+	/**
+	 * @param decl method declaration
+	 * @return thrown exception names
+	 * @deprecated to avoid deprecation warnings
+	 */
+	@Deprecated
+	private static List<Name> getThrownExceptions(MethodDeclaration decl) {
+		return decl.thrownExceptions();
+	}
+
+	private static IMethodBinding findMethodBinding(IMethodBinding method, List<IMethodBinding> allMethods) {
+		for (int i= 0; i < allMethods.size(); i++) {
+			IMethodBinding curr= allMethods.get(i);
+			if (Bindings.isSubsignature(method, curr)) {
+				return curr;
+			}
+		}
+		return null;
+	}
+
+	private static IMethodBinding findOverridingMethod(IMethodBinding method, List<IMethodBinding> allMethods) {
+		for (int i= 0; i < allMethods.size(); i++) {
+			IMethodBinding curr= allMethods.get(i);
+			if (Bindings.areOverriddenMethods(curr, method) || Bindings.isSubsignature(curr, method)) {
+				return curr;
+			}
+		}
+		return null;
+	}
+
+	private static void findUnimplementedInterfaceMethods(ITypeBinding typeBinding, HashSet<ITypeBinding> visited,
+			ArrayList<IMethodBinding> allMethods, IPackageBinding currPack, ArrayList<IMethodBinding> toImplement) {
+
+		if (visited.add(typeBinding)) {
+			IMethodBinding[] typeMethods= typeBinding.getDeclaredMethods();
+
+			nextMethod: for (int i= 0; i < typeMethods.length; i++) {
+				IMethodBinding curr= typeMethods[i];
+				for (Iterator<IMethodBinding> allIter= allMethods.iterator(); allIter.hasNext();) {
+					IMethodBinding oneMethod= allIter.next();
+					if (Bindings.isSubsignature(oneMethod, curr)) {
+						// We've already seen a method that is a subsignature of curr.
+						if (!Bindings.isSubsignature(curr, oneMethod)) {
+							// oneMethod is a true subsignature of curr; let's go with oneMethod
+							continue nextMethod;
+						}
+						// Subsignatures are equivalent.
+						// Check visibility and return types ('getErasure()' tries to achieve effect of "rename type variables")
+						if (Bindings.isVisibleInHierarchy(oneMethod, currPack)
+								&& oneMethod.getReturnType().getErasure().isSubTypeCompatible(curr.getReturnType().getErasure())) {
+							// oneMethod is visible and curr doesn't have a stricter return type; let's go with oneMethod
+							continue nextMethod;
+						}
+						// curr is stricter than oneMethod, so let's remove oneMethod
+						allIter.remove();
+						toImplement.remove(oneMethod);
+					} else if (Bindings.isSubsignature(curr, oneMethod)) {
+						// curr is a true subsignature of oneMethod. Let's remove oneMethod.
+						allIter.remove();
+						toImplement.remove(oneMethod);
+					}
+				}
+				int modifiers= curr.getModifiers();
+				if (!Modifier.isStatic(modifiers)) {
+					allMethods.add(curr);
+					if (Modifier.isAbstract(modifiers)) {
+						toImplement.add(curr);
+					}
+				}
+			}
+			ITypeBinding[] superInterfaces= typeBinding.getInterfaces();
+			for (int i= 0; i < superInterfaces.length; i++) {
+				findUnimplementedInterfaceMethods(superInterfaces[i], visited, allMethods, currPack, toImplement);
+			}
+		}
+	}
+
+	//	public static DelegateEntry[] getDelegatableMethods(ITypeBinding binding) {
+	//		final List<DelegateEntry> tuples= new ArrayList<>();
+	//		final List<IMethodBinding> declared= new ArrayList<>();
+	//		IMethodBinding[] typeMethods= binding.getDeclaredMethods();
+	//		for (int index= 0; index < typeMethods.length; index++) {
+	//			declared.add(typeMethods[index]);
+	//		}
+	//		IVariableBinding[] typeFields= binding.getDeclaredFields();
+	//		for (int index= 0; index < typeFields.length; index++) {
+	//			IVariableBinding fieldBinding= typeFields[index];
+	//			if (fieldBinding.isField() && !fieldBinding.isEnumConstant() && !fieldBinding.isSynthetic()) {
+	//				getDelegatableMethods(new ArrayList<>(declared), fieldBinding, fieldBinding.getType(), binding, tuples);
+	//			}
+	//		}
+	//		// list of tuple<IVariableBinding, IMethodBinding>
+	//		return tuples.toArray(new DelegateEntry[tuples.size()]);
+	//	}
+
+	//	private static void getDelegatableMethods(List<IMethodBinding> methods, IVariableBinding fieldBinding, ITypeBinding typeBinding, ITypeBinding binding, List<DelegateEntry> result) {
+	//		boolean match= false;
+	//		if (typeBinding.isTypeVariable()) {
+	//			ITypeBinding[] typeBounds= typeBinding.getTypeBounds();
+	//			if (typeBounds.length > 0) {
+	//				for (int i= 0; i < typeBounds.length; i++) {
+	//					getDelegatableMethods(methods, fieldBinding, typeBounds[i], binding, result);
+	//				}
+	//			} else {
+	//				ITypeBinding objectBinding= Bindings.findTypeInHierarchy(binding, "java.lang.Object"); //$NON-NLS-1$
+	//				if (objectBinding != null) {
+	//					getDelegatableMethods(methods, fieldBinding, objectBinding, binding, result);
+	//				}
+	//			}
+	//		} else {
+	//			IMethodBinding[] candidates= getDelegateCandidates(typeBinding, binding);
+	//			for (int index= 0; index < candidates.length; index++) {
+	//				match= false;
+	//				final IMethodBinding methodBinding= candidates[index];
+	//				for (int offset= 0; offset < methods.size() && !match; offset++) {
+	//					if (Bindings.areOverriddenMethods(methods.get(offset), methodBinding)) {
+	//						match= true;
+	//					}
+	//				}
+	//				if (!match) {
+	//					result.add(new DelegateEntry(methodBinding, fieldBinding));
+	//					methods.add(methodBinding);
+	//				}
+	//			}
+	//			final ITypeBinding superclass= typeBinding.getSuperclass();
+	//			if (superclass != null) {
+	//				getDelegatableMethods(methods, fieldBinding, superclass, binding, result);
+	//			}
+	//			ITypeBinding[] superInterfaces= typeBinding.getInterfaces();
+	//			for (int offset= 0; offset < superInterfaces.length; offset++) {
+	//				getDelegatableMethods(methods, fieldBinding, superInterfaces[offset], binding, result);
+	//			}
+	//		}
+	//	}
+
+	//	private static IMethodBinding[] getDelegateCandidates(ITypeBinding binding, ITypeBinding hierarchy) {
+	//		List<IMethodBinding> allMethods= new ArrayList<>();
+	//		boolean isInterface= binding.isInterface();
+	//		IMethodBinding[] typeMethods= binding.getDeclaredMethods();
+	//		for (int index= 0; index < typeMethods.length; index++) {
+	//			final int modifiers= typeMethods[index].getModifiers();
+	//			if (!typeMethods[index].isConstructor() && !Modifier.isStatic(modifiers) && (isInterface || Modifier.isPublic(modifiers))) {
+	//				IMethodBinding result= Bindings.findOverriddenMethodInHierarchy(hierarchy, typeMethods[index]);
+	//				if (result != null && Flags.isFinal(result.getModifiers())) {
+	//					continue;
+	//				}
+	//				ITypeBinding[] parameterBindings= typeMethods[index].getParameterTypes();
+	//				boolean upper= false;
+	//				for (int offset= 0; offset < parameterBindings.length; offset++) {
+	//					if (parameterBindings[offset].isWildcardType() && parameterBindings[offset].isUpperbound()) {
+	//						upper= true;
+	//					}
+	//				}
+	//				if (!upper) {
+	//					allMethods.add(typeMethods[index]);
+	//				}
+	//			}
+	//		}
+	//		return allMethods.toArray(new IMethodBinding[allMethods.size()]);
+	//	}
+
+	private static List<IExtendedModifier> getImplementationModifiers(AST ast, IMethodBinding method, boolean inInterface, ImportRewrite importRewrite, ImportRewriteContext context, IAnnotationBinding defaultNullness) throws JavaModelException {
+		IJavaProject javaProject= importRewrite.getCompilationUnit().getJavaProject();
+		int modifiers= method.getModifiers();
+		if (inInterface) {
+			modifiers= modifiers & ~Modifier.PROTECTED & ~Modifier.PUBLIC;
+			if (Modifier.isAbstract(modifiers) && JavaModelUtil.is18OrHigher(javaProject)) {
+				modifiers= modifiers | Modifier.DEFAULT;
+			}
+		} else {
+			modifiers= modifiers & ~Modifier.DEFAULT;
+		}
+		modifiers= modifiers & ~Modifier.ABSTRACT & ~Modifier.NATIVE & ~Modifier.PRIVATE;
+		IAnnotationBinding[] annotations= method.getAnnotations();
+
+		if (modifiers != Modifier.NONE && annotations.length > 0) {
+			// need an AST of the source method to preserve order of modifiers
+			IMethod iMethod= (IMethod) method.getJavaElement();
+			if (iMethod != null && isSourceAvailable(iMethod)) {
+				ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+				parser.setSource(iMethod.getTypeRoot());
+				parser.setIgnoreMethodBodies(true);
+				CompilationUnit otherCU= (CompilationUnit) parser.createAST(null);
+				ASTNode otherMethod= NodeFinder.perform(otherCU, iMethod.getSourceRange());
+				if (otherMethod instanceof MethodDeclaration) {
+					MethodDeclaration otherMD= (MethodDeclaration) otherMethod;
+					ArrayList<IExtendedModifier> result= new ArrayList<>();
+					List<IExtendedModifier> otherModifiers= otherMD.modifiers();
+					for (IExtendedModifier otherModifier : otherModifiers) {
+						if (otherModifier instanceof Modifier) {
+							int otherFlag= ((Modifier) otherModifier).getKeyword().toFlagValue();
+							if ((otherFlag & modifiers) != 0) {
+								modifiers= ~otherFlag & modifiers;
+								result.addAll(ast.newModifiers(otherFlag));
+							}
+						} else {
+							Annotation otherAnnotation= (Annotation) otherModifier;
+							String n= otherAnnotation.getTypeName().getFullyQualifiedName();
+							for (IAnnotationBinding annotation : annotations) {
+								ITypeBinding otherAnnotationType= annotation.getAnnotationType();
+								String qn= otherAnnotationType.getQualifiedName();
+								if (qn.endsWith(n) && (qn.length() == n.length() || qn.charAt(qn.length() - n.length() - 1) == '.')) {
+									if (StubUtility2.isCopyOnInheritAnnotation(otherAnnotationType, javaProject, defaultNullness)) {
+										result.add(importRewrite.addAnnotation(annotation, ast, context));
+									}
+									break;
+								}
+							}
+						}
+					}
+					result.addAll(ASTNodeFactory.newModifiers(ast, modifiers));
+					return result;
+				}
+			}
+		}
+
+		ArrayList<IExtendedModifier> result= new ArrayList<>();
+
+		for (IAnnotationBinding annotation : annotations) {
+			if (StubUtility2.isCopyOnInheritAnnotation(annotation.getAnnotationType(), javaProject, defaultNullness)) {
+				result.add(importRewrite.addAnnotation(annotation, ast, context));
+			}
+		}
+
+		result.addAll(ASTNodeFactory.newModifiers(ast, modifiers));
+
+		return result;
+	}
+
+	public static IMethodBinding[] getOverridableMethods(AST ast, ITypeBinding typeBinding, boolean isSubType) {
+		List<IMethodBinding> allMethods= new ArrayList<>();
+		IMethodBinding[] typeMethods= typeBinding.getDeclaredMethods();
+		for (int index= 0; index < typeMethods.length; index++) {
+			final int modifiers= typeMethods[index].getModifiers();
+			if (!typeMethods[index].isConstructor() && !Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+				allMethods.add(typeMethods[index]);
+			}
+		}
+		ITypeBinding clazz= typeBinding.getSuperclass();
+		while (clazz != null) {
+			IMethodBinding[] methods= clazz.getDeclaredMethods();
+			for (int offset= 0; offset < methods.length; offset++) {
+				final int modifiers= methods[offset].getModifiers();
+				if (!methods[offset].isConstructor() && !Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+					if (findOverridingMethod(methods[offset], allMethods) == null) {
+						allMethods.add(methods[offset]);
+					}
+				}
+			}
+			clazz= clazz.getSuperclass();
+		}
+		clazz= typeBinding;
+		while (clazz != null) {
+			ITypeBinding[] superInterfaces= clazz.getInterfaces();
+			for (int index= 0; index < superInterfaces.length; index++) {
+				getOverridableMethods(ast, superInterfaces[index], allMethods);
+			}
+			clazz= clazz.getSuperclass();
+		}
+		if (typeBinding.isInterface())
+		{
+			getOverridableMethods(ast, ast.resolveWellKnownType("java.lang.Object"), allMethods); //$NON-NLS-1$
+		}
+		if (!isSubType) {
+			allMethods.removeAll(Arrays.asList(typeMethods));
+		}
+		for (int index= allMethods.size() - 1; index >= 0; index--) {
+			IMethodBinding method= allMethods.get(index);
+			if (Modifier.isFinal(method.getModifiers())) {
+				allMethods.remove(index);
+			}
+		}
+		return allMethods.toArray(new IMethodBinding[allMethods.size()]);
+	}
+
+	private static void getOverridableMethods(AST ast, ITypeBinding superBinding, List<IMethodBinding> allMethods) {
+		IMethodBinding[] methods= superBinding.getDeclaredMethods();
+		for (int offset= 0; offset < methods.length; offset++) {
+			final int modifiers= methods[offset].getModifiers();
+			if (!methods[offset].isConstructor() && !Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+				if (findOverridingMethod(methods[offset], allMethods) == null) {
+					allMethods.add(methods[offset]);
+				}
+			}
+		}
+		ITypeBinding[] superInterfaces= superBinding.getInterfaces();
+		for (int index= 0; index < superInterfaces.length; index++) {
+			getOverridableMethods(ast, superInterfaces[index], allMethods);
+		}
+	}
+
+	//	private static String suggestParameterName(ICompilationUnit unit, IVariableBinding binding, String[] excluded) {
+	//		String name= StubUtility.getBaseName(binding, unit.getJavaProject());
+	//		return StubUtility.suggestArgumentName(unit.getJavaProject(), name, excluded);
+	//	}
+	//
+	//	public static IMethodBinding[] getUnimplementedMethods(ITypeBinding typeBinding) {
+	//		return getUnimplementedMethods(typeBinding, false);
+	//	}
+	//
+	//	public static IMethodBinding[] getUnimplementedMethods(ITypeBinding typeBinding, boolean implementAbstractsOfInput) {
+	//		ArrayList<IMethodBinding> allMethods= new ArrayList<>();
+	//		ArrayList<IMethodBinding> toImplement= new ArrayList<>();
+	//
+	//		IMethodBinding[] typeMethods= typeBinding.getDeclaredMethods();
+	//		for (int i= 0; i < typeMethods.length; i++) {
+	//			IMethodBinding curr= typeMethods[i];
+	//			int modifiers= curr.getModifiers();
+	//			if (!curr.isConstructor() && !Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+	//				allMethods.add(curr);
+	//			}
+	//		}
+	//
+	//		ITypeBinding superClass= typeBinding.getSuperclass();
+	//		while (superClass != null) {
+	//			typeMethods= superClass.getDeclaredMethods();
+	//			for (int i= 0; i < typeMethods.length; i++) {
+	//				IMethodBinding curr= typeMethods[i];
+	//				int modifiers= curr.getModifiers();
+	//				if (!curr.isConstructor() && !Modifier.isStatic(modifiers) && !Modifier.isPrivate(modifiers)) {
+	//					if (findMethodBinding(curr, allMethods) == null) {
+	//						allMethods.add(curr);
+	//					}
+	//				}
+	//			}
+	//			superClass= superClass.getSuperclass();
+	//		}
+	//
+	//		for (int i= 0; i < allMethods.size(); i++) {
+	//			IMethodBinding curr= allMethods.get(i);
+	//			int modifiers= curr.getModifiers();
+	//			if ((Modifier.isAbstract(modifiers) || curr.getDeclaringClass().isInterface()) && (implementAbstractsOfInput || typeBinding != curr.getDeclaringClass())) {
+	//				// implement all abstract methods
+	//				toImplement.add(curr);
+	//			}
+	//		}
+	//
+	//		HashSet<ITypeBinding> visited= new HashSet<>();
+	//		ITypeBinding curr= typeBinding;
+	//		while (curr != null) {
+	//			ITypeBinding[] superInterfaces= curr.getInterfaces();
+	//			for (int i= 0; i < superInterfaces.length; i++) {
+	//				findUnimplementedInterfaceMethods(superInterfaces[i], visited, allMethods, typeBinding.getPackage(), toImplement);
+	//			}
+	//			curr= curr.getSuperclass();
+	//		}
+	//
+	//		return toImplement.toArray(new IMethodBinding[toImplement.size()]);
+	//	}
+	//
+	//	public static IMethodBinding[] getVisibleConstructors(ITypeBinding binding, boolean accountExisting, boolean proposeDefault) {
+	//		List<IMethodBinding> constructorMethods= new ArrayList<>();
+	//		List<IMethodBinding> existingConstructors= null;
+	//		ITypeBinding superType= binding.getSuperclass();
+	//		if (superType == null) {
+	//			return new IMethodBinding[0];
+	//		}
+	//		if (accountExisting) {
+	//			IMethodBinding[] methods= binding.getDeclaredMethods();
+	//			existingConstructors= new ArrayList<>(methods.length);
+	//			for (int index= 0; index < methods.length; index++) {
+	//				IMethodBinding method= methods[index];
+	//				if (method.isConstructor() && !method.isDefaultConstructor()) {
+	//					existingConstructors.add(method);
+	//				}
+	//			}
+	//		}
+	//		if (existingConstructors != null) {
+	//			constructorMethods.addAll(existingConstructors);
+	//		}
+	//		IMethodBinding[] methods= binding.getDeclaredMethods();
+	//		IMethodBinding[] superMethods= superType.getDeclaredMethods();
+	//		for (int index= 0; index < superMethods.length; index++) {
+	//			IMethodBinding method= superMethods[index];
+	//			if (method.isConstructor()) {
+	//				if (Bindings.isVisibleInHierarchy(method, binding.getPackage()) && (!accountExisting || !Bindings.containsSignatureEquivalentConstructor(methods, method))) {
+	//					constructorMethods.add(method);
+	//				}
+	//			}
+	//		}
+	//		if (existingConstructors != null) {
+	//			constructorMethods.removeAll(existingConstructors);
+	//		}
+	//		if (constructorMethods.isEmpty()) {
+	//			superType= binding;
+	//			while (superType.getSuperclass() != null) {
+	//				superType= superType.getSuperclass();
+	//			}
+	//			IMethodBinding method= Bindings.findMethodInType(superType, "Object", new ITypeBinding[0]); //$NON-NLS-1$
+	//			if (method != null) {
+	//				if ((proposeDefault || !accountExisting || existingConstructors == null || existingConstructors.isEmpty()) && (!accountExisting || !Bindings.containsSignatureEquivalentConstructor(methods, method))) {
+	//					constructorMethods.add(method);
+	//				}
+	//			}
+	//		}
+	//		return constructorMethods.toArray(new IMethodBinding[constructorMethods.size()]);
+	//	}
+
+
+	/**
+	 * Evaluates the insertion position of a new node.
+	 *
+	 * @param listRewrite The list rewriter to which the new node will be added
+	 * @param sibling The Java element before which the new element should be added.
+	 * @return the AST node of the list to insert before or null to insert as last.
+	 * @throws JavaModelException thrown if accessing the Java element failed
+	 */
+
+	public static ASTNode getNodeToInsertBefore(ListRewrite listRewrite, IJavaElement sibling) throws JavaModelException {
+		if (sibling instanceof IMember) {
+			ISourceRange sourceRange= ((IMember) sibling).getSourceRange();
+			if (sourceRange == null) {
+				return null;
+			}
+			int insertPos= sourceRange.getOffset();
+
+			List<? extends ASTNode> members= listRewrite.getOriginalList();
+			for (int i= 0; i < members.size(); i++) {
+				ASTNode curr= members.get(i);
+				if (curr.getStartPosition() >= insertPos) {
+					return curr;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Creates a new stub utility.
+	 */
+	private StubUtility2() {
+		// Not for instantiation
+	}
+
+	public static boolean isCopyOnInheritAnnotation(ITypeBinding annotationType, IJavaProject project, IAnnotationBinding defaultNullness) {
+		if (JavaCore.ENABLED.equals(project.getOption(JavaCore.COMPILER_INHERIT_NULL_ANNOTATIONS, true))) {
+			return false;
+		}
+		if (defaultNullness != null && Bindings.isNonNullAnnotation(annotationType, project)) {
+			IMemberValuePairBinding[] memberValuePairs= defaultNullness.getDeclaredMemberValuePairs();
+			if (memberValuePairs.length == 1) {
+				Object value= memberValuePairs[0].getValue();
+				if (value instanceof Boolean) {
+					return Boolean.FALSE.equals(value); // do copy within @NonNullByDefault(false)
+				}
+			}
+			// missing or unrecognized value
+			return false; // nonnull within the scope of @NonNullByDefault: don't copy
+		}
+		return Bindings.isAnyNullAnnotation(annotationType, project);
+	}
+
+	public static Annotation findAnnotation(String qualifiedTypeName, List<IExtendedModifier> modifiers) {
+		for (int i= 0; i < modifiers.size(); i++) {
+			IExtendedModifier curr= modifiers.get(i);
+			if (curr instanceof Annotation) {
+				Annotation annot= (Annotation) curr;
+				ITypeBinding binding= annot.getTypeName().resolveTypeBinding();
+				if (binding != null && qualifiedTypeName.equals(binding.getQualifiedName())) {
+					return annot;
+				}
+			}
+		}
+		return null;
+	}
+
+	public static ITypeBinding replaceWildcardsAndCaptures(ITypeBinding type) {
+		while (type.isWildcardType() || type.isCapture() || (type.isArray() && type.getElementType().isCapture())) {
+			ITypeBinding bound= type.getBound();
+			type= (bound != null) ? bound : type.getErasure();
+		}
+		return type;
+	}
+
+	static boolean isSourceAvailable(ISourceReference sourceReference) {
+		try {
+			return SourceRange.isAvailable(sourceReference.getSourceRange());
+		} catch (JavaModelException e) {
+			return false;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/dom/ASTNodeFactory.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/dom/ASTNodeFactory.java
@@ -1,0 +1,388 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.dom;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotatableType;
+import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Dimension;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InfixExpression.Operator;
+import org.eclipse.jdt.core.dom.LambdaExpression;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeParameter;
+import org.eclipse.jdt.core.dom.UnionType;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
+import org.eclipse.jdt.ls.core.internal.corext.codemanipulation.StubUtility2;
+
+/**
+ * JDT-UI-internal helper methods to create new {@link ASTNode}s. Complements
+ * <code>AST#new*(..)</code> and <code>ImportRewrite#add*(..)</code>.
+ *
+ * Code copied from org.eclipse.jdt.internal.corext.dom.ASTNodeFactory
+ *
+ * @see JDTUIHelperClasses
+ */
+public class ASTNodeFactory {
+
+	private static final String STATEMENT_HEADER= "class __X__ { void __x__() { "; //$NON-NLS-1$
+	private static final String STATEMENT_FOOTER= "}}"; //$NON-NLS-1$
+
+	private static final String TYPE_HEADER= "class __X__ { abstract "; //$NON-NLS-1$
+	private static final String TYPE_FOOTER= " __f__(); }}"; //$NON-NLS-1$
+
+	private static final String TYPEPARAM_HEADER= "class __X__ { abstract <"; //$NON-NLS-1$
+	private static final String TYPEPARAM_FOOTER= "> void __f__(); }}"; //$NON-NLS-1$
+
+	private static class PositionClearer extends GenericVisitor {
+
+		public PositionClearer() {
+			super(true);
+		}
+
+		@Override
+		protected boolean visitNode(ASTNode node) {
+			node.setSourceRange(-1, 0);
+			return true;
+		}
+	}
+
+	private ASTNodeFactory() {
+		// no instance;
+	}
+
+	public static ASTNode newStatement(AST ast, String content) {
+		StringBuffer buffer= new StringBuffer(STATEMENT_HEADER);
+		buffer.append(content);
+		buffer.append(STATEMENT_FOOTER);
+		ASTParser p= ASTParser.newParser(ast.apiLevel());
+		p.setSource(buffer.toString().toCharArray());
+		CompilationUnit root= (CompilationUnit) p.createAST(null);
+		ASTNode result= ASTNode.copySubtree(ast, NodeFinder.perform(root, STATEMENT_HEADER.length(), content.length()));
+		result.accept(new PositionClearer());
+		return result;
+	}
+
+	public static Name newName(AST ast, String qualifiedName) {
+		return ast.newName(qualifiedName);
+	}
+
+	public static TypeParameter newTypeParameter(AST ast, String content) {
+		StringBuffer buffer= new StringBuffer(TYPEPARAM_HEADER);
+		buffer.append(content);
+		buffer.append(TYPEPARAM_FOOTER);
+		ASTParser p= ASTParser.newParser(ast.apiLevel());
+		p.setSource(buffer.toString().toCharArray());
+		CompilationUnit root= (CompilationUnit) p.createAST(null);
+		List<AbstractTypeDeclaration> list= root.types();
+		TypeDeclaration typeDecl= (TypeDeclaration) list.get(0);
+		MethodDeclaration methodDecl= typeDecl.getMethods()[0];
+		TypeParameter tp= (TypeParameter) methodDecl.typeParameters().get(0);
+		ASTNode result= ASTNode.copySubtree(ast, tp);
+		result.accept(new PositionClearer());
+		return (TypeParameter) result;
+	}
+
+
+	public static Type newType(AST ast, String content) {
+		StringBuffer buffer= new StringBuffer(TYPE_HEADER);
+		buffer.append(content);
+		buffer.append(TYPE_FOOTER);
+		ASTParser p= ASTParser.newParser(ast.apiLevel());
+		p.setSource(buffer.toString().toCharArray());
+		CompilationUnit root= (CompilationUnit) p.createAST(null);
+		List<AbstractTypeDeclaration> list= root.types();
+		TypeDeclaration typeDecl= (TypeDeclaration) list.get(0);
+		MethodDeclaration methodDecl= typeDecl.getMethods()[0];
+		ASTNode type= methodDecl.getReturnType2();
+		ASTNode result= ASTNode.copySubtree(ast, type);
+		result.accept(new PositionClearer());
+		return (Type)result;
+	}
+
+	/**
+	 * Returns an {@link ArrayType} that adds one dimension to the given type node.
+	 * If the given node is already an ArrayType, then a new {@link Dimension}
+	 * without annotations is inserted at the first position.
+	 *
+	 * @param type the type to be wrapped
+	 * @return the array type
+	 * @since 3.10
+	 */
+	public static ArrayType newArrayType(Type type) {
+		if (type instanceof ArrayType) {
+			Dimension dimension= type.getAST().newDimension();
+			ArrayType arrayType= (ArrayType) type;
+			arrayType.dimensions().add(0, dimension); // first dimension is outermost
+			return arrayType;
+		} else {
+			return type.getAST().newArrayType(type);
+		}
+	}
+
+	/**
+	 * Returns the new type node corresponding to the type of the given declaration
+	 * including the extra dimensions.
+	 * @param ast The AST to create the resulting type with.
+	 * @param declaration The variable declaration to get the type from
+	 * @return a new type node created with the given AST.
+	 */
+	public static Type newType(AST ast, VariableDeclaration declaration) {
+		return newType(ast, declaration, null, null);
+	}
+
+	/**
+	 * Returns the new type node corresponding to the type of the given declaration
+	 * including the extra dimensions. If the type is a {@link UnionType}, use the LUB type.
+	 * If the <code>importRewrite</code> is <code>null</code>, the type may be fully-qualified.
+	 *
+	 * @param ast The AST to create the resulting type with.
+	 * @param declaration The variable declaration to get the type from
+	 * @param importRewrite the import rewrite to use, or <code>null</code>
+	 * @param context the import rewrite context, or <code>null</code>
+	 * @return a new type node created with the given AST.
+	 *
+	 * @since 3.7.1
+	 */
+	public static Type newType(AST ast, VariableDeclaration declaration, ImportRewrite importRewrite, ImportRewriteContext context) {
+		if (declaration instanceof VariableDeclarationFragment && declaration.getParent() instanceof LambdaExpression) {
+			return newType((LambdaExpression) declaration.getParent(), (VariableDeclarationFragment) declaration, ast, importRewrite, context);
+		}
+
+		Type type= ASTNodes.getType(declaration);
+		if (declaration instanceof SingleVariableDeclaration) {
+			Type type2= ((SingleVariableDeclaration) declaration).getType();
+			if (type2 instanceof UnionType) {
+				ITypeBinding typeBinding= type2.resolveBinding();
+				if (typeBinding != null) {
+					if (importRewrite != null) {
+						type= importRewrite.addImport(typeBinding, ast, context);
+						return type;
+					} else {
+						String qualifiedName= typeBinding.getQualifiedName();
+						if (qualifiedName.length() > 0) {
+							type= ast.newSimpleType(ast.newName(qualifiedName));
+							return type;
+						}
+					}
+				}
+				// XXX: fallback for intersection types or unresolved types: take first type of union
+				type= (Type) ((UnionType) type2).types().get(0);
+				return type;
+			}
+		}
+
+		type= (Type) ASTNode.copySubtree(ast, type);
+
+		List<Dimension> extraDimensions= declaration.extraDimensions();
+		if (!extraDimensions.isEmpty()) {
+			ArrayType arrayType;
+			if (type instanceof ArrayType) {
+				arrayType= (ArrayType) type;
+			} else {
+				arrayType= ast.newArrayType(type, 0);
+				type= arrayType;
+			}
+			arrayType.dimensions().addAll(ASTNode.copySubtrees(ast, extraDimensions));
+		}
+		return type;
+	}
+
+	private static Type newType(LambdaExpression lambdaExpression, VariableDeclarationFragment declaration, AST ast, ImportRewrite importRewrite, ImportRewriteContext context) {
+		IMethodBinding method= lambdaExpression.resolveMethodBinding();
+		if (method != null) {
+			ITypeBinding[] parameterTypes= method.getParameterTypes();
+			int index= lambdaExpression.parameters().indexOf(declaration);
+			ITypeBinding typeBinding= parameterTypes[index];
+			if (importRewrite != null) {
+				return importRewrite.addImport(typeBinding, ast, context);
+			} else {
+				String qualifiedName= typeBinding.getQualifiedName();
+				if (qualifiedName.length() > 0) {
+					return newType(ast, qualifiedName);
+				}
+			}
+		}
+		// fall-back
+		return ast.newSimpleType(ast.newSimpleName("Object")); //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns the new type node representing the return type of <code>lambdaExpression</code>
+	 * including the extra dimensions.
+	 *
+	 * @param lambdaExpression the lambda expression
+	 * @param ast the AST to create the return type with
+	 * @param importRewrite the import rewrite to use, or <code>null</code>
+	 * @param context the import rewrite context, or <code>null</code>
+	 * @return a new type node created with the given AST representing the return type of
+	 *         <code>lambdaExpression</code>
+	 *
+	 * @since 3.10
+	 */
+	public static Type newReturnType(LambdaExpression lambdaExpression, AST ast, ImportRewrite importRewrite, ImportRewriteContext context) {
+		IMethodBinding method= lambdaExpression.resolveMethodBinding();
+		if (method != null) {
+			ITypeBinding returnTypeBinding= method.getReturnType();
+			if (importRewrite != null) {
+				return importRewrite.addImport(returnTypeBinding, ast);
+			} else {
+				String qualifiedName= returnTypeBinding.getQualifiedName();
+				if (qualifiedName.length() > 0) {
+					return newType(ast, qualifiedName);
+				}
+			}
+		}
+		// fall-back
+		return ast.newSimpleType(ast.newSimpleName("Object")); //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns an expression that is assignable to the given type. <code>null</code> is
+	 * returned if the type is the 'void' type.
+	 *
+	 * @param ast The AST to create the expression for
+	 * @param type The type of the returned expression
+	 * @param extraDimensions Extra dimensions to the type
+	 * @return the Null-literal for reference types, a boolean-literal for a boolean type, a number
+	 * literal for primitive types or <code>null</code> if the type is void.
+	 */
+	public static Expression newDefaultExpression(AST ast, Type type, int extraDimensions) {
+		if (extraDimensions == 0 && type.isPrimitiveType()) {
+			PrimitiveType primitiveType= (PrimitiveType) type;
+			if (primitiveType.getPrimitiveTypeCode() == PrimitiveType.BOOLEAN) {
+				return ast.newBooleanLiteral(false);
+			} else if (primitiveType.getPrimitiveTypeCode() == PrimitiveType.VOID) {
+				return null;
+			} else {
+				return ast.newNumberLiteral("0"); //$NON-NLS-1$
+			}
+		}
+		return ast.newNullLiteral();
+	}
+
+	/**
+	 * Returns an expression that is assignable to the given type binding. <code>null</code> is
+	 * returned if the type is the 'void' type.
+	 *
+	 * @param ast The AST to create the expression for
+	 * @param type The type binding to which the returned expression is compatible to
+	 * @return the Null-literal for reference types, a boolean-literal for a boolean type, a number
+	 * literal for primitive types or <code>null</code> if the type is void.
+	 */
+	public static Expression newDefaultExpression(AST ast, ITypeBinding type) {
+		if (type.isPrimitive()) {
+			String name= type.getName();
+			if ("boolean".equals(name)) { //$NON-NLS-1$
+				return ast.newBooleanLiteral(false);
+			} else if ("void".equals(name)) { //$NON-NLS-1$
+				return null;
+			} else {
+				return ast.newNumberLiteral("0"); //$NON-NLS-1$
+			}
+		}
+		return ast.newNullLiteral();
+	}
+
+	/**
+	 * Returns a list of newly created Modifier nodes corresponding to the given modifier flags.
+	 * @param ast The AST to create the nodes for.
+	 * @param modifiers The modifier flags describing the modifier nodes to create.
+	 * @return Returns a list of nodes of type {@link Modifier}.
+	 */
+	public static List<Modifier> newModifiers(AST ast, int modifiers) {
+		return ast.newModifiers(modifiers);
+	}
+
+	/**
+	 * Returns a list of newly created Modifier nodes corresponding to a given list of existing modifiers.
+	 * @param ast The AST to create the nodes for.
+	 * @param modifierNodes The modifier nodes describing the modifier nodes to create. Only
+	 * nodes of type {@link Modifier} are looked at and cloned. To create a full copy of the list consider
+	 * to use {@link ASTNode#copySubtrees(AST, List)}.
+	 * @return Returns a list of nodes of type {@link Modifier}.
+	 */
+	public static List<Modifier> newModifiers(AST ast, List<? extends IExtendedModifier> modifierNodes) {
+		List<Modifier> res= new ArrayList<>(modifierNodes.size());
+		for (int i= 0; i < modifierNodes.size(); i++) {
+			Object curr= modifierNodes.get(i);
+			if (curr instanceof Modifier) {
+				res.add(ast.newModifier(((Modifier) curr).getKeyword()));
+			}
+		}
+		return res;
+	}
+
+	public static Expression newInfixExpression(AST ast, Operator operator, ArrayList<Expression> operands) {
+		if (operands.size() == 1) {
+			return operands.get(0);
+		}
+
+		InfixExpression result= ast.newInfixExpression();
+		result.setOperator(operator);
+		result.setLeftOperand(operands.get(0));
+		result.setRightOperand(operands.get(1));
+		result.extendedOperands().addAll(operands.subList(2, operands.size()));
+		return result;
+	}
+
+	/**
+	 * Create a Type suitable as the creationType in a ClassInstanceCreation expression.
+	 * @param ast The AST to create the nodes for.
+	 * @param typeBinding binding representing the given class type
+	 * @param importRewrite the import rewrite to use
+	 * @param importContext the import context used to determine which (null) annotations to consider
+	 * @return a Type suitable as the creationType in a ClassInstanceCreation expression.
+	 */
+	public static Type newCreationType(AST ast, ITypeBinding typeBinding, ImportRewrite importRewrite, ImportRewriteContext importContext) {
+		if (typeBinding.isParameterizedType()) {
+			Type baseType= newCreationType(ast, typeBinding.getTypeDeclaration(), importRewrite, importContext);
+			IAnnotationBinding[] typeAnnotations= importContext.removeRedundantTypeAnnotations(typeBinding.getTypeAnnotations(), TypeLocation.NEW, typeBinding);
+			for (IAnnotationBinding typeAnnotation : typeAnnotations) {
+				((AnnotatableType)baseType).annotations().add(importRewrite.addAnnotation(typeAnnotation, ast, importContext));
+			}
+			ParameterizedType parameterizedType= ast.newParameterizedType(baseType);
+			for (ITypeBinding typeArgument : typeBinding.getTypeArguments()) {
+				typeArgument= StubUtility2.replaceWildcardsAndCaptures(typeArgument);
+				parameterizedType.typeArguments().add(importRewrite.addImport(typeArgument, ast, importContext, TypeLocation.TYPE_ARGUMENT));
+			}
+			return parameterizedType;
+		} else {
+			return importRewrite.addImport(typeBinding, ast, importContext, TypeLocation.NEW);
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2HTMLTextReader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2HTMLTextReader.java
@@ -365,7 +365,7 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
 			buffer.setLength(0);
 			if (c != -1 && c != '}') {
 				buffer.append((char) c);
-				c= getContent(buffer, '}');
+				getContent(buffer, '}');
 			}
 
 			return printBlockTag(tag, buffer.toString());

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.4"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.project
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>java4</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java4/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.4
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.4
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.4

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java4/src/java/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java4/src/java/Foo.java
@@ -1,0 +1,8 @@
+package java;
+
+public class Foo {
+
+	public static void main(String[] args) {
+		System.out.print("Hello world!");
+	}
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.project
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>java5</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java5/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.5

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/java5/src/java/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/java5/src/java/Foo.java
@@ -1,0 +1,8 @@
+package java;
+
+public class Foo {
+
+	public static void main(String[] args) {
+		System.out.print("Hello world!");
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
@@ -20,8 +20,10 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.LanguageServerWorkingCopyOwner;
+import org.eclipse.jdt.ls.core.internal.SharedASTProvider;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mock;
 
@@ -66,5 +68,10 @@ public abstract class AbstractCompletionBasedTest extends AbstractProjectsManage
 		String str= unit.getSource();
 		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 		return JsonRpcHelpers.toLine(unit.getBuffer(), cursorLocation);
+	}
+
+	@After
+	public void shutdown() throws Exception {
+		SharedASTProvider.getInstance().invalidateAll();
 	}
 }


### PR DESCRIPTION
A poor man’s fix for method override code
completion. It improves the current situation but
needs further fixing when we get APIs from JDT

This partially addresses #72 (method body is still missing)

Signed-off-by: Gorkem Ercan <gorkem.ercan@gmail.com>