### PR TITLE
Make JavaClientConnection available to plugins

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -423,4 +423,11 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		return protocol;
 	}
 
+	public JavaClientConnection getClientConnection() {
+		if (protocol != null) {
+			return protocol.getClientConnection();
+		}
+		return null;
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -620,4 +620,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		}
 	}
 
+	public JavaClientConnection getClientConnection() {
+		return client;
+	}
+
 }


### PR DESCRIPTION
Fixes #483 

You can use the following:
```
JavaClientConnection clientConnection = JavaLanguageServerPlugin.getInstance().getClientConnection();
```

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>