### PR TITLE
Boost relevance of current package during completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -42,6 +42,12 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	@Override
 	public void accept(CompletionProposal proposal) {
 		if(!isIgnored(proposal.getKind())) {
+			if (proposal.getKind() == CompletionProposal.PACKAGE_REF && unit.getParent() != null
+					&& String.valueOf(proposal.getCompletion()).equals(unit.getParent().getElementName())) {
+				// Hacky way to boost relevance of current package, for package completions, until
+				// https://bugs.eclipse.org/518140 is fixed
+				proposal.setRelevance(proposal.getRelevance() + 1);
+			}
 			proposals.add(proposal);
 		}
 	}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Baz.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Baz.java
@@ -1,0 +1,4 @@
+package org.sample;
+public class Baz {
+
+}


### PR DESCRIPTION
Current package relevance is boosted but unrelevant packages are still proposed.

Partially fixes https://github.com/redhat-developer/vscode-java/issues/234 until
https://bugs.eclipse.org/518140 is fixed in JDT core.

Signed-off-by: Fred Bricon <fbricon@gmail.com>