### PR TITLE
vscode intellisense failing when 2 jdks are on system

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -87,8 +87,8 @@ public class CompletionHandler{
 			IBuffer buffer = unit.getBuffer();
 			if (buffer != null && buffer.getLength() >= offset) {
 				IProgressMonitor subMonitor = new ProgressMonitorWrapper(monitor) {
-					private final static int TIMEOUT = 1000;
 					private long timeLimit;
+					private static final long TIMEOUT = 5000;
 
 					@Override
 					public void beginTask(String name, int totalWork) {
@@ -101,15 +101,14 @@ public class CompletionHandler{
 					}
 
 				};
-				unit.codeComplete(offset, collector, subMonitor);
-				if (!subMonitor.isCanceled()) {
+				try {
+					unit.codeComplete(offset, collector, subMonitor);
 					proposals.addAll(collector.getCompletionItems());
-				} else {
+				} catch (OperationCanceledException e) {
 					monitor.setCanceled(true);
 				}
 			}
 		}
-
 		return proposals;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
@@ -105,8 +105,8 @@ public final class MapFlattener {
 
 	public static int getInt(Map<String, Object> configuration, String key, int def) {
 		Object val = getValue(configuration, key);
-		if (val instanceof Integer) {
-			return ((Integer) val).intValue();
+		if (val instanceof Number) {
+			return ((Number) val).intValue();
 		} else if (val instanceof String) {
 			try {
 				return Integer.parseInt((String) val);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -31,6 +31,10 @@ import org.eclipse.lsp4j.MessageType;
 public class Preferences {
 
 	/**
+	 * Specifies the folder path to the JDK .
+	 */
+	public static final String JAVA_HOME = "java.home";
+	/**
 	 * Preference key to enable/disable gradle importer.
 	 */
 	public static final String IMPORT_GRADLE_ENABLED = "java.import.gradle.enabled";
@@ -171,6 +175,7 @@ public class Preferences {
 	private String favoriteStaticMembers;
 
 	private List<String> javaImportExclusions = new ArrayList<>();
+	private String javaHome;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new ArrayList<>();
@@ -236,6 +241,7 @@ public class Preferences {
 		preferredContentProviderIds = null;
 		favoriteStaticMembers = "";
 		javaImportExclusions = JAVA_IMPORT_EXCLUSIONS_DEFAULT;
+		javaHome = null;
 	}
 
 	/**
@@ -291,7 +297,15 @@ public class Preferences {
 		List<String> preferredContentProviders = getList(configuration, PREFERRED_CONTENT_PROVIDER_KEY);
 		prefs.setPreferredContentProviderIds(preferredContentProviders);
 
+		String javaHome = getString(configuration, JAVA_HOME);
+		prefs.setJavaHome(javaHome);
+
 		return prefs;
+	}
+
+	public Preferences setJavaHome(String javaHome) {
+		this.javaHome = javaHome;
+		return this;
 	}
 
 	public Preferences setJavaImportExclusions(List<String> javaImportExclusions) {
@@ -374,6 +388,10 @@ public class Preferences {
 
 	public List<String> getJavaImportExclusions() {
 		return javaImportExclusions;
+	}
+
+	public String getJavaHome() {
+		return javaHome;
 	}
 
 	public MemberSortOrder getMemberSortOrder() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/TestVMType.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/TestVMType.java
@@ -30,39 +30,23 @@ import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMInstallType;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.LibraryLocation;
-import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
-import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
 import org.osgi.framework.Bundle;
 
 
 public class TestVMType extends AbstractVMInstallType {
 
-	private static final String VMTYPE_ID = "org.eclipse.jdt.ls.core.internal.TestVMType";
+	public static final String VMTYPE_ID = "org.eclipse.jdt.ls.core.internal.TestVMType";
 	private static final String FAKE_JDK = "/fakejdk";
 	private static final String RTSTUBS_JAR = "rtstubs.jar";
 
 	public static void setTestJREAsDefault() throws CoreException {
 		IVMInstallType vmInstallType = JavaRuntime.getVMInstallType(VMTYPE_ID);
 		IVMInstall testVMInstall = vmInstallType.findVMInstall("1.8");
-
 		if (!testVMInstall.equals(JavaRuntime.getDefaultVMInstall())) {
 			// set the 1.8 test JRE as the new default JRE
 			JavaRuntime.setDefaultVMInstall(testVMInstall, new NullProgressMonitor());
 		}
-
-	// update all environments compatible to use the test JRE
-		IExecutionEnvironmentsManager manager = JavaRuntime.getExecutionEnvironmentsManager();
-		IExecutionEnvironment[] environments = manager.getExecutionEnvironments();
-		for (IExecutionEnvironment environment : environments) {
-			IVMInstall[] compatibleVMs = environment.getCompatibleVMs();
-			for (IVMInstall compatibleVM : compatibleVMs) {
-				if (VMTYPE_ID.equals(compatibleVM.getVMInstallType().getId()) && compatibleVM.getVMInstallType().findVMInstall(compatibleVM.getId()) != null && !compatibleVM.equals(environment.getDefaultVM())
-				// Fugly way to ensure the lowest VM version is set:
-						&& (environment.getDefaultVM() == null || compatibleVM.getId().compareTo(environment.getDefaultVM().getId()) < 0)) {
-					environment.setDefaultVM(compatibleVM);
-				}
-			}
-		}
+		JDTUtils.setCompatibleVMs(VMTYPE_ID);
 	}
 
 	public TestVMType() {
@@ -88,7 +72,7 @@ public class TestVMType extends AbstractVMInstallType {
 		return null;
 	}
 
-	static File getFakeJDKsLocation() {
+	public static File getFakeJDKsLocation() {
 		Bundle bundle = Platform.getBundle(JavaLanguageServerTestPlugin.PLUGIN_ID);
 		try {
 			URL url = FileLocator.toFileURL(bundle.getEntry(FAKE_JDK));


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/392

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>

There are two issues:

1) Eclipse JDT will always use a default VM Runtime if it exists.

If you start VS Code with JDK 8, Java LS will set JDK8 as a default VM and use it although you, after that, start Java LSP with JDK 9.
A workaround is to remove a workspace before starting VS Code - https://github.com/redhat-developer/vscode-java/wiki/Troubleshooting#clean-the-workspace-directory

I have fixed this issue by setting a default VM based on the "java.home" property.
Maybe we would need to remove other JDKs defined in the workspace or add a JRE view. See https://github.com/redhat-developer/vscode-java/issues/237.

2) Intellisense (code assist) won't work if it takes more than one second.
I have changed it to five seconds.