### PR TITLE
DocumentSymbolHandler should return unambiguous results

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.SymbolInformation;
@@ -60,7 +61,8 @@ public class DocumentSymbolHandler {
 			Location location = JDTUtils.toLocation(element);
 			if (location != null) {
 				SymbolInformation si = new SymbolInformation();
-				si.setName(element.getElementName());
+				String name = JavaElementLabels.getElementLabel(element, JavaElementLabels.ALL_DEFAULT);
+				si.setName(name == null ? element.getElementName() : name);
 				si.setKind(mapKind(element));
 				if (element.getParent() != null)
 					si.setContainerName(element.getParent().getElementName());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -63,6 +63,10 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 	public void testSyntheticMember() throws Exception {
 		String className = "java.util.zip.ZipFile";
 		List<? extends SymbolInformation> symbols = getSymbols(className);
+		boolean getEntryFound = false;
+		boolean getNameFound = false;
+		String getEntry = "getEntry(String)";
+		String getName = "getName()";
 		for (SymbolInformation symbol : symbols) {
 			Location loc = symbol.getLocation();
 			assertTrue("Class: " + className + ", Symbol:" + symbol.getName() + " - invalid location.",
@@ -71,7 +75,15 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 					symbol.getName().startsWith("access$"));
 			assertFalse("Class: " + className + ", Symbol:" + symbol.getName() + "- invalid name",
 					symbol.getName().equals("<clinit>"));
+			if (getEntry.equals(symbol.getName())) {
+				getEntryFound = true;
+			}
+			if (getName.equals(symbol.getName())) {
+				getNameFound = true;
+			}
 		}
+		assertTrue("The " + getEntry + " method hasn't been found", getEntryFound);
+		assertTrue("The " + getName + " method hasn't been found", getNameFound);
 	}
 
 	private void testClass(String className)


### PR DESCRIPTION
https://github.com/eclipse/eclipse.jdt.ls/issues/214

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>