### PR TITLE
'Invalid project description' thrown when opening Eclipse projects

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
@@ -74,6 +74,8 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 			IProject project = workspace.getRoot().getProject(name);
 			if (project.exists()) {
 				IPath existingProjectPath = project.getLocation();
+				existingProjectPath = fixDevice(existingProjectPath);
+				dotProjectPath = fixDevice(dotProjectPath);
 				if (existingProjectPath.equals(dotProjectPath.removeLastSegments(1))) {
 					project.open(IResource.NONE, monitor);
 					project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
@@ -87,8 +89,16 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 			project.open(IResource.NONE, monitor);
 			monitor.done();
 		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e.getStatus());
 			throw new RuntimeException(e);
 		}
+	}
+
+	private IPath fixDevice(IPath path) {
+		if (path != null && path.getDevice() != null) {
+			return path.setDevice(path.getDevice().toUpperCase());
+		}
+		return path;
 	}
 
 	//XXX should be package protected. Temporary fix (ahaha!) until test fragment can work in tycho builds

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
@@ -41,6 +41,10 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 		importProjects("eclipse/"+name);
 		IProject project = getProject(name );
 		assertIsJavaProject(project);
+		// a test for https://github.com/redhat-developer/vscode-java/issues/244
+		importProjects("eclipse/" + name);
+		project = getProject(name);
+		assertIsJavaProject(project);
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

Fixes https://github.com/redhat-developer/vscode-java/issues/244

The issue happens because Eclipse LS creates a path with lower case device id on Windows (c: instead of C:, for instance).
Eclipse returns the following errors: "Invalid project description" and "XXX/Test overlaps the location of another project: 'Test'".
The PR fixes the issue by converting the device id to upper case.