### PR TITLE
Use *real* URI to find resources

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.lsp4j,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.xtend.lib,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.core.filesystem;bundle-version="1.7.0"
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.contentassist;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.handlers;x-friends:="org.eclipse.jdt.ls.tests",

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -534,6 +535,15 @@ public final class JDTUtils {
 			return null;
 		}
 		IFile[] resources = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(uri);
+		if (resources.length == 0) {
+			//On Mac, Linked resources are referenced via the "real" URI, i.e file://USERS/username/...
+			//instead of file://Users/username/..., so we check against that real URI.
+			URI realUri = FileUtil.realURI(uri);
+			if (!uri.equals(realUri)) {
+				uri = realUri;
+				resources = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(uri);
+			}
+		}
 		if (resources.length == 0 && Platform.OS_WIN32.equals(Platform.getOS()) && uri.toString().startsWith(ResourceUtils.FILE_UNC_PREFIX)) {
 			String uriString = uri.toString();
 			int index = uriString.indexOf(PATH_SEPARATOR, ResourceUtils.FILE_UNC_PREFIX.length());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JDTUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JDTUtilsTest.java
@@ -97,8 +97,8 @@ public class JDTUtilsTest extends AbstractWorkspaceTest {
 		assertEquals(2, elements.length);
 		assertTrue(IPackageDeclaration.class.isAssignableFrom(elements[0].getClass()));
 		assertTrue(IType.class.isAssignableFrom(elements[1].getClass()));
-
 		assertTrue(cu.getResource().isLinked());
+		assertEquals(cu.getResource(), JDTUtils.findFile(uri));
 
 		uri = helloSrcRoot.resolve("NoPackage.java").toUri();
 		cu = JDTUtils.resolveCompilationUnit(uri.toString());


### PR DESCRIPTION
Fixes #388

This fixes the issue described in https://github.com/eclipse/eclipse.jdt.ls/pull/356#issuecomment-332025615

~~However, with these changes, DocumentLifeCycleHandlerTest.testNotExpectedPackage() and 
DocumentLifeCycleHandlerTest.testNotExpectedPackage2() fail on Mac, need to let the CI build this PR so we can see how Linux behaves.~~ fixed

Signed-off-by: Fred Bricon <fbricon@gmail.com>