### PR TITLE
Gradle import fails behind corporate proxy with auth

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Import-Package: org.osgi.framework;version="1.3.0",
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources,
+ org.eclipse.core.net,
  org.eclipse.jdt.core,
  org.eclipse.text;bundle-version="3.6.0",
  org.eclipse.m2e.core,

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -13,8 +13,10 @@ package org.eclipse.jdt.ls.core.internal.managers;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.util.gradle.GradleDistributionWrapper;
@@ -85,7 +87,26 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	}
 
 	protected void startSynchronization(File location, GradleDistribution distribution, NewProjectHandler newProjectHandler) {
-		FixedRequestAttributes attributes = new FixedRequestAttributes(location, null, distribution, null, Collections.emptyList(), Collections.emptyList());
+		List<String> jvmArgs = new ArrayList<>();
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTP_PROXY_HOST);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTP_PROXY_PORT);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTP_PROXY_USER);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTP_PROXY_PASSWORD);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTPS_PROXY_HOST);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTPS_PROXY_PORT);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTPS_PROXY_USER);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTPS_PROXY_PASSWORD);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTP_NON_PROXY_HOSTS);
+		addArgs(jvmArgs, JavaLanguageServerPlugin.HTTPS_NON_PROXY_HOSTS);
+		FixedRequestAttributes attributes = new FixedRequestAttributes(location, null, distribution, null, jvmArgs, Collections.emptyList());
 		CorePlugin.gradleWorkspaceManager().getGradleBuild(attributes).synchronize(newProjectHandler);
+	}
+
+	private void addArgs(List<String> jvmArgs, String name) {
+		String value = System.getProperty(name);
+		if (value != null) {
+			jvmArgs.add(String.format("-D%s=%s", name, value));
+
+		}
 	}
 }

--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -31,6 +31,11 @@
       <plugin id="org.eclipse.core.expressions"/>
       <plugin id="org.eclipse.core.filesystem"/>
       <plugin id="org.eclipse.core.jobs"/>
+      <plugin id="org.eclipse.core.net"/>
+      <plugin id="org.eclipse.core.net.linux.x86" fragment="true"/>
+      <plugin id="org.eclipse.core.net.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.core.net.win32.x86" fragment="true"/>
+      <plugin id="org.eclipse.core.net.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.core.resources"/>
       <plugin id="org.eclipse.core.runtime"/>
       <plugin id="org.eclipse.core.variables"/>
@@ -39,6 +44,11 @@
       <plugin id="org.eclipse.equinox.common"/>
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
+      <plugin id="org.eclipse.equinox.security"/>
+      <plugin id="org.eclipse.equinox.security.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.win32.x86" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.jdt.compiler.apt" fragment="true"/>
       <plugin id="org.eclipse.jdt.compiler.tool" fragment="true"/>
       <plugin id="org.eclipse.jdt.core"/>
@@ -60,6 +70,7 @@
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.jdt.core" autoStart="false" startLevel="0" />
       <plugin id="org.eclipse.jdt.launching" autoStart="false" startLevel="0" />
+      <plugin id="org.eclipse.jdt.ls.core" autoStart="true" startLevel="0" />
    </configurations>
 
    <preferencesInfo>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="74">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mockito.mockito-all" version="1.9.5"/>
 <repository location="http://download.eclipse.org/scout/releases/4.0/testing"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
 <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
@@ -13,11 +13,11 @@
 <unit id="com.google.gson.source" version="2.7.0.v20170129-0911"/>
 <repository location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20170516-2043"/>
 <repository location="http://download.eclipse.org/technology/m2e/milestones/1.8/1.8.0.20170516-2043"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170518-1049"/>
 <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170516-1513"/>
 <unit id="org.eclipse.equinox.executable.feature.group" version="3.7.0.v20170511-1520"/>
@@ -29,7 +29,7 @@
 <unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170518-1424"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.7milestones"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.buildship.feature.group" version="2.0.2.v20170420-0909"/>
 <repository location="http://download.eclipse.org/releases/oxygen"/>
 </location>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -1,36 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="71">
+<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="74">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.mockito.mockito-all" version="1.9.5"/>
 <repository location="http://download.eclipse.org/scout/releases/4.0/testing"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
 <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
 <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/S20170516192513/repository"/>
