### PR TITLE
Decide to use gradlew based on gradle-wrapper.properties as per GradleTooling

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -92,7 +92,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 
 	public static GradleDistribution getGradleDistribution(Path rootFolder) {
 		GradleDistribution distribution = DEFAULT_DISTRIBUTION;
-		if (Files.exists(rootFolder.resolve("gradlew"))) {
+		if (Files.exists(rootFolder.resolve("gradle/wrapper/gradle-wrapper.properties"))) {
 			distribution = GradleDistributionWrapper.from(DistributionType.WRAPPER, null).toGradleDistribution();
 		} else {
 			String gradleHome = System.getenv(GRADLE_HOME);


### PR DESCRIPTION
The aim here is to have consistent behaviour with the GradleTooling API whilst still allowing a fallback to GRADLE_HOME.

https://github.com/gradle/gradle/blob/master/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java#L38