### PR TITLE
improve startup performance for gradle projects in workspace

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -10,10 +10,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.buildship.core.configuration.GradleProjectNature;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -56,6 +60,11 @@ public final class ProjectUtils {
 		IJavaProject javaProject = JavaCore.create(project);
 		Map<String, String> options = javaProject.getOptions(true);
 		return options.get(JavaCore.COMPILER_SOURCE);
+	}
+
+	public static List<IProject> getGradleProjects() {
+		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+		return Stream.of(projects).filter(ProjectUtils::isGradleProject).collect(Collectors.toList());
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;


### PR DESCRIPTION
Fixes #451 

Buildship creates project's preferences and saves them in Eclipse. It uses those preferences when opening a project in Eclipse which doesn't work in Java LS because buildship, for some reason, saves the preferences in the o.e.buildship.ui plugin that isn't used in Java LS. This PR fixes the issue. 

It also works the following:

- disables autorefresh (it is off, by default, in Eclipse)
- saves the workspace properly when stopping Java LS so that the workspace isn't refreshed unless necessary

Opening the sagan project (https://github.com/spring-io/sagan) takes 40+ seconds on my machine. After applying the PR, it takes a few seconds to open it when doing that the second time.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>