### PR TITLE
Cannot save file in UTF-8 correctly

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
@@ -331,7 +331,8 @@ public class DocumentLifeCycleHandler {
 		if (unit.isWorkingCopy()) {
 			try {
 				projectsManager.fileChanged(uri, CHANGE_TYPE.CHANGED);
-				unit.commitWorkingCopy(true, new NullProgressMonitor());
+				unit.discardWorkingCopy();
+				unit.becomeWorkingCopy(new NullProgressMonitor());
 			} catch (Exception e) {
 				JavaLanguageServerPlugin.logException("Error while handling document save", e);
 			}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/394

The issue can be reproduced on Windows.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>