### PR TITLE
Add auto organize imports function to save action.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -41,6 +42,7 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.SharedASTProvider;
+import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -55,6 +57,8 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.WillSaveTextDocumentParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.text.edits.DeleteEdit;
 import org.eclipse.text.edits.InsertEdit;
 import org.eclipse.text.edits.MalformedTreeException;
@@ -337,6 +341,42 @@ public class DocumentLifeCycleHandler {
 				JavaLanguageServerPlugin.logException("Error while handling document save", e);
 			}
 		}
+	}
+
+	public List<org.eclipse.lsp4j.TextEdit> handleWillSaveWaitUntil(WillSaveTextDocumentParams params, IProgressMonitor monitor) {
+		List<org.eclipse.lsp4j.TextEdit> edit = new ArrayList<>();
+
+		if (monitor.isCanceled()) {
+			return edit;
+		}
+
+		String documentUri = params.getTextDocument().getUri();
+
+		if (preferenceManager.getPreferences().isJavaSaveActionAutoOrganizeImportsEnabled()) {
+			edit.addAll(handleAutoOrganizeImports(documentUri, monitor));
+		}
+
+		return edit.stream().sorted().collect(Collectors.toList());
+	}
+
+	private List<org.eclipse.lsp4j.TextEdit> handleAutoOrganizeImports(String uri, IProgressMonitor monitor) {
+		List<org.eclipse.lsp4j.TextEdit> edit = new ArrayList<>();
+		if (monitor.isCanceled()) {
+			return edit;
+		}
+
+		List<Object> params = new ArrayList<>(1);
+		params.add(uri);
+		try {
+			Object organizedResult = OrganizeImportsCommand.organizeImports(params);
+			if (organizedResult instanceof WorkspaceEdit) {
+				return ((WorkspaceEdit) organizedResult).getChanges().get(uri);
+			}
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logException("Error wihile handling auto organize imports", e);
+		}
+
+		return edit;
 	}
 
 	private ICompilationUnit checkPackageDeclaration(String uri, ICompilationUnit unit) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -44,6 +44,7 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.SaveOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
@@ -164,6 +165,8 @@ final public class InitHandler {
 			capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		}
 		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
