### PR TITLE
Add support for renaming.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/RenameProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/RenameProcessor.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.refactoring.code;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.TextEditConverter;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.eclipse.text.edits.TextEdit;
+
+public class RenameProcessor {
+
+	public void renameOccurrences(WorkspaceEdit edit, IJavaElement element, String newName, IProgressMonitor monitor) throws JavaModelException, CoreException {
+		if (element == null || !canRename(element)) {
+			return;
+		}
+
+		int oldNameLen = element.getElementName().length();
+
+		SearchPattern pattern = SearchPattern.createPattern(element, IJavaSearchConstants.ALL_OCCURRENCES);
+		SearchEngine engine = new SearchEngine();
+		engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, createSearchScope(), new SearchRequestor() {
+
+			@Override
+			public void acceptSearchMatch(SearchMatch match) throws CoreException {
+				Object o = match.getElement();
+				if (o instanceof IJavaElement) {
+					IJavaElement element = (IJavaElement) o;
+					ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
+					if (compilationUnit == null) {
+						return;
+					}
+					TextEdit repalceEdit = new ReplaceEdit(match.getOffset(), oldNameLen, newName);
+					convert(edit, compilationUnit, repalceEdit);
+					// Location location = JDTUtils.toLocation(compilationUnit, match.getOffset(), match.getLength());
+					// result.add(match);
+				}
+			}
+		}, monitor);
+
+	}
+
+	private void convert(WorkspaceEdit root, ICompilationUnit unit, TextEdit edits) {
+		TextEditConverter converter = new TextEditConverter(unit, edits);
+		String uri = JDTUtils.getFileURI(unit);
+		Map<String, List<org.eclipse.lsp4j.TextEdit>> changes = root.getChanges();
+		if (changes.containsKey(uri)) {
+			changes.get(uri).addAll(converter.convert());
+		} else {
+			root.getChanges().put(uri, converter.convert());
+		}
+	}
+
+	private IJavaSearchScope createSearchScope() throws JavaModelException {
+		IJavaProject[] projects = JavaCore.create(ResourcesPlugin.getWorkspace().getRoot()).getJavaProjects();
+		return SearchEngine.createJavaSearchScope(projects, IJavaSearchScope.SOURCES);
+	}
+
+	private boolean canRename(IJavaElement element) {
+		if (element instanceof IPackageFragment) {
+			return false;
+		}
+		ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
+		return compilationUnit != null;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -16,7 +16,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
@@ -28,7 +27,7 @@ public class RenameTypeProcessor extends RenameProcessor {
 	}
 
 	@Override
-	public void renameOccurrences(WorkspaceEdit edit, String newName, IProgressMonitor monitor) throws JavaModelException, CoreException {
+	public void renameOccurrences(WorkspaceEdit edit, String newName, IProgressMonitor monitor) throws CoreException {
 		super.renameOccurrences(edit, newName, monitor);
 
 		IType t = (IType) fElement;
@@ -36,7 +35,7 @@ public class RenameTypeProcessor extends RenameProcessor {
 
 		for (IMethod method : methods) {
 			if (method.isConstructor()) {
-				TextEdit replaceEdit = new ReplaceEdit(method.getNameRange().getOffset(), method.getElementName().length(), newName);
+				TextEdit replaceEdit = new ReplaceEdit(method.getNameRange().getOffset(), method.getNameRange().getLength(), newName);
 				convert(edit, t.getCompilationUnit(), replaceEdit);
 			}
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.refactoring.rename;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.eclipse.text.edits.TextEdit;
+
+public class RenameTypeProcessor extends RenameProcessor {
+
+	public RenameTypeProcessor(IJavaElement selectedElement) {
+		super(selectedElement);
+	}
+
+	@Override
+	public void renameOccurrences(WorkspaceEdit edit, String newName, IProgressMonitor monitor) throws JavaModelException, CoreException {
+		super.renameOccurrences(edit, newName, monitor);
+
+		IType t = (IType) fElement;
+		IMethod[] methods = t.getMethods();
+
+		for (IMethod method : methods) {
+			if (method.isConstructor()) {
+				TextEdit replaceEdit = new ReplaceEdit(method.getNameRange().getOffset(), method.getElementName().length(), newName);
+				convert(edit, t.getCompilationUnit(), replaceEdit);
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RippleMethodFinder.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RippleMethodFinder.java
@@ -1,0 +1,400 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Code copied from org.eclipse.jdt.internal.corext.refactoring.rename.RippleMethodFinder2
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.refactoring.rename;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IRegion;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.corext.util.JdtFlags;
+
+public class RippleMethodFinder {
+
+	private final IMethod fMethod;
+	private List<IMethod> fDeclarations;
+	private ITypeHierarchy fHierarchy;
+	private Map<IType, IMethod> fTypeToMethod;
+	private Set<IType> fRootTypes;
+	private MultiMap<IType, IType> fRootReps;
+	private Map<IType, ITypeHierarchy> fRootHierarchies;
+	private UnionFind fUnionFind;
+
+	private static class MultiMap<K, V> {
+		HashMap<K, Collection<V>> fImplementation = new HashMap<>();
+
+		public void put(K key, V value) {
+			Collection<V> collection = fImplementation.get(key);
+			if (collection == null) {
+				collection = new HashSet<>();
+				fImplementation.put(key, collection);
+			}
+			collection.add(value);
+		}
+
+		public Collection<V> get(K key) {
+			return fImplementation.get(key);
+		}
+	}
+
+	private static class UnionFind {
+		HashMap<IType, IType> fElementToRepresentative = new HashMap<>();
+
+		public void init(IType type) {
+			fElementToRepresentative.put(type, type);
+		}
+
+		//path compression:
+		public IType find(IType element) {
+			IType root = element;
+			IType rep = fElementToRepresentative.get(root);
+			while (rep != null && !rep.equals(root)) {
+				root = rep;
+				rep = fElementToRepresentative.get(root);
+			}
+			if (rep == null) {
+				return null;
+			}
+
+			rep = fElementToRepresentative.get(element);
+			while (!rep.equals(root)) {
+				IType temp = element;
+				element = rep;
+				fElementToRepresentative.put(temp, root);
+				rep = fElementToRepresentative.get(element);
+			}
+			return root;
+		}
+
+		public void union(IType rep1, IType rep2) {
+			fElementToRepresentative.put(rep1, rep2);
+		}
+	}
+
+
+	private RippleMethodFinder(IMethod method) {
+		fMethod = method;
+	}
+
+	public static IMethod[] getRelatedMethods(IMethod method, IProgressMonitor pm, WorkingCopyOwner owner) throws CoreException {
+		try {
+			if (!isVirtual(method)) {
+				return new IMethod[]{ method };
+			}
+
+			return new RippleMethodFinder(method).getAllRippleMethods(pm, owner);
+		} finally {
+			pm.done();
+		}
+	}
+
+	private static boolean isVirtual(IMethod method) throws JavaModelException {
+		if (method.isConstructor()) {
+			return false;
+		}
+		if (JdtFlags.isPrivate(method)) {
+			return false;
+		}
+		if (JdtFlags.isStatic(method)) {
+			return false;
+		}
+		return true;
+	}
+
+	private IMethod[] getAllRippleMethods(IProgressMonitor pm, WorkingCopyOwner owner) throws CoreException {
+		IMethod[] rippleMethods = findAllRippleMethods(pm, owner);
+		return rippleMethods;
+	}
+
+	private IMethod[] findAllRippleMethods(IProgressMonitor pm, WorkingCopyOwner owner) throws CoreException {
+		pm.beginTask("", 4); //$NON-NLS-1$
+
+		findAllDeclarations(pm, owner);
+
+		//TODO: report assertion as error status and fall back to only return fMethod
+		//check for bug 81058:
+		if (!fDeclarations.contains(fMethod))
+		 {
+			Assert.isTrue(false, "Search for method declaration did not find original element: " + fMethod.toString()); //$NON-NLS-1$
+		}
+
+		createHierarchyOfDeclarations(new SubProgressMonitor(pm, 1), owner);
+		createTypeToMethod();
+		createUnionFind();
+		if (pm.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+
+		fHierarchy = null;
+		fRootTypes = null;
+
+		Map<IType, List<IType>> partitioning = new HashMap<>();
+		for (Iterator<IType> iter = fTypeToMethod.keySet().iterator(); iter.hasNext();) {
+			IType type = iter.next();
+			IType rep = fUnionFind.find(type);
+			List<IType> types = partitioning.get(rep);
+			if (types == null) {
+				types = new ArrayList<>();
+			}
+			types.add(type);
+			partitioning.put(rep, types);
+		}
+		Assert.isTrue(partitioning.size() > 0);
+		if (partitioning.size() == 1) {
+			return fDeclarations.toArray(new IMethod[fDeclarations.size()]);
+		}
+
+		//Multiple partitions; must look out for nasty marriage cases
+		//(types inheriting method from two ancestors, but without redeclaring it).
+		IType methodTypeRep = fUnionFind.find(fMethod.getDeclaringType());
+		List<IType> relatedTypes = partitioning.get(methodTypeRep);
+		boolean hasRelatedInterfaces = false;
+		List<IMethod> relatedMethods = new ArrayList<>();
+		for (Iterator<IType> iter = relatedTypes.iterator(); iter.hasNext();) {
+			IType relatedType = iter.next();
+			relatedMethods.add(fTypeToMethod.get(relatedType));
+			if (relatedType.isInterface()) {
+				hasRelatedInterfaces = true;
+			}
+		}
+
+		//Definition: An alien type is a type that is not a related type. The set of
+		// alien types diminishes as new types become related (a.k.a marry a relatedType).
+
+		List<IMethod> alienDeclarations = new ArrayList<>(fDeclarations);
+		fDeclarations = null;
+		alienDeclarations.removeAll(relatedMethods);
+		List<IType> alienTypes = new ArrayList<>();
+		boolean hasAlienInterfaces = false;
+		for (Iterator<IMethod> iter = alienDeclarations.iterator(); iter.hasNext();) {
+			IMethod alienDeclaration = iter.next();
+			IType alienType = alienDeclaration.getDeclaringType();
+			alienTypes.add(alienType);
+			if (alienType.isInterface()) {
+				hasAlienInterfaces= true;
+			}
+		}
+		if (alienTypes.size() == 0) {
+			return relatedMethods.toArray(new IMethod[relatedMethods.size()]);
+		}
+		if (!hasRelatedInterfaces && !hasAlienInterfaces) {
+			return relatedMethods.toArray(new IMethod[relatedMethods.size()]);
+		}
+
+		//find all subtypes of related types:
+		HashSet<IType> relatedSubTypes = new HashSet<>();
+		List<IType> relatedTypesToProcess = new ArrayList<>(relatedTypes);
+		while (relatedTypesToProcess.size() > 0) {
+			//TODO: would only need subtype hierarchies of all top-of-ripple relatedTypesToProcess
+			for (Iterator<IType> iter = relatedTypesToProcess.iterator(); iter.hasNext();) {
+				if (pm.isCanceled()) {
+					throw new OperationCanceledException();
+				}
+				IType relatedType = iter.next();
+				ITypeHierarchy hierarchy = getCachedHierarchy(relatedType, owner, new SubProgressMonitor(pm, 1));
+				if (hierarchy == null) {
+					hierarchy = relatedType.newTypeHierarchy(owner, new SubProgressMonitor(pm, 1));
+				}
+				IType[] allSubTypes = hierarchy.getAllSubtypes(relatedType);
+				for (int i = 0; i < allSubTypes.length; i++) {
+					relatedSubTypes.add(allSubTypes[i]);
+				}
+			}
+			relatedTypesToProcess.clear(); //processed; make sure loop terminates
+
+			HashSet<IType> marriedAlienTypeReps = new HashSet<>();
+			for (Iterator<IType> iter = alienTypes.iterator(); iter.hasNext();) {
+				if (pm.isCanceled()) {
+					throw new OperationCanceledException();
+				}
+				IType alienType = iter.next();
+				IMethod alienMethod = fTypeToMethod.get(alienType);
+				ITypeHierarchy hierarchy = getCachedHierarchy(alienType, owner, new SubProgressMonitor(pm, 1));
+				if (hierarchy == null) {
+					hierarchy = alienType.newTypeHierarchy(owner, new SubProgressMonitor(pm, 1));
+				}
+				IType[] allSubtypes = hierarchy.getAllSubtypes(alienType);
+				for (int i = 0; i < allSubtypes.length; i++) {
+					IType subtype = allSubtypes[i];
+					if (relatedSubTypes.contains(subtype)) {
+						if (JavaModelUtil.isVisibleInHierarchy(alienMethod, subtype.getPackageFragment())) {
+							marriedAlienTypeReps.add(fUnionFind.find(alienType));
+						} else {
+							// not overridden
+						}
+					}
+				}
+			}
+
+			if (marriedAlienTypeReps.size() == 0) {
+				return relatedMethods.toArray(new IMethod[relatedMethods.size()]);
+			}
+
+			for (Iterator<IType> iter = marriedAlienTypeReps.iterator(); iter.hasNext();) {
+				IType marriedAlienTypeRep = iter.next();
+				List<IType> marriedAlienTypes = partitioning.get(marriedAlienTypeRep);
+				for (Iterator<IType> iterator = marriedAlienTypes.iterator(); iterator.hasNext();) {
+					IType marriedAlienInterfaceType = iterator.next();
+					relatedMethods.add(fTypeToMethod.get(marriedAlienInterfaceType));
+				}
+				alienTypes.removeAll(marriedAlienTypes); //not alien any more
+				relatedTypesToProcess.addAll(marriedAlienTypes); //process freshly married types again
+			}
+		}
+
+		fRootReps = null;
+		fRootHierarchies = null;
+		fTypeToMethod = null;
+		fUnionFind = null;
+
+		return relatedMethods.toArray(new IMethod[relatedMethods.size()]);
+	}
+
+	private ITypeHierarchy getCachedHierarchy(IType type, WorkingCopyOwner owner, IProgressMonitor monitor) throws JavaModelException {
+		IType rep = fUnionFind.find(type);
+		if (rep != null) {
+			Collection<IType> collection = fRootReps.get(rep);
+			for (Iterator<IType> iter = collection.iterator(); iter.hasNext();) {
+				IType root = iter.next();
+				ITypeHierarchy hierarchy = fRootHierarchies.get(root);
+				if (hierarchy == null) {
+					hierarchy = root.newTypeHierarchy(owner, new SubProgressMonitor(monitor, 1));
+					fRootHierarchies.put(root, hierarchy);
+				}
+				if (hierarchy.contains(type)) {
+					return hierarchy;
+				}
+			}
+		}
+		return null;
+	}
+
+	private void findAllDeclarations(IProgressMonitor monitor, WorkingCopyOwner owner) throws CoreException {
+		fDeclarations = new ArrayList<>();
+
+		class MethodRequestor extends SearchRequestor {
+			@Override
+			public void acceptSearchMatch(SearchMatch match) throws CoreException {
+				IMethod method = (IMethod) match.getElement();
+				boolean isBinary = method.isBinary();
+				if (!isBinary) {
+					fDeclarations.add(method);
+				}
+			}
+		}
+
+		int limitTo = IJavaSearchConstants.DECLARATIONS | IJavaSearchConstants.IGNORE_DECLARING_TYPE | IJavaSearchConstants.IGNORE_RETURN_TYPE;
+		int matchRule = SearchPattern.R_ERASURE_MATCH | SearchPattern.R_CASE_SENSITIVE;
+		SearchPattern pattern = SearchPattern.createPattern(fMethod, limitTo, matchRule);
+		MethodRequestor requestor = new MethodRequestor();
+		SearchEngine searchEngine = owner != null ? new SearchEngine(owner) : new SearchEngine();
+
+		searchEngine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, createSearchScope(), requestor, monitor);
+	}
+
+	private void createHierarchyOfDeclarations(IProgressMonitor pm, WorkingCopyOwner owner) throws JavaModelException {
+		IRegion region = JavaCore.newRegion();
+		for (Iterator<IMethod> iter = fDeclarations.iterator(); iter.hasNext();) {
+			IType declaringType = iter.next().getDeclaringType();
+			region.add(declaringType);
+		}
+		fHierarchy = JavaCore.newTypeHierarchy(region, owner, pm);
+	}
+
+	private void createTypeToMethod() {
+		fTypeToMethod = new HashMap<>();
+		for (Iterator<IMethod> iter = fDeclarations.iterator(); iter.hasNext();) {
+			IMethod declaration = iter.next();
+			fTypeToMethod.put(declaration.getDeclaringType(), declaration);
+		}
+	}
+
+	private void createUnionFind() throws JavaModelException {
+		fRootTypes = new HashSet<>(fTypeToMethod.keySet());
+		fUnionFind = new UnionFind();
+		for (Iterator<IType> iter = fTypeToMethod.keySet().iterator(); iter.hasNext();) {
+			IType type = iter.next();
+			fUnionFind.init(type);
+		}
+		for (Iterator<IType> iter = fTypeToMethod.keySet().iterator(); iter.hasNext();) {
+			IType type = iter.next();
+			uniteWithSupertypes(type, type);
+		}
+		fRootReps = new MultiMap<>();
+		for (Iterator<IType> iter = fRootTypes.iterator(); iter.hasNext();) {
+			IType type = iter.next();
+			IType rep = fUnionFind.find(type);
+			if (rep != null) {
+				fRootReps.put(rep, type);
+			}
+		}
+		fRootHierarchies = new HashMap<>();
+	}
+
+	private void uniteWithSupertypes(IType anchor, IType type) throws JavaModelException {
+		IType[] supertypes = fHierarchy.getSupertypes(type);
+		for (int i = 0; i < supertypes.length; i++) {
+			IType supertype = supertypes[i];
+			IType superRep = fUnionFind.find(supertype);
+			if (superRep == null) {
+				//Type doesn't declare method, but maybe supertypes?
+				uniteWithSupertypes(anchor, supertype);
+			} else {
+				//check whether method in supertype is really overridden:
+				IMember superMethod = fTypeToMethod.get(supertype);
+				if (JavaModelUtil.isVisibleInHierarchy(superMethod, anchor.getPackageFragment())) {
+					IType rep = fUnionFind.find(anchor);
+					fUnionFind.union(rep, superRep);
+					// current type is no root anymore
+					fRootTypes.remove(anchor);
+					uniteWithSupertypes(supertype, supertype);
+				} else {
+					//Not overridden -> overriding chain ends here.
+				}
+			}
+		}
+	}
+
+	private IJavaSearchScope createSearchScope() throws JavaModelException {
+		IJavaProject[] projects = JavaCore.create(ResourcesPlugin.getWorkspace().getRoot()).getJavaProjects();
+		return SearchEngine.createJavaSearchScope(projects, IJavaSearchScope.SOURCES);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -102,6 +102,9 @@ final public class InitHandler {
 		if (!preferenceManager.getClientPreferences().isSignatureHelpDynamicRegistrationSupported()) {
 			capabilities.setSignatureHelpProvider(SignatureHelpHandler.createOptions());
 		}
+		if (!preferenceManager.getClientPreferences().isRenameDynamicRegistrationSupported()) {
+			capabilities.setRenameProvider(Boolean.TRUE);
+		}
 		capabilities.setCodeActionProvider(Boolean.TRUE);
 		result.setCapabilities(capabilities);
 		return result;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -219,6 +219,13 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 				unregisterCapability(Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP);
 			}
 		}
+		if (preferenceManager.getClientPreferences().isRenameDynamicRegistrationSupported()) {
+			if (preferenceManager.getPreferences().isRenameEnabled()) {
+				registerCapability(Preferences.RENAME_ID, Preferences.TEXT_DOCUMENT_RENAME);
+			} else {
+				unregisterCapability(Preferences.RENAME_ID, Preferences.TEXT_DOCUMENT_RENAME);
+			}
+		}
 		logInfo(">>New configuration: " + settings);
 	}
 
@@ -386,8 +393,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<WorkspaceEdit> rename(RenameParams params) {
 		logInfo(">> document/rename");
-		// Not yet implemented
-		return null;
+		RenameHandler handler = new RenameHandler(preferenceManager);
+		return computeAsync((cc) -> handler.rename(params, toMonitor(cc)));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
@@ -1,0 +1,71 @@
+
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.RenameProcessor;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
+
+public class RenameHandler {
+
+	private PreferenceManager preferenceManager;
+
+	public RenameHandler(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
+	}
+
+	public WorkspaceEdit rename(RenameParams params, IProgressMonitor monitor) {
+		WorkspaceEdit edit = new WorkspaceEdit();
+		if (!preferenceManager.getPreferences().isRenameEnabled()) {
+			return edit;
+		}
+		try {
+			final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
+
+			IJavaElement[] elements = JDTUtils.findElementsAtSelection(unit, params.getPosition().getLine(), params.getPosition().getCharacter());
+			if (elements == null || elements.length == 0) {
+				return edit;
+			}
+			IJavaElement curr = null;
+			if (elements.length != 1) {
+				// they could be package fragments.
+				// We need to select the one that matches the package fragment of the current unit
+				IPackageFragment packageFragment = (IPackageFragment) unit.getParent();
+				IJavaElement found = Stream.of(elements).filter(e -> e.equals(packageFragment)).findFirst().orElse(null);
+				if (found == null) {
+					// this would be a binary package fragment
+					curr = elements[0];
+				} else {
+					curr = found;
+				}
+			} else {
+				curr = elements[0];
+			}
+
+			RenameProcessor processor = new RenameProcessor();
+			processor.renameOccurrences(edit, curr, params.getNewName(), monitor);
+		} catch (Exception ex) {
+
+		}
+
+		return edit;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -58,4 +58,8 @@ public class ClientPreferences {
 	public boolean isSignatureHelpDynamicRegistrationSupported() {
 		return v3supported && capabilities.getTextDocument().getSignatureHelp().getDynamicRegistration();
 	}
+
+	public boolean isRenameDynamicRegistrationSupported() {
+		return v3supported && capabilities.getTextDocument().getRename().getDynamicRegistration();
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -51,6 +51,10 @@ public class Preferences {
 	 */
 	public static final String SIGNATURE_HELP_ENABLED_KEY = "java.signatureHelp.enabled";
 
+	/**
+	 * Preference key to enable/disable rename.
+	 */
+	public static final String RENAME_ENABLED_KEY = "java.rename.enabled";
 
 	/**
 	 * Preference key to exclude directories when importing projects.
@@ -107,11 +111,13 @@ public class Preferences {
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
 	public static final String TEXT_DOCUMENT_SIGNATURE_HELP = "textDocument/signatureHelp";
+	public static final String TEXT_DOCUMENT_RENAME = "textDocument/rename";
 
 	public static final String FORMATTING_ID = UUID.randomUUID().toString();
 	public static final String FORMATTING_RANGE_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
 	public static final String SIGNATURE_HELP_ID = UUID.randomUUID().toString();
+	public static final String RENAME_ID = UUID.randomUUID().toString();
 
 	private Severity incompleteClasspathSeverity;
 	private FeatureStatus updateBuildConfigurationStatus;
@@ -119,6 +125,7 @@ public class Preferences {
 	private boolean implementationsCodeLensEnabled;
 	private boolean javaFormatEnabled;
 	private boolean signatureHelpEnabled;
+	private boolean renameEnabled;
 	private MemberSortOrder memberOrders;
 
 	private String mavenUserSettings;
@@ -181,6 +188,7 @@ public class Preferences {
 		implementationsCodeLensEnabled = false;
 		javaFormatEnabled = true;
 		signatureHelpEnabled = false;
+		renameEnabled = true;
 		memberOrders = new MemberSortOrder(null);
 		favoriteStaticMembers = "";
 		javaImportExclusions = JAVA_IMPORT_EXCLUSIONS_DEFAULT;
@@ -256,6 +264,9 @@ public class Preferences {
 		boolean signatureHelpEnabled = getBooleanValue(configuration, SIGNATURE_HELP_ENABLED_KEY, true);
 		prefs.setSignatureHelpEnabled(signatureHelpEnabled);
 
+		boolean renameEnabled = getBooleanValue(configuration, RENAME_ENABLED_KEY, true);
+		prefs.setRenameEnabled(renameEnabled);
+
 		List<String> javaImportExclusions = getListValue(configuration, JAVA_IMPORT_EXCLUSIONS_KEY, JAVA_IMPORT_EXCLUSIONS_DEFAULT);
 		prefs.setJavaImportExclusions(javaImportExclusions);
 
@@ -293,6 +304,11 @@ public class Preferences {
 
 	private Preferences setImplementationCodelensEnabled(boolean enabled) {
 		this.implementationsCodeLensEnabled = enabled;
+		return this;
+	}
+
+	private Preferences setRenameEnabled(boolean enabled) {
+		this.renameEnabled = enabled;
 		return this;
 	}
 
@@ -350,6 +366,10 @@ public class Preferences {
 
 	public boolean isSignatureHelpEnabled() {
 		return signatureHelpEnabled;
+	}
+
+	public boolean isRenameEnabled() {
+		return renameEnabled;
 	}
 
 	public Preferences setMavenUserSettings(String mavenUserSettings) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -23,9 +23,11 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.TextEditUtil;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -56,13 +58,12 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testRename_parameter() throws JavaModelException {
+	public void testRenameParameter() throws JavaModelException, BadLocationException {
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
 		String[] codes = {
 				"package test1;\n",
 				"public class E {\n",
-				"   /** This is a method */\n",
 				"   public int foo(String str) {\n",
 				"  		str|*.length()\n",
 				"   }\n",
@@ -76,13 +77,23 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
 
 		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+
 		assertNotNull(edit);
 		assertEquals(edit.getChanges().size(), 1);
-		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+
+		assertEquals(TextEditUtil.apply(builder.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))), "package test1;\n" +
+				"public class E {\n" +
+				"   public int foo(String newname) {\n" +
+				"  		newname.length()\n" +
+				"   }\n" +
+				"   public int bar(String str) {\n" +
+				"   	str.length()\n" +
+				"   }\n" +
+				"}\n");
 	}
 
 	@Test
-	public void testRename_localVariable() throws JavaModelException {
+	public void testRenameLocalVariable() throws JavaModelException, BadLocationException {
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
 		String[] codes = {
@@ -105,11 +116,52 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
 		assertNotNull(edit);
 		assertEquals(edit.getChanges().size(), 1);
-		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+		assertEquals(TextEditUtil.apply(builder.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))),
+				"package test1;\n" +
+				"public class E {\n" +
+				"   public int bar() {\n" +
+				"		String str = new String();\n" +
+				"   	str.length();\n" +
+				"   }\n" +
+				"   public int foo() {\n" +
+				"		String newname = new String();\n" +
+				"   	newname.length()\n" +
+				"   }\n" +
+				"}\n");
 	}
 
 	@Test
-	public void testRename_method() throws JavaModelException {
+	public void testRenameField() throws JavaModelException, BadLocationException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes = {
+				"package test1;\n",
+				"public class E {\n",
+				"	private int myValue = 2;\n",
+				"   public void bar() {\n",
+				"		myValue|* = 3;\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builder = new StringBuilder();
+		Position pos = mergeCode(builder, codes);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+		assertEquals(TextEditUtil.apply(builder.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))),
+				"package test1;\n" +
+				"public class E {\n" +
+				"	private int newname = 2;\n" +
+				"   public void bar() {\n" +
+				"		newname = 3;\n" +
+				"   }\n" +
+				"}\n");
+	}
+
+	@Test
+	public void testRenameMethod() throws JavaModelException, BadLocationException {
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
 		String[] codes = {
@@ -129,11 +181,20 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
 		assertNotNull(edit);
 		assertEquals(edit.getChanges().size(), 1);
-		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+		assertEquals(TextEditUtil.apply(builder.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))),
+				"package test1;\n" +
+				"public class E {\n" +
+				"   public int newname() {\n" +
+				"   }\n" +
+				"   public int foo() {\n" +
+				"		this.newname();\n" +
+				"   }\n" +
+				"}\n"
+				);
 	}
 
 	@Test
-	public void testRename_systemLibrary() throws JavaModelException {
+	public void testRenameSystemLibrary() throws JavaModelException {
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
 		String[] codes = {
@@ -155,19 +216,13 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testRename_multipleFiles() throws JavaModelException {
+	public void testRenameMultipleFiles() throws JavaModelException, BadLocationException {
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
 		String[] codes1= {
 				"package test1;\n",
 				"public class A {\n",
-				"   public void bar() {\n",
-				"		String str = new String();\n",
-				"   	str.length();\n",
-				"   }\n",
 				"   public void foo() {\n",
-				"		String str = new String();\n",
-				"   	str.length()\n",
 				"   }\n",
 				"}\n"
 		};
@@ -175,13 +230,60 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 		String[] codes2 = {
 				"package test1;\n",
 				"public class B {\n",
-				"   public void bar() {\n",
-				"		String str = new String();\n",
-				"   	str.length();\n",
-				"   }\n",
 				"   public void foo() {\n",
 				"		A a = new A();\n",
 				"		a.foo|*();\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builderA = new StringBuilder();
+		mergeCode(builderA, codes1);
+		ICompilationUnit cuA = pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+		StringBuilder builderB = new StringBuilder();
+		Position pos = mergeCode(builderB, codes2);
+		ICompilationUnit cuB = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cuB, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 2);
+
+		assertEquals(TextEditUtil.apply(builderA.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuA))),
+				"package test1;\n" +
+				"public class A {\n" +
+				"   public void newname() {\n" +
+				"   }\n" +
+				"}\n"
+				);
+
+		assertEquals(TextEditUtil.apply(builderB.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuB))),
+				"package test1;\n" +
+				"public class B {\n" +
+				"   public void foo() {\n" +
+				"		A a = new A();\n" +
+						"		a.newname();\n" +
+				"   }\n" +
+				"}\n"
+				);
+
+	}
+
+	@Test
+	public void testRenameOverrideMethod() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public class A {\n",
+				"   public void foo(){}\n",
+				"}\n"
+		};
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B extends A {\n",
+				"	@Override\n",
+				"   public void foo|*() {\n",
 				"   }\n",
 				"}\n"
 		};
@@ -197,6 +299,211 @@ public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(edit);
 		assertEquals(edit.getChanges().size(), 2);
 		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 1);
+	}
+
+	@Test
+	public void testRenameInterfaceMethod() throws JavaModelException, BadLocationException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public interface A {\n",
+				"   public void foo();\n",
+				"}\n"
+		};
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B implements A {\n",
+				"	@Override\n",
+				"   public void foo|*() {\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builderA = new StringBuilder();
+		mergeCode(builderA, codes1);
+		ICompilationUnit cuA = pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+		StringBuilder builderB = new StringBuilder();
+		Position pos = mergeCode(builderB, codes2);
+		ICompilationUnit cuB = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cuB, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 2);
+
+		assertEquals(TextEditUtil.apply(builderA.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuA))),
+				"package test1;\n" +
+				"public interface A {\n" +
+				"   public void newname();\n" +
+				"}\n"
+				);
+
+		assertEquals(TextEditUtil.apply(builderB.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuB))),
+				"package test1;\n" +
+				"public class B implements A {\n" +
+				"	@Override\n" +
+				"   public void newname() {\n" +
+				"   }\n" +
+				"}\n"
+				);
+
+	}
+
+	@Test
+	public void testRenameType() throws JavaModelException, BadLocationException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public class A {\n",
+				"   public void foo(){\n",
+				"		B b = new B();\n",
+				"		b.foo();\n",
+				"	}\n",
+				"}\n"
+		};
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B|* {\n",
+				"   public void foo() {}\n",
+				"}\n"
+		};
+		StringBuilder builderA = new StringBuilder();
+		mergeCode(builderA, codes1);
+		ICompilationUnit cuA = pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+		StringBuilder builderB = new StringBuilder();
+		Position pos = mergeCode(builderB, codes2);
+		ICompilationUnit cuB = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cuB, pos, "NewType");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 2);
+
+		assertEquals(TextEditUtil.apply(builderA.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuA))),
+				"package test1;\n" +
+				"public class A {\n" +
+				"   public void foo(){\n" +
+				"		NewType b = new NewType();\n" +
+				"		b.foo();\n" +
+				"	}\n" +
+				"}\n"
+				);
+
+		assertEquals(TextEditUtil.apply(builderB.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuB))),
+				"package test1;\n" +
+				"public class NewType {\n" +
+				"   public void foo() {}\n" +
+				"}\n"
+				);
+	}
+
+	@Test
+	public void testRenameConstructor() throws JavaModelException, BadLocationException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public class A {\n",
+				"   public void foo(){\n",
+				"		B b = new B();\n",
+				"		b.foo();\n",
+				"	}\n",
+				"}\n"
+		};
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B {\n",
+				"   public B|*() {}\n",
+				"   public void foo() {}\n",
+				"}\n"
+		};
+		StringBuilder builderA = new StringBuilder();
+		mergeCode(builderA, codes1);
+		ICompilationUnit cuA = pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+		StringBuilder builderB = new StringBuilder();
+		Position pos = mergeCode(builderB, codes2);
+		ICompilationUnit cuB = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cuB, pos, "NewName");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 2);
+
+		assertEquals(TextEditUtil.apply(builderA.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuA))),
+				"package test1;\n" +
+				"public class A {\n" +
+				"   public void foo(){\n" +
+				"		NewName b = new NewName();\n" +
+				"		b.foo();\n" +
+				"	}\n" +
+				"}\n"
+				);
+
+		assertEquals(TextEditUtil.apply(builderB.toString(), edit.getChanges().get(JDTUtils.getFileURI(cuB))),
+				"package test1;\n" +
+				"public class NewName {\n" +
+				"   public NewName() {}\n" +
+				"   public void foo() {}\n" +
+				"}\n"
+				);
+	}
+
+	@Test
+	public void testRenameTypeParameter() throws JavaModelException, BadLocationException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public class A<T|*> {\n",
+				"	private T t;\n",
+				"	public T get() { return t; }\n",
+				"}\n"
+		};
+
+		StringBuilder builderA = new StringBuilder();
+		Position pos = mergeCode(builderA, codes1);
+		ICompilationUnit cu = pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "TT");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+
+		assertEquals(TextEditUtil.apply(builderA.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))),
+				"package test1;\n" +
+				"public class A<TT> {\n" +
+				"	private TT t;\n" +
+				"	public TT get() { return t; }\n" +
+				"}\n"
+				);
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B<T> {\n",
+				"	private T t;\n",
+				"	public <U|* extends Number> inspect(U u) { return u; }\n",
+				"}\n"
+		};
+
+		StringBuilder builderB = new StringBuilder();
+		pos = mergeCode(builderB, codes2);
+		cu = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		edit = getRenameEdit(cu, pos, "UU");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+
+		assertEquals(TextEditUtil.apply(builderB.toString(), edit.getChanges().get(JDTUtils.getFileURI(cu))),
+				"package test1;\n" +
+				"public class B<T> {\n" +
+				"	private T t;\n" +
+				"	public <UU extends Number> inspect(UU u) { return u; }\n" +
+				"}\n"
+				);
 	}
 
 	private Position mergeCode(StringBuilder builder, String[] codes) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -1,0 +1,221 @@
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RenameHandlerTest extends AbstractCompilationUnitBasedTest {
+
+	private RenameHandler handler;
+
+	private PreferenceManager preferenceManager;
+
+	private IPackageFragmentRoot sourceFolder;
+
+	@Override
+	@Before
+	public void setup() throws Exception {
+		importProjects("eclipse/hello");
+		project = WorkspaceHelper.getProject("hello");
+		IJavaProject javaProject = JavaCore.create(project);
+		sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
+		preferenceManager = mock(PreferenceManager.class);
+		Preferences p = mock(Preferences.class);
+		when(preferenceManager.getPreferences()).thenReturn(p);
+		when(p.isRenameEnabled()).thenReturn(true);
+		handler = new RenameHandler(preferenceManager);
+	}
+
+	@Test
+	public void testRename_parameter() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes = {
+				"package test1;\n",
+				"public class E {\n",
+				"   /** This is a method */\n",
+				"   public int foo(String str) {\n",
+				"  		str|*.length()\n",
+				"   }\n",
+				"   public int bar(String str) {\n",
+				"   	str.length()\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builder = new StringBuilder();
+		Position pos = mergeCode(builder, codes);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+	}
+
+	@Test
+	public void testRename_localVariable() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes = {
+				"package test1;\n",
+				"public class E {\n",
+				"   public int bar() {\n",
+				"		String str = new String();\n",
+				"   	str.length();\n",
+				"   }\n",
+				"   public int foo() {\n",
+				"		String str = new String();\n",
+				"   	str|*.length()\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builder = new StringBuilder();
+		Position pos = mergeCode(builder, codes);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+	}
+
+	@Test
+	public void testRename_method() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes = {
+				"package test1;\n",
+				"public class E {\n",
+				"   public int bar() {\n",
+				"   }\n",
+				"   public int foo() {\n",
+				"		this.bar|*();\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builder = new StringBuilder();
+		Position pos = mergeCode(builder, codes);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 1);
+		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 2);
+	}
+
+	@Test
+	public void testRename_systemLibrary() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes = {
+				"package test1;\n",
+				"public class E {\n",
+				"   public int bar() {\n",
+				"		String str = new String();\n",
+				"   	str.len|*gth();\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builder = new StringBuilder();
+		Position pos = mergeCode(builder, codes);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", builder.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 0);
+	}
+
+	@Test
+	public void testRename_multipleFiles() throws JavaModelException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		String[] codes1= {
+				"package test1;\n",
+				"public class A {\n",
+				"   public void bar() {\n",
+				"		String str = new String();\n",
+				"   	str.length();\n",
+				"   }\n",
+				"   public void foo() {\n",
+				"		String str = new String();\n",
+				"   	str.length()\n",
+				"   }\n",
+				"}\n"
+		};
+
+		String[] codes2 = {
+				"package test1;\n",
+				"public class B {\n",
+				"   public void bar() {\n",
+				"		String str = new String();\n",
+				"   	str.length();\n",
+				"   }\n",
+				"   public void foo() {\n",
+				"		A a = new A();\n",
+				"		a.foo|*();\n",
+				"   }\n",
+				"}\n"
+		};
+		StringBuilder builderA = new StringBuilder();
+		mergeCode(builderA, codes1);
+		pack1.createCompilationUnit("A.java", builderA.toString(), false, null);
+
+		StringBuilder builderB = new StringBuilder();
+		Position pos = mergeCode(builderB, codes2);
+		ICompilationUnit cu = pack1.createCompilationUnit("B.java", builderB.toString(), false, null);
+
+		WorkspaceEdit edit = getRenameEdit(cu, pos, "newname");
+		assertNotNull(edit);
+		assertEquals(edit.getChanges().size(), 2);
+		assertEquals(edit.getChanges().get(JDTUtils.getFileURI(cu)).size(), 1);
+	}
+
+	private Position mergeCode(StringBuilder builder, String[] codes) {
+		Position pos = null;
+		for (int i = 0; i < codes.length; i++) {
+			int ind = codes[i].indexOf("|*");
+			if (ind > 0) {
+				pos = new Position(i, ind);
+				codes[i] = codes[i].replace("|*", "");
+			}
+			builder.append(codes[i]);
+		}
+		return pos;
+	}
+
+	private WorkspaceEdit getRenameEdit(ICompilationUnit cu, Position pos, String newName) {
+		TextDocumentIdentifier identifier = new TextDocumentIdentifier(JDTUtils.getFileURI(cu));
+
+		RenameParams params = new RenameParams(identifier, pos, newName);
+		return handler.rename(params, monitor);
+	}
+}


### PR DESCRIPTION
@fbricon @gorkem @aeschli 

The basic rename support for java: supports methods/variable/parameter/classname. Not support package rename.  
1. For the main type, since VSCode protocol don't support rename file, it is not the same as eclipse implementation which will rename file also. 
2. Package rename is not supported since it should also rename lots of files/folders. 
3. Currently, rename only failed silently for not supported scenarios. 

https://github.com/redhat-developer/vscode-java/issues/71