### PR TITLE
Restrict navigation to classes from current project's classpath

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -150,7 +150,7 @@ public final class JDTUtils {
 			return null;
 		}
 		IJavaProject javaProject = JavaCore.create(project);
-		
+
 		String packageName = getPackageName(javaProject, uri);
 		String fileName = path.getName(path.getNameCount() - 1).toString();
 		String packagePath = packageName.replace(".", "/");
@@ -469,7 +469,9 @@ public final class JDTUtils {
 						}
 						SearchPattern pattern = SearchPattern.createPattern(name, IJavaSearchConstants.TYPE,
 								IJavaSearchConstants.DECLARATIONS, SearchPattern.R_FULL_MATCH);
-						IJavaSearchScope scope = SearchEngine.createWorkspaceScope();
+
+						IJavaSearchScope scope = createSearchScope(unit.getJavaProject());
+
 						List<IJavaElement> elements = new ArrayList<>();
 						SearchRequestor requestor = new SearchRequestor() {
 							@Override
@@ -614,6 +616,14 @@ public final class JDTUtils {
 			JavaLanguageServerPlugin.logError("Unable to disassemble " + classFile.getHandleIdentifier());
 		}
 		return disassembledByteCode;
+	}
+
+	public static IJavaSearchScope createSearchScope(IJavaProject project) {
+		if (project == null) {
+			return SearchEngine.createWorkspaceScope();
+		}
+		return SearchEngine.createJavaSearchScope(new IJavaProject[] { project },
+				IJavaSearchScope.SOURCES | IJavaSearchScope.APPLICATION_LIBRARIES | IJavaSearchScope.SYSTEM_LIBRARIES);
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ClassFileUtil.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ClassFileUtil.java
@@ -17,7 +17,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
-import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeNameMatch;
@@ -46,7 +45,7 @@ public final class ClassFileUtil {
 		new SearchEngine().searchAllTypeNames(packageName.toCharArray(),SearchPattern.R_EXACT_MATCH,
 				className.toCharArray(), SearchPattern.R_EXACT_MATCH,
 				IJavaSearchConstants.TYPE,
-				createSearchScope(javaProject),
+				JDTUtils.createSearchScope(javaProject),
 				extractor,
 				IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH,
 				new NullProgressMonitor());
@@ -72,11 +71,6 @@ public final class ClassFileUtil {
 				throw new RuntimeException(e);
 			}
 		}
-	}
-
-	private static IJavaSearchScope createSearchScope(IJavaProject project) {
-		return SearchEngine.createJavaSearchScope(new IJavaProject[] {project} ,
-				IJavaSearchScope.SOURCES | IJavaSearchScope.APPLICATION_LIBRARIES | IJavaSearchScope.SYSTEM_LIBRARIES);
 	}
 
 }


### PR DESCRIPTION
This fixes NavigateToDefinitionHandlerTest.testDisassembledSource's failure, when multiple JDKs have been detected.

Signed-off-by: Fred Bricon <fbricon@gmail.com>