### PR TITLE
Expand workspace symbol search to all classes from classpath.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
@@ -34,7 +34,9 @@ final public class JsonRpcHelpers {
 	 */
 	public static int toOffset(IBuffer buffer, int line, int column){
 		try {
-			return toDocument(buffer).getLineOffset(line) + column;
+			if (buffer != null) {
+				return toDocument(buffer).getLineOffset(line) + column;
+			}
 		} catch (BadLocationException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -67,9 +69,12 @@ final public class JsonRpcHelpers {
 	 * The returned document may or may not be connected to the buffer.
 	 *
 	 * @param buffer a buffer
-	 * @return a document with the same contents as the buffer
+	 * @return a document with the same contents as the buffer or <code>null</code> is the buffer is <code>null</code>
 	 */
 	public static IDocument toDocument(IBuffer buffer) {
+		if (buffer == null) {
+			return null;
+		}
 		if (buffer instanceof IDocument) {
 			return (IDocument) buffer;
 		} else if (buffer instanceof org.eclipse.jdt.ls.core.internal.DocumentAdapter) {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/IFoo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/IFoo.java
@@ -1,0 +1,8 @@
+package java;
+
+/**
+ * This is IFoo
+ */
+public interface IFoo {
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ClassFileUtil.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ClassFileUtil.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.TypeNameMatch;
+import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
+import org.eclipse.lsp4j.Location;
+
+/**
+ * @author snjeza
+ * @author Fred Bricon
+ *
+ */
+public class ClassFileUtil {
+
+	private ClassFileUtil() {
+	}
+
+	public static String getURI(IProject project, String fqcn) throws JavaModelException {
+		Assert.isNotNull(project, "Project can't be null");
+		Assert.isNotNull(fqcn, "FQCN can't be null");
+
+		IJavaProject javaProject = JavaCore.create(project);
+		int lastDot = fqcn.lastIndexOf(".");
+		String packageName = lastDot > 0? fqcn.substring(0, lastDot):"";
+		String className = lastDot > 0? fqcn.substring(lastDot+1):fqcn;
+		ClassUriExtractor extractor = new ClassUriExtractor();
+		new SearchEngine().searchAllTypeNames(packageName.toCharArray(),SearchPattern.R_EXACT_MATCH,
+				className.toCharArray(), SearchPattern.R_EXACT_MATCH,
+				IJavaSearchConstants.TYPE,
+				createSearchScope(javaProject),
+				extractor,
+				IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH,
+				new NullProgressMonitor());
+		return extractor.uri;
+	}
+
+	private static class ClassUriExtractor extends TypeNameMatchRequestor {
+
+		String uri;
+
+		@Override
+		public void acceptTypeNameMatch(TypeNameMatch match) {
+			try {
+				if (match.getType().isBinary()) {
+					Location location = JDTUtils.toLocation(match.getType().getClassFile());
+					if (location != null) {
+						uri = location.getUri();
+					}
+				}  else {
+					uri = match.getType().getResource().getLocationURI().toString();
+				}
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	private static IJavaSearchScope createSearchScope(IJavaProject project) {
+		return SearchEngine.createJavaSearchScope(new IJavaProject[] {project} ,
+				IJavaSearchScope.SOURCES | IJavaSearchScope.APPLICATION_LIBRARIES | IJavaSearchScope.SYSTEM_LIBRARIES);
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClassfileContentHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClassfileContentHandlerTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Fred Bricon
+ */
+public class ClassfileContentHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	private IProject project;
+	private ClassfileContentHandler handler;
+
+	@Before
+	public void setup() throws Exception {
+		importProjects("eclipse/hello");
+		project = WorkspaceHelper.getProject("hello");
+		handler = new ClassfileContentHandler();
+	}
+
+	@Test
+	public void testOpenClassFile() throws Exception {
+		String uri = ClassFileUtil.getURI(project, "java.util.Map");
+		String source = getSource(uri);
+		assertNotNull(source);
+		assertFalse("header should be missing from "+source, source.startsWith(ClassfileContentHandler.MISSING_SOURCES_HEADER));
+		assertTrue("unexpected body content "+source, source.contains("An object that maps keys to values"));
+	}
+
+	@Test
+	public void testOpenSourceLessClassFile() throws Exception {
+		String uri = ClassFileUtil.getURI(project, "jdk.nashorn.tools.Shell");
+		String source = getSource(uri);
+		assertNotNull(source);
+		assertTrue("header is missing from "+source, source.startsWith(ClassfileContentHandler.MISSING_SOURCES_HEADER));
+		assertTrue("unexpected body content "+source, source.contains("package jdk.nashorn.tools;"));
+		assertTrue("unexpected body content "+source, source.contains("public class Shell {"));
+	}
+
+
+	@Test
+	public void testOpenMissingFile() throws Exception {
+		String uri = "file://this/is/Missing.class";
+		String source = getSource(uri);
+		assertNotNull(source);
+		assertTrue(source.isEmpty());
+	}
+
+	private String getSource(String uri) throws Exception {
+		TextDocumentIdentifier param = new TextDocumentIdentifier(uri);
+		return handler.contents(param).get();
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -14,19 +14,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IPackageFragment;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -98,7 +92,7 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	private List<? extends SymbolInformation> getSymbols(String className)
 			throws JavaModelException, UnsupportedEncodingException, InterruptedException, ExecutionException {
-		String uri = getURI(project, className);
+		String uri = ClassFileUtil.getURI(project, className);
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
 		DocumentSymbolParams params = new DocumentSymbolParams();
 		params.setTextDocument(identifier);
@@ -116,34 +110,5 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 		return position != null && position.getLine() >= 0 && position.getCharacter() >= 0;
 	}
 
-	private static String getURI(IProject project, String className) throws JavaModelException, UnsupportedEncodingException {
-		IJavaProject javaProject = JavaCore.create(project);
-		javaProject.open(new NullProgressMonitor());
-		String packageName = className.substring(0, className.lastIndexOf("."));
-		String cName = className.substring(packageName.length() + 1, className.length()) + ".class";
-		String classFileName = "/" + className.replaceAll("\\.", "/") + ".class";
-		IPackageFragmentRoot[] packageFragmentRoots = javaProject.getAllPackageFragmentRoots();
-		for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
-			if (packageFragmentRoot.isArchive()) {
-				IPackageFragment packageFragment = packageFragmentRoot.getPackageFragment(packageName);
-				if (packageFragment != null && packageFragment.exists()) {
-					IClassFile classFile;
-					try {
-						classFile = packageFragment.getClassFile(cName);
-					} catch (Exception e) {
-						continue;
-					}
-					if (classFile.exists()) {
-						String ret1 = String.format("jdt://contents/%s%s?=", packageFragmentRoot.getElementName(),
-								classFileName);
-						String ret2 = String.format("%s/%s<%s(%s", project.getName(), packageFragmentRoot.getPath(),
-								packageName, cName);
-						return ret1 + URLEncoder.encode(ret2, "UTF-8");
-					}
-				}
-			}
-		}
-		return null;
-	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Fred Bricon
+ */
+public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	private WorkspaceSymbolHandler handler;
+
+	@Before
+	public void setup() throws Exception {
+		importProjects("eclipse/hello");//We need at least 1 project
+		handler = new WorkspaceSymbolHandler();
+	}
+
+	@Test
+	public void testSearchWithEmptyResults() {
+		List<SymbolInformation> results = handler.search(null);
+		assertNotNull(results);
+		assertEquals(0, results.size());
+
+		results = handler.search("  ");
+		assertNotNull(results);
+		assertEquals(0, results.size());
+
+		results = handler.search("Abracadabra");
+		assertNotNull(results);
+		assertEquals(0, results.size());
+	}
+
+
+	@Test
+	public void testWorkspaceSearch() {
+		String query = "Abstract";
+		List<SymbolInformation> results = handler.search(query);
+		assertNotNull(results);
+		assertTrue("Found "+ results.size() + " results", results.size() > 100);
+		Range defaultRange = JDTUtils.newRange();
+		for (SymbolInformation symbol : results) {
+			assertNotNull("Kind is missing", symbol.getKind());
+			assertNotNull("ContainerName is missing", symbol.getContainerName());
+			assertTrue(symbol.getName().startsWith(query));
+			Location location = symbol.getLocation();
+			assertEquals(defaultRange, location.getRange());
+			//No class in the workspace project starts with Abstract, so everything comes from the JDK
+			assertTrue("Unexpected uri "+ location.getUri(), location.getUri().startsWith("jdt://"));
+		}
+	}
+
+	@Test
+	public void testProjectSearch() {
+		String query = "IFoo";
+		List<SymbolInformation> results = handler.search(query);
+		assertNotNull(results);
+		assertEquals("Found "+ results.size() + " results", 1, results.size());
+		SymbolInformation symbol = results.get(0);
+		assertEquals(SymbolKind.Interface, symbol.getKind());
+		assertEquals("java", symbol.getContainerName());
+		assertEquals(query, symbol.getName());
+		Location location = symbol.getLocation();
+		assertEquals(JDTUtils.newRange(), location.getRange());
+		assertTrue("Unexpected uri "+ location.getUri(), location.getUri().endsWith("Foo.java"));
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/204

This fix also includes generating stub class body for source-less classes.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
![may-12-2017 21-26-23](https://cloud.githubusercontent.com/assets/148698/26021371/c3f9e38a-3759-11e7-8ba1-b6b17112582d.gif)

