### PR TITLE
Add organize imports

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -49,4 +49,10 @@
             cacheable="true">
       </contentProvider>
    </extension>
+   <extension
+         point="org.eclipse.jdt.ls.core.delegateCommandHandler">
+      <delegateCommandHandler class="org.eclipse.jdt.ls.core.internal.JDTDelegateCommandHandler">
+            <command id="java.edit.organizeImports"/>
+      </delegateCommandHandler>
+   </extension>
 </plugin>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ImportTextEditConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ImportTextEditConverter.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.text.edits.MoveSourceEdit;
+import org.eclipse.text.edits.TextEdit;
+
+public class ImportTextEditConverter extends TextEditConverter {
+
+	public ImportTextEditConverter(ICompilationUnit unit, TextEdit edit) {
+		super(unit, edit);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.text.edits.TextEditVisitor#visit(org.eclipse.text.edits.DeleteEdit)
+	 */
+	@Override
+	public boolean visit(MoveSourceEdit edit) {
+		try {
+			org.eclipse.lsp4j.TextEdit te = new org.eclipse.lsp4j.TextEdit();
+			te.setNewText("");
+			te.setRange(JDTUtils.toRange(compilationUnit, edit.getOffset(), edit.getLength()));
+			converted.add(te);
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException("Error converting TextEdits", e);
+		}
+		return super.visit(edit);
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.ls.core.internal.corext.codemanipulation.OrganizeImportsOperation;
+import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.ltk.core.refactoring.TextChange;
+import org.eclipse.text.edits.TextEdit;
+
+public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.IDelegateCommandHandler#executeCommand(java.lang.String, java.util.List, org.eclipse.core.runtime.IProgressMonitor)
+	 */
+	@Override
+	public Object executeCommand(String commandId, List<Object> arguments, IProgressMonitor monitor) throws Exception {
+		if (!StringUtils.isBlank(commandId)) {
+			switch (commandId) {
+				case "java.edit.organizeImports":
+					return organizeImports(arguments);
+				default:
+					break;
+			}
+		}
+		throw new UnsupportedOperationException(String.format("Java language server doesn't support the command '%s'.", commandId));
+	}
+
+	public Object organizeImports(List<Object> arguments) {
+		String fileUri = (String) arguments.get(0);
+		if (JDTUtils.toURI(fileUri) != null) {
+			final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(fileUri);
+			return organizeImports(unit);
+		}
+
+		return new WorkspaceEdit();
+	}
+
+	public WorkspaceEdit organizeImports(ICompilationUnit unit) {
+		try {
+			if (unit == null) {
+				return new WorkspaceEdit();
+			}
+
+			InnovationContext context = new InnovationContext(unit, 0, unit.getBuffer().getLength() - 1);
+			CUCorrectionProposal proposal = new CUCorrectionProposal("OrganizeImports", unit, IProposalRelevance.ORGANIZE_IMPORTS) {
+				@Override
+				protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
+					CompilationUnit astRoot = context.getASTRoot();
+					OrganizeImportsOperation op = new OrganizeImportsOperation(unit, astRoot, true, false, true, null);
+					editRoot.addChild(op.createTextEdit(null));
+				}
+			};
+
+			return getWorkspaceEdit(proposal, unit);
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logException("Problem organize imports ", e);
+		}
+		return new WorkspaceEdit();
+	}
+
+	private WorkspaceEdit getWorkspaceEdit(CUCorrectionProposal proposal, ICompilationUnit cu) throws CoreException {
+		TextChange textChange = proposal.getTextChange();
+		TextEdit edit = textChange.getEdit();
+		TextEditConverter converter = new ImportTextEditConverter(cu, edit);
+		WorkspaceEdit $ = new WorkspaceEdit();
+		$.getChanges().put(JDTUtils.getFileURI(cu), converter.convert());
+		return $;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/TextEditConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/TextEditConverter.java
@@ -36,8 +36,8 @@ import org.eclipse.text.edits.TextEditVisitor;
 public class TextEditConverter extends TextEditVisitor{
 
 	private final TextEdit source;
-	private final ICompilationUnit compilationUnit;
-	private final List<org.eclipse.lsp4j.TextEdit> converted;
+	protected ICompilationUnit compilationUnit;
+	protected List<org.eclipse.lsp4j.TextEdit> converted;
 
 	public TextEditConverter(ICompilationUnit unit, TextEdit edit) {
 		this.source = edit;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/codemanipulation/OrganizeImportsOperation.java
@@ -536,6 +536,7 @@ public class OrganizeImportsOperation {
 			}
 
 			ImportRewrite importsRewrite= StubUtility.createImportRewrite(astRoot, false);
+			importsRewrite.setImportOrder(new String[] { "java", "javax", "com", "org" });
 
 			Set<String> oldSingleImports= new HashSet<>();
 			Set<String>  oldDemandImports= new HashSet<>();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandlerTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JDTDelegateCommandHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	private JDTDelegateCommandHandler handler = new JDTDelegateCommandHandler();
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testOrganizeImportsUnused() throws CoreException, BadLocationException {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		assertEquals(getOrganizeImportResult(cu, handler.organizeImports(cu)), buf.toString());
+	}
+
+	@Test
+	public void testOrganizeImportsSort() throws CoreException, BadLocationException {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		assertEquals(getOrganizeImportResult(cu, handler.organizeImports(cu)), buf.toString());
+	}
+
+	@Test
+	public void testOrganizeImportsAutomaticallyResolve() throws CoreException, BadLocationException {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		assertEquals(getOrganizeImportResult(cu, handler.organizeImports(cu)), buf.toString());
+	}
+
+	private String getOrganizeImportResult(ICompilationUnit cu, WorkspaceEdit we) throws BadLocationException, CoreException {
+		Iterator<Entry<String, List<TextEdit>>> editEntries = we.getChanges().entrySet().iterator();
+		Entry<String, List<TextEdit>> entry = editEntries.next();
+		assertNotNull("No edits generated", entry);
+		assertEquals("More than one resource modified", false, editEntries.hasNext());
+
+		Document doc = new Document();
+		doc.set(cu.getSource());
+
+		return TextEditUtil.apply(doc, entry.getValue());
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yaohai Zheng <yaozheng@microsoft.com>

@fbricon @gorkem @aeschli 

This is the proposed changes for "Organize Imports". However, the change is still buggy. And there is another import related bug: https://github.com/redhat-developer/vscode-java/issues/253

It's hard to track the root cause for the issue of misalignment of change between JDT'textedit and vscode's workspace edit. Any insight on this issue? 