+<unit id="com.google.gson.source" version="2.7.0.v20170129-0911"/>
+<repository location="http://download.eclipse.org/tools/orbit/R-builds/R20170516192513/repository"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170510-2118"/>
-<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170510-2118"/>
-<unit id="org.eclipse.equinox.executable.feature.group" version="3.7.0.v20170511-1520"/>
-<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="1.4.0.v20170510-2006"/>
-<unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="1.4.0.v20170510-2006"/>
-<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.3.0.v20170510-2006"/>
-<unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170511-1520"/>
-<unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170512-0500"/>
-<unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170512-0500"/>
-<repository location="http://download.eclipse.org/releases/oxygen/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.buildship.feature.group" version="2.0.2.v20170420-0909"/>
-<repository location="http://download.eclipse.org/releases/oxygen"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20170516-2043"/>
 <repository location="http://download.eclipse.org/technology/m2e/milestones/1.8/1.8.0.20170516-2043"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170518-1049"/>
+<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170516-1513"/>
+<unit id="org.eclipse.equinox.executable.feature.group" version="3.7.0.v20170511-1520"/>
+<unit id="org.eclipse.equinox.p2.core.feature.feature.group" version="1.4.0.v20170516-0526"/>
+<unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="1.4.0.v20170516-0526"/>
+<unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.3.0.v20170516-0526"/>
+<unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170518-1049"/>
+<unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170518-1110"/>
+<unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170518-1424"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.7milestones"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+<unit id="org.eclipse.buildship.feature.group" version="2.0.2.v20170420-0909"/>
+<repository location="http://download.eclipse.org/releases/oxygen"/>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompletionBasedTest.java
@@ -43,6 +43,7 @@ public abstract class AbstractCompletionBasedTest extends AbstractProjectsManage
 		project = WorkspaceHelper.getProject("hello");
 		wcOwner = new LanguageServerWorkingCopyOwner(connection);
 		server= new JDTLanguageServer(projectsManager, preferenceManager);
+		JavaCore.initializeAfterLoad(null);
 	}
 
 	protected ICompilationUnit getWorkingCopy(String path, String source) throws JavaModelException {


### PR DESCRIPTION
The PR does the following:

- updates the target platform to Oxygen 4.7RC1, buildship 2.0.2
- fixes https://github.com/redhat-developer/vscode-java/issues/212
- fixes the issue with the tests described at https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java#L67
The issue happens when a completion starts before Java Core is initialized. It is more often reproduced in Oxygen >=M7 than in earlier versions of Eclipse.
- fixes https://github.com/redhat-developer/vscode-java/issues/211
You can set a proxy as described in https://github.com/redhat-developer/vscode-java/wiki/Using-a-Proxy

I haven't succeeded to set a proxy in Eclipse without using the Eclipse UI preferences. There are two issues:
- it seems there is no way to set a proxy provider type (manual, native or direct) without the UI 
- the plugin removes the http.*, https.* system properties when setting its preferences and a proxy provider isn't manual
The fix solves both of these issues.

It is also possible to set a proxy using maven settings.xml for maven projects - https://maven.apache.org/guides/mini/guide-proxies.html and using gradle.properties for gradle projects - https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy.
In my opinion, the easiest and the safest way is to add proxy properties to global maven/gradle settings because they aren't added as JVM system arguments. You don't have to set either Eclipse or VSCode in this case. 

I haven't succeeded to set a proxy in Eclipse or VSCode so m2e can use it. M2e ignores the http(s)* properties and maven doesn't recognize the httpUser/httpsUser and httpPassword/httpsPassword property. You have to set a proxy using settings.xml. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=459638
Buildship also ignores the Eclipse proxy properties when the Eclipse proxy provider is Manual. I have fixed the issue in org.eclipse.ls by adding the http/https* JVM properties when starting a gradle build.
I have seen https://bugs.eclipse.org/bugs/show_bug.cgi?id=471943#c4, but it doesn't help. 

There is also a problem when setting a proxy for gradle. It isn't related to o.e.jdt.ls or Eclipse/buildship. 
When gradle downloads a gradle distribution, it requires setting the proxy properties as the following:
```
systemProp.http.proxyHost=<user>:<password>@<proxy_ip>
systemProp.http.proxyPort=<port>
systemProp.https.proxyHost=<user>:<password>@<proxy_ip>
systemProp.https.proxyPort=<port>
```

However, when downloading dependencies, gradle requires the proxy properties to be set as described at https://docs.gradle.org/current/userguide/build_environment.html#sec:accessing_the_web_via_a_proxy:

```
systemProp.http.proxyHost=<proxy_id>
systemProp.http.proxyPort=<port>
systemProp.http.proxyUser=<user>
systemProp.http.proxyPassword=<password>
systemProp.https.proxyHost=<proxy_id>
systemProp.https.proxyPort=<port>
systemProp.https.proxyUser=<user>
systemProp.https.proxyPassword=<password>
```

This fix will download dependencies, but won't work if there isn't the required gradle distribution. You have to download the distribution using gradle.properties as described above. 

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>