### PR TITLE
Add SignatureHelp support.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -53,6 +53,44 @@ public class CompletionProposalDescriptionProvider {
 	}
 
 	/**
+	 * Creates and returns the method signature suitable for display.
+	 *
+	 * @param proposal
+	 *            the proposal to create the description for
+	 * @return the string of method signature suitable for display
+	 */
+	public StringBuilder createMethodProposalDescription(CompletionProposal proposal) {
+		int kind = proposal.getKind();
+		switch (kind) {
+			case CompletionProposal.METHOD_REF:
+			case CompletionProposal.POTENTIAL_METHOD_DECLARATION:
+			case CompletionProposal.CONSTRUCTOR_INVOCATION:
+			case CompletionProposal.ANONYMOUS_CLASS_DECLARATION:
+			case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
+				StringBuilder description = new StringBuilder();
+
+				// method name
+				description.append(proposal.getName());
+
+				// parameters
+				description.append('(');
+				appendUnboundedParameterList(description, proposal);
+				description.append(')');
+
+				// return type
+				if (!proposal.isConstructor()) {
+					// TODO remove SignatureUtil.fix83600 call when bugs are fixed
+					char[] returnType = createTypeDisplayName(SignatureUtil.getUpperBound(Signature.getReturnType(SignatureUtil.fix83600(proposal.getSignature()))));
+					description.append(RETURN_TYPE_SEPARATOR);
+					description.append(returnType);
+				}
+				return description;
+			default:
+				return null; // dummy
+		}
+	}
+
+	/**
 	 * Creates and returns a parameter list of the given method or type proposal suitable for
 	 * display. The list does not include parentheses. The lower bound of parameter types is
 	 * returned.
@@ -255,26 +293,10 @@ public class CompletionProposalDescriptionProvider {
 	 * @param item to update
 	 */
 	private void createMethodProposalLabel(CompletionProposal methodProposal, CompletionItem item) {
-		StringBuilder description = new StringBuilder();
-
-		// method name
-		description.append(methodProposal.getName());
-		item.setInsertText(description.toString());
-
-		// parameters
-		description.append('(');
-		appendUnboundedParameterList(description, methodProposal);
-		description.append(')');
-
-		// return type
-		if (!methodProposal.isConstructor()) {
-			// TODO remove SignatureUtil.fix83600 call when bugs are fixed
-			char[] returnType= createTypeDisplayName(SignatureUtil.getUpperBound(Signature.getReturnType(SignatureUtil.fix83600(methodProposal.getSignature()))));
-			description.append(RETURN_TYPE_SEPARATOR);
-			description.append(returnType);
-		}
-
+		StringBuilder description = this.createMethodProposalDescription(methodProposal);
 		item.setLabel(description.toString());
+		item.setInsertText(String.valueOf(methodProposal.getName()));
+
 		// declaring type
 		StringBuilder typeInfo = new StringBuilder();
 		String declaringType= extractDeclaringTypeFQN(methodProposal);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -25,12 +25,12 @@ import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponses;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 
-public class CompletionProposalRequestor extends CompletionRequestor {
+public final class CompletionProposalRequestor extends CompletionRequestor {
 
-	protected List<CompletionProposal> proposals = new ArrayList<>();
-	protected final ICompilationUnit unit;
+	private List<CompletionProposal> proposals = new ArrayList<>();
+	private final ICompilationUnit unit;
 	private CompletionProposalDescriptionProvider descriptionProvider;
-	protected CompletionResponse response;
+	private CompletionResponse response;
 
 	public CompletionProposalRequestor(ICompilationUnit aUnit, int offset) {
 		this.unit = aUnit;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -25,12 +25,12 @@ import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponses;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 
-public final class CompletionProposalRequestor extends CompletionRequestor {
+public class CompletionProposalRequestor extends CompletionRequestor {
 
-	private List<CompletionProposal> proposals = new ArrayList<>();
-	private final ICompilationUnit unit;
+	protected List<CompletionProposal> proposals = new ArrayList<>();
+	protected final ICompilationUnit unit;
 	private CompletionProposalDescriptionProvider descriptionProvider;
-	private CompletionResponse response;
+	protected CompletionResponse response;
 
 	public CompletionProposalRequestor(ICompilationUnit aUnit, int offset) {
 		this.unit = aUnit;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponses;
@@ -65,6 +66,8 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 		for (int i = 0; i < proposals.size(); i++) {
 			if (!monitor.isCanceled()) {
 				signatureHelp.getSignatures().add(this.toSignatureInformation(proposals.get(i)));
+			} else {
+				return null;
 			}
 		}
 
@@ -121,7 +124,12 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 
 		List<ParameterInformation> parameterInfos = new LinkedList<>();
 		for (int i = 0; i < parameterTypes.length; i++) {
-			parameterInfos.add(new ParameterInformation(new String(parameterNames[i]), new String(parameterTypes[i])));
+			StringBuffer buff = new StringBuffer();
+			buff.append(parameterTypes[i]);
+			buff.append(' ');
+			buff.append(parameterNames[i]);
+
+			parameterInfos.add(new ParameterInformation(buff.toString(), null));
 		}
 
 		$.setParameters(parameterInfos);
@@ -162,7 +170,7 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 					parameters[i]= getLowerBound(parameters[i]);
 				}
 
-				IMethod method = type.getMethod(String.valueOf(proposal.getName()), parameters);
+				IMethod method = JavaModelUtil.findMethod(String.valueOf(proposal.getName()), parameters, proposal.isConstructor(), type);
 
 				if (method != null && method.exists()) {
 					String javadoc = null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.contentassist;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponses;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureInformation;
+
+public final class SignatureHelpRequestor extends CompletionProposalRequestor {
+
+	public SignatureHelpRequestor(ICompilationUnit aUnit, int offset) {
+		super(aUnit, offset);
+		setRequireExtendedContext(true);
+	}
+
+	public SignatureHelp getSignatureHelp() {
+		SignatureHelp signatureHelp = new SignatureHelp();
+		response.setProposals(proposals);
+		CompletionResponses.store(response);
+
+		for (int i = 0; i < proposals.size(); i++) {
+			CompletionItem item = this.toCompletionItem(proposals.get(i), i);
+			signatureHelp.getSignatures().add(this.toSignatureInformation(item, proposals.get(i)));
+		}
+
+		signatureHelp.getSignatures().sort((SignatureInformation a, SignatureInformation b) -> a.getParameters().size() - b.getParameters().size());
+
+		return signatureHelp;
+	}
+
+	public SignatureInformation toSignatureInformation(CompletionItem item, CompletionProposal methodProposal) {
+		SignatureInformation $ = new SignatureInformation();
+		$.setLabel(item.getLabel());
+		$.setDocumentation(item.getDocumentation());
+
+		char[] signature = SignatureUtil.fix83600(methodProposal.getSignature());
+		char[][] parameterNames = methodProposal.findParameterNames(null);
+		char[][] parameterTypes = Signature.getParameterTypes(signature);
+
+		for (int i = 0; i < parameterTypes.length; i++) {
+			parameterTypes[i] = createTypeDisplayName(SignatureUtil.getLowerBound(parameterTypes[i]));
+		}
+
+		if (Flags.isVarargs(methodProposal.getFlags())) {
+			int index = parameterTypes.length - 1;
+			parameterTypes[index] = convertToVararg(parameterTypes[index]);
+		}
+
+		List<ParameterInformation> parameterInfos = new LinkedList<>();
+		for (int i = 0; i < parameterTypes.length; i++) {
+			parameterInfos.add(new ParameterInformation(new String(parameterNames[i]), new String(parameterTypes[i])));
+		}
+
+		$.setParameters(parameterInfos);
+
+		return $;
+	}
+
+	private char[] convertToVararg(char[] typeName) {
+		if (typeName == null) {
+			return typeName;
+		}
+		final int len = typeName.length;
+		if (len < 2) {
+			return typeName;
+		}
+
+		if (typeName[len - 1] != ']') {
+			return typeName;
+		}
+		if (typeName[len - 2] != '[') {
+			return typeName;
+		}
+
+		char[] vararg = new char[len + 1];
+		System.arraycopy(typeName, 0, vararg, 0, len - 2);
+		vararg[len - 2] = '.';
+		vararg[len - 1] = '.';
+		vararg[len] = '.';
+		return vararg;
+	}
+
+	private char[] createTypeDisplayName(char[] typeSignature) throws IllegalArgumentException {
+		char[] displayName = Signature.getSimpleName(Signature.toCharArray(typeSignature));
+
+		// XXX see https://bugs.eclipse.org/bugs/show_bug.cgi?id=84675
+		boolean useShortGenerics = false;
+		if (useShortGenerics) {
+			StringBuilder buf = new StringBuilder();
+			buf.append(displayName);
+			int pos;
+			do {
+				pos = buf.indexOf("? extends "); //$NON-NLS-1$
+				if (pos >= 0) {
+					buf.replace(pos, pos + 10, "+"); //$NON-NLS-1$
+				} else {
+					pos = buf.indexOf("? super "); //$NON-NLS-1$
+					if (pos >= 0) {
+						buf.replace(pos, pos + 8, "-"); //$NON-NLS-1$
+					}
+				}
+			} while (pos >= 0);
+			return buf.toString().toCharArray();
+		}
+		return displayName;
+	}
+
+	@Override
+	public boolean isIgnored(int completionProposalKind) {
+		return completionProposalKind != CompletionProposal.METHOD_REF;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -174,6 +174,11 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 				IMethod method = JavaModelUtil.findMethod(String.valueOf(proposal.getName()), parameters, proposal.isConstructor(), type);
 
 				if (method != null && method.exists()) {
+					ICompilationUnit unit = type.getCompilationUnit();
+					if (unit != null) {
+						unit.reconcile(ICompilationUnit.NO_AST, false, null, null);
+					}
+
 					String javadoc = null;
 					try {
 						javadoc = new SimpleTimeLimiter().callWithTimeout(() -> {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -63,15 +63,16 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 		response.setProposals(proposals);
 		CompletionResponses.store(response);
 
+		List<SignatureInformation> infos = new ArrayList<>();
 		for (int i = 0; i < proposals.size(); i++) {
 			if (!monitor.isCanceled()) {
-				signatureHelp.getSignatures().add(this.toSignatureInformation(proposals.get(i)));
+				infos.add(this.toSignatureInformation(proposals.get(i)));
 			} else {
-				return null;
+				return signatureHelp;
 			}
 		}
-
-		signatureHelp.getSignatures().sort((SignatureInformation a, SignatureInformation b) -> a.getParameters().size() - b.getParameters().size());
+		infos.sort((SignatureInformation a, SignatureInformation b) -> a.getParameters().size() - b.getParameters().size());
+		signatureHelp.getSignatures().addAll(infos);
 
 		return signatureHelp;
 	}
@@ -124,12 +125,12 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 
 		List<ParameterInformation> parameterInfos = new LinkedList<>();
 		for (int i = 0; i < parameterTypes.length; i++) {
-			StringBuffer buff = new StringBuffer();
-			buff.append(parameterTypes[i]);
-			buff.append(' ');
-			buff.append(parameterNames[i]);
+			StringBuilder builder = new StringBuilder();
+			builder.append(parameterTypes[i]);
+			builder.append(' ');
+			builder.append(parameterNames[i]);
 
-			parameterInfos.add(new ParameterInformation(buff.toString(), null));
+			parameterInfos.add(new ParameterInformation(builder.toString(), null));
 		}
 
 		$.setParameters(parameterInfos);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -37,7 +37,6 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 
 /**
@@ -86,7 +85,6 @@ final public class InitHandler {
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","@","#")));
 		capabilities.setHoverProvider(Boolean.TRUE);
-		capabilities.setSignatureHelpProvider(new SignatureHelpOptions(Arrays.asList("(")));
 		capabilities.setDefinitionProvider(Boolean.TRUE);
 		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
 		capabilities.setWorkspaceSymbolProvider(Boolean.TRUE);
@@ -100,6 +98,9 @@ final public class InitHandler {
 		}
 		if (!preferenceManager.getClientPreferences().isCodeLensDynamicRegistrationSupported()) {
 			capabilities.setCodeLensProvider(new CodeLensOptions(true));
+		}
+		if (!preferenceManager.getClientPreferences().isSignatureHelpDynamicRegistrationSupported()) {
+			capabilities.setSignatureHelpProvider(SignatureHelpHandler.createOptions());
 		}
 		capabilities.setCodeActionProvider(Boolean.TRUE);
 		result.setCapabilities(capabilities);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 
 /**
@@ -85,6 +86,7 @@ final public class InitHandler {
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".","@","#")));
 		capabilities.setHoverProvider(Boolean.TRUE);
+		capabilities.setSignatureHelpProvider(new SignatureHelpOptions(Arrays.asList("(")));
 		capabilities.setDefinitionProvider(Boolean.TRUE);
 		capabilities.setDocumentSymbolProvider(Boolean.TRUE);
 		capabilities.setWorkspaceSymbolProvider(Boolean.TRUE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -211,7 +211,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		}
 		if (preferenceManager.getClientPreferences().isSignatureHelpDynamicRegistrationSupported()) {
 			if (preferenceManager.getPreferences().isSignatureHelpEnabled()) {
-				registerCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP, new CodeLensOptions(true));
+				registerCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP, SignatureHelpHandler.createOptions());
 			} else {
 				unregisterCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP);
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -209,6 +209,13 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 				unregisterCapability(Preferences.CODE_LENS_ID, Preferences.TEXT_DOCUMENT_CODE_LENS);
 			}
 		}
+		if (preferenceManager.getClientPreferences().isSignatureHelpDynamicRegistrationSupported()) {
+			if (preferenceManager.getPreferences().isSignatureHelpEnabled()) {
+				registerCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP, new CodeLensOptions(true));
+			} else {
+				unregisterCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP);
+			}
+		}
 		logInfo(">>New configuration: " + settings);
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -258,8 +258,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
 		logInfo(">> document/signatureHelp");
-		// Not yet implemented
-		return null;
+		SignatureHelpHandler handler = new SignatureHelpHandler();
+		return computeAsync((cc) -> handler.signatureHelp(position, toMonitor(cc)));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -258,7 +258,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
 		logInfo(">> document/signatureHelp");
-		SignatureHelpHandler handler = new SignatureHelpHandler();
+		SignatureHelpHandler handler = new SignatureHelpHandler(preferenceManager);
 		return computeAsync((cc) -> handler.signatureHelp(position, toMonitor(cc)));
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
@@ -22,10 +23,15 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.SignatureHelpRequestor;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 
 public class SignatureHelpHandler {
+
+	public static SignatureHelpOptions createOptions() {
+		return new SignatureHelpOptions(Arrays.asList("("));
+	}
 
 	private static final int SEARCH_BOUND = 2000;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.SignatureHelpRequestor;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+
+public class SignatureHelpHandler {
+
+	private static final int SEARCH_BOUND = 2000;
+
+	public SignatureHelp signatureHelp(TextDocumentPositionParams position, IProgressMonitor monitor) {
+
+		SignatureHelp help = new SignatureHelp();
+
+		try {
+			ICompilationUnit unit = JDTUtils.resolveCompilationUnit(position.getTextDocument().getUri());
+			final int offset = JsonRpcHelpers.toOffset(unit.getBuffer(), position.getPosition().getLine(), position.getPosition().getCharacter());
+			int[] contextInfomation = getContextInfomation(unit.getBuffer(), offset);
+			if (contextInfomation[0] == -1) {
+				return help;
+			}
+			SignatureHelpRequestor collector = new SignatureHelpRequestor(unit, contextInfomation[0] + 1);
+
+			if (offset > -1 && !monitor.isCanceled()) {
+				unit.codeComplete(contextInfomation[0] + 1, collector, monitor);
+				help = collector.getSignatureHelp();
+
+				int currentParameter = contextInfomation[1];
+				List<SignatureInformation> infos = help.getSignatures();
+				for (int i = 0; i < infos.size(); i++) {
+					if (infos.get(i).getParameters().size() >= currentParameter) {
+						help.setActiveSignature(i);
+						help.setActiveParameter(currentParameter);
+						break;
+					}
+				}
+			}
+		} catch (CoreException ex) {
+			JavaLanguageServerPlugin.logException("Find signatureHelp failure ", ex);
+		}
+		return help;
+	}
+
+	/*
+	 * @return Array of integer. The first will be the starting '(' of the methods if found. The second will be the current parameter position.
+	 */
+	private int[] getContextInfomation(IBuffer buffer, int offset) {
+		int[] result = new int[2];
+		result[0] = -1;
+		int depth = 1;
+
+		for (int i = offset - 1; i >= 0 && ((offset - i) < SEARCH_BOUND); i--) {
+			char c = buffer.getChar(i);
+			if (c == ')') {
+				depth++;
+			}
+			if (c == '(') {
+				depth--;
+			}
+			if (c == ',' && depth == 1) {
+				result[1]++;
+			}
+			if (depth == 0) {
+				result[0] = i;
+				break;
+			}
+		}
+		// Assuming user are typing current parameter:
+		if (result[0] + 1 != offset) {
+			result[1]++;
+		}
+		return result;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
@@ -62,13 +62,15 @@ public class SignatureHelpHandler {
 				unit.codeComplete(contextInfomation[0] + 1, collector, monitor);
 				help = collector.getSignatureHelp(monitor);
 
-				int currentParameter = contextInfomation[1];
-				List<SignatureInformation> infos = help.getSignatures();
-				for (int i = 0; i < infos.size(); i++) {
-					if (infos.get(i).getParameters().size() >= currentParameter) {
-						help.setActiveSignature(i);
-						help.setActiveParameter(currentParameter);
-						break;
+				if (help != null) {
+					int currentParameter = contextInfomation[1];
+					List<SignatureInformation> infos = help.getSignatures();
+					for (int i = 0; i < infos.size(); i++) {
+						if (infos.get(i).getParameters().size() >= currentParameter + 1) {
+							help.setActiveSignature(i);
+							help.setActiveParameter(currentParameter);
+							break;
+						}
 					}
 				}
 			}
@@ -79,11 +81,14 @@ public class SignatureHelpHandler {
 	}
 
 	/*
-	 * @return Array of integer. The first will be the starting '(' of the methods if found. The second will be the current parameter position.
+	 * Calculate the heuristic information about the start offset of method and current parameter position. The parameter position is 0-based.
+	 * If cannot find the methods start offset after max search bound, -1 will be return.
+	 *
+	 * @return array of 2 integer2: the first one is starting offset of method and the second one is the current parameter position.
 	 */
 	private int[] getContextInfomation(IBuffer buffer, int offset) {
 		int[] result = new int[2];
-		result[0] = -1;
+		result[0] = result[1] = -1;
 		int depth = 1;
 
 		for (int i = offset - 1; i >= 0 && ((offset - i) < SEARCH_BOUND); i--) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.SignatureHelpRequestor;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -28,9 +29,19 @@ public class SignatureHelpHandler {
 
 	private static final int SEARCH_BOUND = 2000;
 
+	private PreferenceManager preferenceManager;
+
+	public SignatureHelpHandler(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
+	}
+
 	public SignatureHelp signatureHelp(TextDocumentPositionParams position, IProgressMonitor monitor) {
 
 		SignatureHelp help = new SignatureHelp();
+
+		if (!preferenceManager.getPreferences(null).isSignatureHelpEnabled()) {
+			return help;
+		}
 
 		try {
 			ICompilationUnit unit = JDTUtils.resolveCompilationUnit(position.getTextDocument().getUri());
@@ -43,7 +54,7 @@ public class SignatureHelpHandler {
 
 			if (offset > -1 && !monitor.isCanceled()) {
 				unit.codeComplete(contextInfomation[0] + 1, collector, monitor);
-				help = collector.getSignatureHelp();
+				help = collector.getSignatureHelp(monitor);
 
 				int currentParameter = contextInfomation[1];
 				List<SignatureInformation> infos = help.getSignatures();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -54,4 +54,8 @@ public class ClientPreferences {
 	public boolean isCodeLensDynamicRegistrationSupported() {
 		return v3supported && capabilities.getTextDocument().getCodeLens().getDynamicRegistration();
 	}
+
+	public boolean isSignatureHelpDynamicRegistrationSupported() {
+		return v3supported && capabilities.getTextDocument().getSignatureHelp().getDynamicRegistration();
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -101,10 +101,12 @@ public class Preferences {
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
+	public static final String TEXT_DOCUMENT_SIGNATURE_HELP = "textDocument/signatureHelp";
 
 	public static final String FORMATTING_ID = UUID.randomUUID().toString();
 	public static final String FORMATTING_RANGE_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
+	public static final String SIGNATURE_HELP_ID = UUID.randomUUID().toString();
 
 	private Severity incompleteClasspathSeverity;
 	private FeatureStatus updateBuildConfigurationStatus;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -42,6 +42,12 @@ public class Preferences {
 	public static final String JAVA_FORMAT_ENABLED_KEY = "java.format.enabled";
 
 	/**
+	 * Preference key to enable/disable signature help.
+	 */
+	public static final String SIGNATURE_HELP_ENABLED_KEY = "java.signatureHelp.enabled";
+
+
+	/**
 	 * Preference key to exclude directories when importing projects.
 	 */
 	public static final String JAVA_IMPORT_EXCLUSIONS_KEY = "java.import.exclusions";
@@ -104,6 +110,7 @@ public class Preferences {
 	private FeatureStatus updateBuildConfigurationStatus;
 	private boolean referencesCodeLensEnabled;
 	private boolean javaFormatEnabled;
+	private boolean signatureHelpEnabled;
 	private MemberSortOrder memberOrders;
 
 	private String mavenUserSettings;
@@ -164,6 +171,7 @@ public class Preferences {
 		updateBuildConfigurationStatus = FeatureStatus.interactive;
 		referencesCodeLensEnabled = true;
 		javaFormatEnabled = true;
+		signatureHelpEnabled = false;
 		memberOrders = new MemberSortOrder(null);
 		favoriteStaticMembers = "";
 		javaImportExclusions = JAVA_IMPORT_EXCLUSIONS_DEFAULT;
@@ -234,6 +242,9 @@ public class Preferences {
 		boolean javaFormatEnabled = getBooleanValue(configuration, JAVA_FORMAT_ENABLED_KEY, true);
 		prefs.setJavaFormatEnabled(javaFormatEnabled);
 
+		boolean signatureHelpEnabled = getBooleanValue(configuration, SIGNATURE_HELP_ENABLED_KEY, true);
+		prefs.setSignatureHelpEnabled(signatureHelpEnabled);
+
 		List<String> javaImportExclusions = getListValue(configuration, JAVA_IMPORT_EXCLUSIONS_KEY, JAVA_IMPORT_EXCLUSIONS_DEFAULT);
 		prefs.setJavaImportExclusions(javaImportExclusions);
 
@@ -261,6 +272,11 @@ public class Preferences {
 
 	private Preferences setReferencesCodelensEnabled(boolean enabled) {
 		this.referencesCodeLensEnabled = enabled;
+		return this;
+	}
+
+	private Preferences setSignatureHelpEnabled(boolean enabled) {
+		this.signatureHelpEnabled = enabled;
 		return this;
 	}
 
@@ -306,6 +322,10 @@ public class Preferences {
 
 	public boolean isJavaFormatEnabled() {
 		return javaFormatEnabled;
+	}
+
+	public boolean isSignatureHelpEnabled() {
+		return signatureHelpEnabled;
 	}
 
 	public Preferences setMavenUserSettings(String mavenUserSettings) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -69,10 +69,11 @@ public class JDTLanguageServerTest {
 		Map<String, Object> map = new HashMap<>();
 		map.put(Preferences.REFERENCES_CODE_LENS_ENABLED_KEY, true);
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, true);
+		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, true);
 		DidChangeConfigurationParams params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
-		verify(client, times(3)).registerCapability(any());
+		verify(client, times(4)).registerCapability(any());
 
 		//On 2nd call, no registration calls should be emitted
 		reset(client);
@@ -83,10 +84,11 @@ public class JDTLanguageServerTest {
 		reset(client);
 		map.put(Preferences.REFERENCES_CODE_LENS_ENABLED_KEY, false);
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, false);
+		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, false);
 		params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
-		verify(client, times(3)).unregisterCapability(any());
+		verify(client, times(4)).unregisterCapability(any());
 
 		//On 2nd call, no unregistration calls should be emitted
 		reset(client);
@@ -101,6 +103,7 @@ public class JDTLanguageServerTest {
 		Map<String, Object> map = new HashMap<>();
 		map.put(Preferences.REFERENCES_CODE_LENS_ENABLED_KEY, true);
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, true);
+		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, true);
 		DidChangeConfigurationParams params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
@@ -109,6 +112,7 @@ public class JDTLanguageServerTest {
 		// unregister capabilities
 		map.put(Preferences.REFERENCES_CODE_LENS_ENABLED_KEY, false);
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, false);
+		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, false);
 		params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
@@ -119,6 +123,7 @@ public class JDTLanguageServerTest {
 		when(clientPreferences.isCodeLensDynamicRegistrationSupported()).thenReturn(enable);
 		when(clientPreferences.isFormattingDynamicRegistrationSupported()).thenReturn(enable);
 		when(clientPreferences.isRangeFormattingDynamicRegistrationSupported()).thenReturn(enable);
+		when(clientPreferences.isSignatureHelpDynamicRegistrationSupported()).thenReturn(enable);
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -78,15 +78,17 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		StringBuilder buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("public class E {\n");
+		buf.append("   /** This is a method */\n");
 		buf.append("   public int foo(String s) { }\n");
 		buf.append("   public int bar(String s) { this.foo() }\n");
 		buf.append("}\n");
 		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
 
-		SignatureHelp help = getSignatureHelp(cu, 3, 39);
+		SignatureHelp help = getSignatureHelp(cu, 4, 39);
 		assertNotNull(help);
 		assertEquals(help.getSignatures().size(), 1);
 		assertEquals(help.getSignatures().get(0).getLabel(), "foo(String s) : int");
+		assertTrue(help.getSignatures().get(0).getDocumentation().length() > 0);
 	}
 
 	@Test
@@ -105,8 +107,8 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		SignatureHelp help = getSignatureHelp(cu, 5, 42);
 		assertNotNull(help);
 		assertEquals(help.getSignatures().size(), 3);
+		assertEquals(help.getActiveParameter(), (Integer) 1);
 		assertEquals(help.getSignatures().get(help.getActiveSignature()).getLabel(), "foo(int s, String s) : int");
-
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.eclipse.jdt.ls.core.internal.JsonMessageHelper.getParams;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
+
+	private static String HOVER_TEMPLATE =
+			"{\n" +
+					"    \"id\": \"1\",\n" +
+					"    \"method\": \"textDocument/signatureHelp\",\n" +
+					"    \"params\": {\n" +
+					"        \"textDocument\": {\n" +
+					"            \"uri\": \"${file}\"\n" +
+					"        },\n" +
+					"        \"position\": {\n" +
+					"            \"line\": ${line},\n" +
+					"            \"character\": ${char}\n" +
+					"        }\n" +
+					"    },\n" +
+					"    \"jsonrpc\": \"2.0\"\n" +
+					"}";
+
+	private SignatureHelpHandler handler;
+
+	private IProject project;
+
+	private IPackageFragmentRoot sourceFolder;
+
+	@Override
+	@Before
+	public void setup() throws Exception {
+		importProjects("eclipse/hello");
+		project = WorkspaceHelper.getProject("hello");
+		IJavaProject javaProject = JavaCore.create(project);
+		sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
+		handler = new SignatureHelpHandler();
+	}
+
+	@Test
+	public void testSignatureHelp_singleMethod() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("   public int foo(String s) { }\n");
+		buf.append("   public int bar(String s) { this.foo() }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		SignatureHelp help = getSignatureHelp(cu, 3, 39);
+		assertNotNull(help);
+		assertEquals(help.getSignatures().size(), 1);
+		assertEquals(help.getSignatures().get(0).getLabel(), "foo(String s) : int");
+	}
+
+	@Test
+	public void testSignatureHelp_multipeMethod() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("   public int foo(String s) { }\n");
+		buf.append("   public int foo(int s) { }\n");
+		buf.append("   public int foo(int s, String s) { }\n");
+		buf.append("   public int bar(String s) { this.foo(2,  ) }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		SignatureHelp help = getSignatureHelp(cu, 5, 42);
+		assertNotNull(help);
+		assertEquals(help.getSignatures().size(), 3);
+		assertEquals(help.getSignatures().get(help.getActiveSignature()).getLabel(), "foo(int s, String s) : int");
+
+	}
+
+	@Test
+	public void testSignatureHelp_binary() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("   public int bar(String s) { System.out.println(  }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		SignatureHelp help = getSignatureHelp(cu, 2, 50);
+		assertNotNull(help);
+		assertTrue(help.getSignatures().size() >= 10);
+		assertTrue(help.getSignatures().get(help.getActiveSignature()).getLabel().matches("println\\(\\w+ \\w+\\) : void"));
+	}
+
+	private SignatureHelp getSignatureHelp(ICompilationUnit cu, int line, int character) {
+		String payload = createSignatureHelpRequest(cu, line, character);
+		TextDocumentPositionParams position = getParams(payload);
+		return handler.signatureHelp(position, monitor);
+	}
+
+	String createSignatureHelpRequest(ICompilationUnit cu, int line, int kar) {
+		URI uri = cu.getResource().getRawLocationURI();
+		return createSignatureHelpRequest(uri, line, kar);
+	}
+
+	String createSignatureHelpRequest(URI file, int line, int kar) {
+		String fileURI = ResourceUtils.fixURI(file);
+		return HOVER_TEMPLATE.replace("${file}", fileURI).replace("${line}", String.valueOf(line)).replace("${char}", String.valueOf(kar));
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -14,10 +14,11 @@ import static org.eclipse.jdt.ls.core.internal.JsonMessageHelper.getParams;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.net.URI;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -26,12 +27,16 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.junit.Before;
 import org.junit.Test;
 
 public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
+
+	private PreferenceManager preferenceManager;
 
 	private static String HOVER_TEMPLATE =
 			"{\n" +
@@ -51,8 +56,6 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	private SignatureHelpHandler handler;
 
-	private IProject project;
-
 	private IPackageFragmentRoot sourceFolder;
 
 	@Override
@@ -62,7 +65,11 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		project = WorkspaceHelper.getProject("hello");
 		IJavaProject javaProject = JavaCore.create(project);
 		sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
-		handler = new SignatureHelpHandler();
+		preferenceManager = mock(PreferenceManager.class);
+		Preferences p = mock(Preferences.class);
+		when(preferenceManager.getPreferences(null)).thenReturn(p);
+		when(p.isSignatureHelpEnabled()).thenReturn(true);
+		handler = new SignatureHelpHandler(preferenceManager);
 	}
 
 	@Test


### PR DESCRIPTION
SignatureHelp UI: 
![signaturehelp](https://user-images.githubusercontent.com/6461412/27845818-084a805a-6165-11e7-967f-593f0771f97c.gif)
(Example for TypeScript)

Current provide active parameter and active signature based on parameter number without type context information yet. 

Fixes #12