### PR TITLE
Catch CancellationException when checking if monitor is cancelled

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/CancellableProgressMonitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/CancellableProgressMonitor.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.util.concurrent.CancellationException;
+
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
@@ -33,7 +35,11 @@ public class CancellableProgressMonitor extends NullProgressMonitor {
 	@Override
 	public boolean isCanceled() {
 		if(cancelChecker != null ){
-			cancelChecker.checkCanceled();
+			try {
+				cancelChecker.checkCanceled();
+			} catch (CancellationException ce) {
+				return true;
+			}
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/CancellableProgressMonitorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/CancellableProgressMonitorTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doThrow;
+
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Fred Bricon
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CancellableProgressMonitorTest {
+
+	@Mock
+	private CancelChecker checker;
+
+	@Test
+	public void testCancelled() {
+		doThrow(CancellationException.class).when(checker).checkCanceled();
+		assertTrue(new CancellableProgressMonitor(checker).isCanceled());
+	}
+
+	@Test
+	public void testNotCancelled() {
+		assertFalse(new CancellableProgressMonitor(null).isCanceled());
+		assertFalse(new CancellableProgressMonitor(checker).isCanceled());
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/213

Signed-off-by: Fred Bricon <fbricon@gmail.com>