### PR TITLE
Remove parent process checks

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executors;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.internal.net.ProxySelector;
 import org.eclipse.core.net.proxy.IProxyData;
@@ -235,7 +236,11 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 	private void startConnection() throws IOException {
 		protocol = new JDTLanguageServer(projectsManager, preferenceManager);
 		ConnectionStreamFactory connectionFactory = new ConnectionStreamFactory();
-		Launcher<JavaLanguageClient> launcher = Launcher.createLauncher(protocol, JavaLanguageClient.class, connectionFactory.getInputStream(), connectionFactory.getOutputStream());
+		Launcher<JavaLanguageClient> launcher = Launcher.createLauncher(protocol,
+																		JavaLanguageClient.class,
+																		connectionFactory.getInputStream(),
+																		connectionFactory.getOutputStream(),
+																		Executors.newCachedThreadPool(), new ParentProcessWatcher(this.languageServer));
 		protocol.connectClient(launcher.getRemoteProxy());
 		launcher.startListening();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServer.java
@@ -16,6 +16,7 @@ import org.eclipse.equinox.app.IApplicationContext;
 public class LanguageServer implements IApplication {
 
   private volatile boolean shutdown;
+  private long parentProcessId;
   private final Object waitLock = new Object();
 
 	@Override
@@ -50,4 +51,15 @@ public class LanguageServer implements IApplication {
       waitLock.notifyAll();
     }
   }
+
+	public void setParentProcessId(long pid) {
+		this.parentProcessId = pid;
+	}
+
+	/**
+	 * @return the parentProcessId
+	 */
+	long getParentProcessId() {
+		return parentProcessId;
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+
+/**
+ * Watches the parent process PID and invokes exit if it is no longer available.
+ * This implementation waits for periods of inactivity to start querying the PIDs.
+ */
+public final class ParentProcessWatcher implements Runnable, Function<MessageConsumer, MessageConsumer>{
+
+	private static final long INACTIVITY_DELAY_SECS = 30 *1000;
+	private static final int POLL_DELAY_SECS = 2;
+	private volatile long lastActivityTime;
+	private final LanguageServer server;
+	private ScheduledFuture<?> task;
+	private ScheduledExecutorService service;
+
+	public ParentProcessWatcher(LanguageServer server ) {
+		this.server = server;
+		service = Executors.newScheduledThreadPool(1);
+		task =  service.scheduleWithFixedDelay(this, POLL_DELAY_SECS, POLL_DELAY_SECS, TimeUnit.SECONDS);
+	}
+
+	@Override
+	public void run() {
+		if (!parentProcessStillRunning()) {
+			task.cancel(true);
+			server.exit();
+		}
+	}
+
+	/**
+	 * Checks whether the parent process is still running.
+	 * If not, then we assume it has crashed, and we have to terminate the Java Language Server.
+	 *
+	 * @return true if the parent process is still running
+	 */
+	private boolean parentProcessStillRunning() {
+		// Wait until parent process id is available
+		final long pid = server.getParentProcessId();
+		if (pid == 0 || lastActivityTime > (System.currentTimeMillis() - INACTIVITY_DELAY_SECS)) {
+			return true;
+		}
+		String command;
+		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+			command = "cmd /c \"tasklist /FI \"PID eq " + pid + "\" | findstr " + pid + "\"";
+		} else {
+			command = "ps -p " + pid;
+		}
+		try {
+			Process process = Runtime.getRuntime().exec(command);
+			int processResult = process.waitFor();
+			return processResult == 0;
+		} catch (IOException | InterruptedException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+			return true;
+		}
+	}
+
+	@Override
+	public MessageConsumer apply(final MessageConsumer consumer) {
+		//inject our own consumer to refresh the timestamp
+		return message -> {
+			lastActivityTime=System.currentTimeMillis();
+			consumer.consume(message);
+		};
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -107,10 +107,6 @@ final public class InitHandler {
 
 		triggerInitialization(rootPaths);
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new WorkspaceDiagnosticsHandler(connection, projectsManager), IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.POST_CHANGE);
-		Integer processId = param.getProcessId();
-		if (processId != null) {
-			JavaLanguageServerPlugin.getLanguageServer().setParentProcessId(processId.longValue());
-		}
 		try {
 			Collection<String> bundleList = getBundleList(initializationOptions);
 			BundleUtils.loadBundles(bundleList);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -107,6 +107,10 @@ final public class InitHandler {
 
 		triggerInitialization(rootPaths);
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(new WorkspaceDiagnosticsHandler(connection, projectsManager), IResourceChangeEvent.POST_BUILD | IResourceChangeEvent.POST_CHANGE);
+		Integer processId = param.getProcessId();
+		if (processId != null) {
+			JavaLanguageServerPlugin.getLanguageServer().setParentProcessId(processId.longValue());
+		}
 		try {
 			Collection<String> bundleList = getBundleList(initializationOptions);
 			BundleUtils.loadBundles(bundleList);


### PR DESCRIPTION
Removes the parent process check from LanguageServer. Changes the way main thread is stopped. Adjusts the shutdown and exit behaviour to match the protocol definition. fixes #378, #349 