### PR TITLE
DocumentSymbolHandler should not exclude attributes via regexp

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IJavaElement;
@@ -72,23 +73,22 @@ public class DocumentSymbolHandler {
 	}
 
 	private IJavaElement[] filter(IJavaElement[] elements) {
-		List<IJavaElement> result = new ArrayList<>();
-		for (int i = 0; i < elements.length; i++) {
-			IJavaElement element = elements[i];
-			if (element.getElementType() == IJavaElement.METHOD) {
-				String name= element.getElementName();
-				if ((name != null && name.indexOf('<') >= 0)) {
-					continue;
-				}
-			}
-			if (!isSynteticElement(element)) {
-				result.add(element);
-			}
-		}
-		return result.toArray(new IJavaElement[0]);
+		return Stream.of(elements)
+				.filter(e -> (!isInitializer(e) && !isSyntheticElement(e)))
+				.toArray(IJavaElement[]::new);
 	}
 
-	private boolean isSynteticElement(IJavaElement element) {
+	private boolean isInitializer(IJavaElement element) {
+		if (element.getElementType() == IJavaElement.METHOD) {
+			String name = element.getElementName();
+			if ((name != null && name.indexOf('<') >= 0)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isSyntheticElement(IJavaElement element) {
 		if (!(element instanceof IMember))
 			return false;
 		IMember member= (IMember)element;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -60,7 +60,7 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 	}
 
 	@Test
-	public void testSynteticMember() throws Exception {
+	public void testSyntheticMember() throws Exception {
 		String className = "java.util.zip.ZipFile";
 		List<? extends SymbolInformation> symbols = getSymbols(className);
 		for (SymbolInformation symbol : symbols) {


### PR DESCRIPTION
#212 DocumentSymbolHandler should not exclude attributes via regexp pattern matching

I have used the code from org.eclipse.jdt.internal.ui.javaeditor.JavaOutlinePage.JavaOutlineViewer and  org.eclipse.jdt.internal.ui.filters.SyntheticMembersFilter

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>