### PR TITLE
Add an ability to connect to JDT LS by TCP socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ by setting up environment variables.
 * To use standard streams(stdin, stdout) of the server process do not set any
 of the above environment variables and the server will fall back to standard streams.
 
+* To start a **TCP server**, set the following environment variable before starting the server:
+   * `JDTLS_SERVER_PORT`: the port of the socket to listen to
+
+   Java LS will listen to the **JDTLS_SERVER_PORT** port. See https://github.com/eclipse/eclipse.jdt.ls/pull/504.
+
 For socket and named pipes, the client is expected to create the connections
 and wait for the server to connect.
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactoryTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactoryTest.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.ls.core.internal;
 
 import java.io.IOException;
 
+import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.LanguageServerStreamProvider;
 import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.SocketStreamProvider;
 import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StdIOStreamProvider;
 import org.eclipse.jdt.ls.core.internal.ConnectionStreamFactory.StreamProvider;
@@ -26,6 +27,13 @@ public class ConnectionStreamFactoryTest {
 	@Test
 	public void testStdIOSelection(){
 		checkStreamProvider(StdIOStreamProvider.class);
+	}
+
+	@Test
+	public void testLsServerPortSelection() {
+		System.setProperty("JDTLS_SERVER_PORT", "8888");
+		checkStreamProvider(LanguageServerStreamProvider.class);
+		System.clearProperty("JDTLS_SERVER_PORT");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #431 
Requires https://github.com/redhat-developer/vscode-java/pull/395

In order to test this feature, you have to do the following:

1) start Java LS with:

```
JDTLS_SERVER_PORT=8888 sudo java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044 -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4 -Declipse.product=org.eclipse.jdt.ls.core.product -Dlog.protocol=true -Dlog.level=ALL -noverify -Xmx1G -jar ./plugins/org.eclipse.equinox.launcher_1.4.0.v20161219-1356.jar -configuration ./config_win -data ~/workspacetemp
```

or if you have cloned the https://github.com/redhat-developer/vscode-java and git@github.com:eclipse/eclipse.jdt.ls.git projects with:

```
npm run build_server
tsc --outDir out src/runServer.ts
cd server
node ../out/runServer.js
```

See https://github.com/eclipse/eclipse.jdt.ls#running-from-the-command-line.
Java LS will listen to the 8888 port.

2) start the VS Code language client using the "Launch Extension - JDTLS TCP Client" launch configuration.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>