+		textDocumentSyncOptions.setOpenClose(Boolean.TRUE);
+		textDocumentSyncOptions.setSave(new SaveOptions(Boolean.TRUE));
 		textDocumentSyncOptions.setChange(TextDocumentSyncKind.Incremental);
 		if (preferenceManager.getClientPreferences().isWillSaveRegistered()) {
 			textDocumentSyncOptions.setWillSave(Boolean.TRUE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.TextDocumentSyncOptions;
 
 /**
  * Handler for the VS Code extension initialization
@@ -121,7 +122,6 @@ final public class InitHandler {
 		}
 		InitializeResult result = new InitializeResult();
 		ServerCapabilities capabilities = new ServerCapabilities();
-		capabilities.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".", "@", "#")));
 		if (!preferenceManager.getClientPreferences().isFormattingDynamicRegistrationSupported()) {
 			capabilities.setDocumentFormattingProvider(Boolean.TRUE);
@@ -163,6 +163,16 @@ final public class InitHandler {
 		if (!preferenceManager.getClientPreferences().isDocumentHighlightDynamicRegistered()) {
 			capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		}
+		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
+		textDocumentSyncOptions.setChange(TextDocumentSyncKind.Incremental);
+		if (preferenceManager.getClientPreferences().isWillSaveRegistered()) {
+			textDocumentSyncOptions.setWillSave(Boolean.TRUE);
+		}
+
+		if (preferenceManager.getClientPreferences().isWillSaveWaitUntilRegistered()) {
+			textDocumentSyncOptions.setWillSaveWaitUntil(Boolean.TRUE);
+		}
+		capabilities.setTextDocumentSync(textDocumentSyncOptions);
 
 		result.setCapabilities(capabilities);
 		return result;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -92,6 +92,7 @@ import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -185,8 +186,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	 */
 	@Override
 	public void exit() {
-    logInfo(">> exit");
-    JavaLanguageServerPlugin.getLanguageServer().exit();
+		logInfo(">> exit");
+		JavaLanguageServerPlugin.getLanguageServer().exit();
 		Executors.newSingleThreadScheduledExecutor().schedule(() -> {
 			logInfo("Forcing exit after 1 min.");
 			System.exit(FORCED_EXIT_CODE);
@@ -625,6 +626,24 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	public void didClose(DidCloseTextDocumentParams params) {
 		logInfo(">> document/didClose");
 		documentLifeCycleHandler.didClose(params);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.lsp4j.services.TextDocumentService#willSave(org.eclipse.lsp4j.WillSaveTextDocumentParams)
+	 */
+	@Override
+	public void willSave(WillSaveTextDocumentParams params) {
+		logInfo(">> document/willSave");
+		TextDocumentService.super.willSave(params);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.lsp4j.services.TextDocumentService#willSaveWaitUntil(org.eclipse.lsp4j.WillSaveTextDocumentParams)
+	 */
+	@Override
+	public CompletableFuture<List<TextEdit>> willSaveWaitUntil(WillSaveTextDocumentParams params) {
+		logInfo(">> document/willSaveWailUntil");
+		return computeAsync((cc) -> documentLifeCycleHandler.handleWillSaveWaitUntil(params, toMonitor(cc)));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -629,21 +629,13 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	}
 
 	/* (non-Javadoc)
-	 * @see org.eclipse.lsp4j.services.TextDocumentService#willSave(org.eclipse.lsp4j.WillSaveTextDocumentParams)
-	 */
-	@Override
-	public void willSave(WillSaveTextDocumentParams params) {
-		logInfo(">> document/willSave");
-		TextDocumentService.super.willSave(params);
-	}
-
-	/* (non-Javadoc)
 	 * @see org.eclipse.lsp4j.services.TextDocumentService#willSaveWaitUntil(org.eclipse.lsp4j.WillSaveTextDocumentParams)
 	 */
 	@Override
 	public CompletableFuture<List<TextEdit>> willSaveWaitUntil(WillSaveTextDocumentParams params) {
 		logInfo(">> document/willSaveWailUntil");
-		return computeAsync((cc) -> documentLifeCycleHandler.handleWillSaveWaitUntil(params, toMonitor(cc)));
+		SaveActionHandler handler = new SaveActionHandler(preferenceManager);
+		return computeAsync((cc) -> handler.willSaveWaitUntil(params, toMonitor(cc)));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
@@ -11,6 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -39,7 +40,7 @@ public class SaveActionHandler {
 
 		String documentUri = params.getTextDocument().getUri();
 
-		if (preferenceManager.getPreferences().isJavaSaveActionOrganizeImportsEnabled()) {
+		if (preferenceManager.getPreferences().isJavaSaveActionsOrganizeImportsEnabled()) {
 			edit.addAll(handleSaveActionOrganizeImports(documentUri, monitor));
 		}
 
@@ -48,11 +49,11 @@ public class SaveActionHandler {
 
 	private List<TextEdit> handleSaveActionOrganizeImports(String uri, IProgressMonitor monitor) {
 		if (monitor.isCanceled()) {
-			return new ArrayList<>();
+			return Collections.emptyList();
 		}
 		WorkspaceEdit organizedResult = organizeImportsCommand.organizeImportsInFile(uri);
 		List<TextEdit> edit = organizedResult.getChanges().get(uri);
-		edit = edit == null ? new ArrayList<>() : edit;
+		edit = edit == null ? Collections.emptyList() : edit;
 		return edit;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     btstream - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WillSaveTextDocumentParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
+
+public class SaveActionHandler {
+
+	private PreferenceManager preferenceManager;
+	private OrganizeImportsCommand organizeImportsCommand;
+
+	public SaveActionHandler(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
+		this.organizeImportsCommand = new OrganizeImportsCommand();
+	}
+
+	public List<TextEdit> willSaveWaitUntil(WillSaveTextDocumentParams params, IProgressMonitor monitor) {
+		List<TextEdit> edit = new ArrayList<>();
+
+		if (monitor.isCanceled()) {
+			return edit;
+		}
+
+		String documentUri = params.getTextDocument().getUri();
+
+		if (preferenceManager.getPreferences().isJavaSaveActionOrganizeImportsEnabled()) {
+			edit.addAll(handleSaveActionOrganizeImports(documentUri, monitor));
+		}
+
+		return edit;
+	}
+
+	private List<TextEdit> handleSaveActionOrganizeImports(String uri, IProgressMonitor monitor) {
+		if (monitor.isCanceled()) {
+			return new ArrayList<>();
+		}
+		WorkspaceEdit organizedResult = organizeImportsCommand.organizeImportsInFile(uri);
+		List<TextEdit> edit = organizedResult.getChanges().get(uri);
+		edit = edit == null ? new ArrayList<>() : edit;
+		return edit;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandler.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.TextEdit;
@@ -47,7 +49,8 @@ public class SaveActionHandler {
 		return edit;
 	}
 
-	private List<TextEdit> handleSaveActionOrganizeImports(String uri, IProgressMonitor monitor) {
+	private List<TextEdit> handleSaveActionOrganizeImports(String documentUri, IProgressMonitor monitor) {
+		String uri = ResourceUtils.fixURI(JDTUtils.toURI(documentUri));
 		if (monitor.isCanceled()) {
 			return Collections.emptyList();
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -118,11 +118,11 @@ public class ClientPreferences {
 	}
 
 	public boolean isWillSaveRegistered() {
-		return v3supported && capabilities.getTextDocument().getSynchronization() != null && capabilities.getTextDocument().getSynchronization().getWillSave();
+		return v3supported && capabilities.getTextDocument().getSynchronization() != null && isTrue(capabilities.getTextDocument().getSynchronization().getWillSave());
 	}
 
 	public boolean isWillSaveWaitUntilRegistered() {
-		return v3supported && capabilities.getTextDocument().getSynchronization() != null && capabilities.getTextDocument().getSynchronization().getWillSaveWaitUntil();
+		return v3supported && capabilities.getTextDocument().getSynchronization() != null && isTrue(capabilities.getTextDocument().getSynchronization().getWillSaveWaitUntil());
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -116,4 +116,13 @@ public class ClientPreferences {
 	public boolean isDocumentHighlightDynamicRegistered() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getDocumentHighlight());
 	}
+
+	public boolean isWillSaveRegistered() {
+		return v3supported && capabilities.getTextDocument().getSynchronization() != null && capabilities.getTextDocument().getSynchronization().getWillSave();
+	}
+
+	public boolean isWillSaveWaitUntilRegistered() {
+		return v3supported && capabilities.getTextDocument().getSynchronization() != null && capabilities.getTextDocument().getSynchronization().getWillSaveWaitUntil();
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -58,9 +58,9 @@ public class Preferences {
 	public static final String JAVA_FORMAT_ENABLED_KEY = "java.format.enabled";
 
 	/**
-	 * Preference key to enable/disable auto organize imports
+	 * Preference key to enable/disable organize imports on save
 	 */
-	public static final String JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY = "java.saveAction.organizeImports";
+	public static final String JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY = "java.saveActions.organizeImports";
 
 	/**
 	 * Preference key to enable/disable signature help.
@@ -280,7 +280,7 @@ public class Preferences {
 		boolean javaFormatEnabled = getBoolean(configuration, JAVA_FORMAT_ENABLED_KEY, true);
 		prefs.setJavaFormatEnabled(javaFormatEnabled);
 
-		boolean javaSaveActionAutoOrganizeImportsEnabled = getBoolean(configuration, JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY, false);
+		boolean javaSaveActionAutoOrganizeImportsEnabled = getBoolean(configuration, JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY, false);
 		prefs.setJavaSaveActionAutoOrganizeImportsEnabled(javaSaveActionAutoOrganizeImportsEnabled);
 
 		boolean signatureHelpEnabled = getBoolean(configuration, SIGNATURE_HELP_ENABLED_KEY, true);
@@ -441,7 +441,7 @@ public class Preferences {
 		return javaFormatEnabled;
 	}
 
-	public boolean isJavaSaveActionOrganizeImportsEnabled() {
+	public boolean isJavaSaveActionsOrganizeImportsEnabled() {
 		return javaSaveActionsOrganizeImportsEnabled;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -60,7 +60,7 @@ public class Preferences {
 	/**
 	 * Preference key to enable/disable auto organize imports
 	 */
-	public static final String JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY = "java.saveAction.autoOrganizeImports";
+	public static final String JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY = "java.saveAction.organizeImports";
 
 	/**
 	 * Preference key to enable/disable signature help.
@@ -169,7 +169,7 @@ public class Preferences {
 	private boolean importMavenEnabled;
 	private boolean implementationsCodeLensEnabled;
 	private boolean javaFormatEnabled;
-	private boolean javaSaveActionAutoOrganizeImportsEnabled;
+	private boolean javaSaveActionsOrganizeImportsEnabled;
 	private boolean signatureHelpEnabled;
 	private boolean renameEnabled;
 	private boolean executeCommandEnabled;
@@ -240,7 +240,7 @@ public class Preferences {
 		referencesCodeLensEnabled = true;
 		implementationsCodeLensEnabled = false;
 		javaFormatEnabled = true;
-		javaSaveActionAutoOrganizeImportsEnabled = false;
+		javaSaveActionsOrganizeImportsEnabled = false;
 		signatureHelpEnabled = false;
 		renameEnabled = true;
 		executeCommandEnabled = true;
@@ -374,7 +374,7 @@ public class Preferences {
 	}
 
 	public Preferences setJavaSaveActionAutoOrganizeImportsEnabled(boolean javaSaveActionAutoOrganizeImportsEnabled) {
-		this.javaSaveActionAutoOrganizeImportsEnabled = javaSaveActionAutoOrganizeImportsEnabled;
+		this.javaSaveActionsOrganizeImportsEnabled = javaSaveActionAutoOrganizeImportsEnabled;
 		return this;
 	}
 
@@ -441,8 +441,8 @@ public class Preferences {
 		return javaFormatEnabled;
 	}
 
-	public boolean isJavaSaveActionAutoOrganizeImportsEnabled() {
-		return javaSaveActionAutoOrganizeImportsEnabled;
+	public boolean isJavaSaveActionOrganizeImportsEnabled() {
+		return javaSaveActionsOrganizeImportsEnabled;
 	}
 
 	public boolean isSignatureHelpEnabled() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -58,6 +58,11 @@ public class Preferences {
 	public static final String JAVA_FORMAT_ENABLED_KEY = "java.format.enabled";
 
 	/**
+	 * Preference key to enable/disable auto organize imports
+	 */
+	public static final String JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY = "java.saveAction.autoOrganizeImports";
+
+	/**
 	 * Preference key to enable/disable signature help.
 	 */
 	public static final String SIGNATURE_HELP_ENABLED_KEY = "java.signatureHelp.enabled";
@@ -164,6 +169,7 @@ public class Preferences {
 	private boolean importMavenEnabled;
 	private boolean implementationsCodeLensEnabled;
 	private boolean javaFormatEnabled;
+	private boolean javaSaveActionAutoOrganizeImportsEnabled;
 	private boolean signatureHelpEnabled;
 	private boolean renameEnabled;
 	private boolean executeCommandEnabled;
@@ -234,6 +240,7 @@ public class Preferences {
 		referencesCodeLensEnabled = true;
 		implementationsCodeLensEnabled = false;
 		javaFormatEnabled = true;
+		javaSaveActionAutoOrganizeImportsEnabled = false;
 		signatureHelpEnabled = false;
 		renameEnabled = true;
 		executeCommandEnabled = true;
@@ -272,6 +279,9 @@ public class Preferences {
 
 		boolean javaFormatEnabled = getBoolean(configuration, JAVA_FORMAT_ENABLED_KEY, true);
 		prefs.setJavaFormatEnabled(javaFormatEnabled);
+
+		boolean javaSaveActionAutoOrganizeImportsEnabled = getBoolean(configuration, JAVA_SAVE_ACTION_AUTO_ORGANIZE_IMPORTS_KEY, false);
+		prefs.setJavaSaveActionAutoOrganizeImportsEnabled(javaSaveActionAutoOrganizeImportsEnabled);
 
 		boolean signatureHelpEnabled = getBoolean(configuration, SIGNATURE_HELP_ENABLED_KEY, true);
 		prefs.setSignatureHelpEnabled(signatureHelpEnabled);
@@ -363,6 +373,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setJavaSaveActionAutoOrganizeImportsEnabled(boolean javaSaveActionAutoOrganizeImportsEnabled) {
+		this.javaSaveActionAutoOrganizeImportsEnabled = javaSaveActionAutoOrganizeImportsEnabled;
+		return this;
+	}
+
 	public Preferences setUpdateBuildConfigurationStatus(FeatureStatus status) {
 		this.updateBuildConfigurationStatus = status;
 		return this;
@@ -424,6 +439,10 @@ public class Preferences {
 
 	public boolean isJavaFormatEnabled() {
 		return javaFormatEnabled;
+	}
+
+	public boolean isJavaSaveActionAutoOrganizeImportsEnabled() {
+		return javaSaveActionAutoOrganizeImportsEnabled;
 	}
 
 	public boolean isSignatureHelpEnabled() {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Foo4.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Foo4.java
@@ -1,0 +1,6 @@
+package java;
+
+import java.util.ArrayList;
+
+public class Foo4 {
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -34,7 +35,10 @@ import org.eclipse.lsp4j.ExecuteCommandCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.TextDocumentSyncOptions;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -94,6 +98,18 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	@Test
+	public void testWillSaveAndWillSaveWaitUntilCapabilities() throws Exception {
+		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
+		when(mockCapabilies.isExecuteCommandDynamicRegistrationSupported()).thenReturn(Boolean.TRUE);
+		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		InitializeResult result = initialize(true);
+		Either<TextDocumentSyncKind, TextDocumentSyncOptions> o = result.getCapabilities().getTextDocumentSync();
+		assertTrue(o.isRight());
+		assertTrue(o.getRight().getWillSave());
+		assertTrue(o.getRight().getWillSaveWaitUntil());
+	}
+
+	@Test
 	public void testRegisterDelayedCapability() throws Exception {
 		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
 		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
@@ -121,6 +137,8 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		workspaceCapabilities.setExecuteCommand(executeCommand);
 		capabilities.setWorkspace(workspaceCapabilities);
 		TextDocumentClientCapabilities textDocument = new TextDocumentClientCapabilities();
+		textDocument.getSynchronization().setWillSave(true);
+		textDocument.getSynchronization().setWillSaveWaitUntil(true);
 		capabilities.setTextDocument(textDocument);
 		params.setCapabilities(capabilities);
 		CompletableFuture<InitializeResult> result = server.initialize(params);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.ExecuteCommandCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.SynchronizationCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
@@ -102,6 +103,8 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
 		when(mockCapabilies.isExecuteCommandDynamicRegistrationSupported()).thenReturn(Boolean.TRUE);
 		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		when(mockCapabilies.isWillSaveRegistered()).thenReturn(Boolean.TRUE);
+		when(mockCapabilies.isWillSaveWaitUntilRegistered()).thenReturn(Boolean.TRUE);
 		InitializeResult result = initialize(true);
 		Either<TextDocumentSyncKind, TextDocumentSyncOptions> o = result.getCapabilities().getTextDocumentSync();
 		assertTrue(o.isRight());
@@ -137,8 +140,9 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		workspaceCapabilities.setExecuteCommand(executeCommand);
 		capabilities.setWorkspace(workspaceCapabilities);
 		TextDocumentClientCapabilities textDocument = new TextDocumentClientCapabilities();
-		textDocument.getSynchronization().setWillSave(true);
-		textDocument.getSynchronization().setWillSaveWaitUntil(true);
+		SynchronizationCapabilities synchronizationCapabilities = new SynchronizationCapabilities();
+		synchronizationCapabilities.setWillSave(Boolean.TRUE);
+		synchronizationCapabilities.setWillSaveWaitUntil(Boolean.TRUE);
 		capabilities.setTextDocument(textDocument);
 		params.setCapabilities(capabilities);
 		CompletableFuture<InitializeResult> result = server.initialize(params);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SaveActionHandlerTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     btstream - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.TextEditUtil;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jface.text.Document;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WillSaveTextDocumentParams;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SaveActionHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	private SaveActionHandler handler;
+
+	private PreferenceManager preferenceManager;
+
+	private IPackageFragmentRoot sourceFolder;
+
+	private IProgressMonitor monitor;
+
+	@Before
+	public void setup() throws Exception {
+		IJavaProject javaProject = newEmptyProject();
+		sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
+		preferenceManager = mock(PreferenceManager.class);
+		ClientPreferences clientPreferences = mock(ClientPreferences.class);
+		when(preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
+		when(clientPreferences.isWillSaveRegistered()).thenReturn(true);
+		when(clientPreferences.isWillSaveWaitUntilRegistered()).thenReturn(true);
+		monitor = mock(IProgressMonitor.class);
+		when(monitor.isCanceled()).thenReturn(false);
+		handler = new SaveActionHandler(preferenceManager);
+	}
+
+	@Test
+	public void testWillSaveWaitUntil() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		WillSaveTextDocumentParams params = new WillSaveTextDocumentParams();
+		TextDocumentIdentifier document = new TextDocumentIdentifier();
+		document.setUri(cu.getPath().toOSString());
+		params.setTextDocument(document);
+
+		List<TextEdit> result = handler.willSaveWaitUntil(params, monitor);
+
+		Document doc = new Document();
+		assertEquals(TextEditUtil.apply(doc, result), buf.toString());
+	}
+
+}


### PR DESCRIPTION
Personally, I like 'Save Actions' very much in Eclipse, especially `Organize Imports` when save file. So I try to add this function to this language server. 

I think the best choice is to use LanguageClient's `willSaveWaitUntil` feature. I tried to register this feature dynamically, but failed. So, for now, I enabled `willSaveWaitUntil`  feature if the client support this feature during init stage.

I also submitted a pull request to `vscode-java`, in which an option `java.saveAction.autoOrganizeImports` is added.
  