### PR TITLE
Fix bundle resolve issue when installing

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BundleUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BundleUtils.java
@@ -62,6 +62,7 @@ public class BundleUtils {
 					bundle.update();
 				} else {
 					bundle = context.installBundle(location);
+					bundle.start(Bundle.START_ACTIVATION_POLICY);
 				}
 			} catch (BundleException e) {
 				status.add(new Status(IStatus.ERROR, context.getBundle().getSymbolicName(), "Install bundle failure " + bundleLocation, e));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/BundleUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/BundleUtilsTest.java
@@ -46,9 +46,8 @@ public class BundleUtilsTest extends AbstractProjectsManagerBasedTest {
 		BundleContext context = JavaLanguageServerPlugin.getBundleContext();
 		Bundle installedBundle = context.getBundle(bundleLocation);
 		assertNotNull(installedBundle);
-		assertEquals(installedBundle.getState(), Bundle.INSTALLED);
+		assertEquals(installedBundle.getState(), Bundle.STARTING);
 
-		installedBundle.start();
 		String extResult = getBundleExtensionResult();
 		assertEquals("EXT_TOSTRING", extResult);
 		// Uninstall the bundle to clean up the testing bundle context.
@@ -63,9 +62,8 @@ public class BundleUtilsTest extends AbstractProjectsManagerBasedTest {
 		BundleContext context = JavaLanguageServerPlugin.getBundleContext();
 		Bundle installedBundle = context.getBundle(bundleLocation);
 		assertNotNull(installedBundle);
-		assertEquals(installedBundle.getState(), Bundle.INSTALLED);
+		assertEquals(installedBundle.getState(), Bundle.STARTING);
 
-		installedBundle.start();
 		String extResult = getBundleExtensionResult();
 		assertEquals("EXT_TOSTRING", extResult);
 		// Uninstall the bundle to clean up the testing bundle context.


### PR DESCRIPTION
Signed-off-by: Yaohai Zheng <yaozheng@microsoft.com>

When the bundle is installed the first time, it is not automatically resolved the bundle. Calling the lazy activation according to this link: https://www.osgi.org/developer/design/lazy-start/

@aeschli @gorkem @fbricon 