### PR TITLE
Update m2e to 1.9.0.20180124-2208

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="106">
+<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="107">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.mockito.mockito-all" version="1.9.5"/>
@@ -33,12 +33,12 @@
             <repository location="http://download.eclipse.org/lsp4j/updates/releases/0.3.0/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.m2e.feature.feature.group" version="1.8.2.20171007-0217"/>
-            <repository location="http://download.eclipse.org/technology/m2e/releases/1.8/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="2.2.0.v20171211-1404"/>
             <repository location="http://download.eclipse.org/buildship/updates/e47/releases/2.x/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180124-2208"/>
+            <repository location="https://ci.eclipse.org/m2e/job/m2e-master/238/artifact/org.eclipse.m2e.site/target/repository/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>


### PR DESCRIPTION
temporary link to CI build of m2e 1.9.0, in order to check https://github.com/redhat-developer/vscode-java/issues/391
Will switch to m2e 1.9.0 M5 once it's released.

Signed-off-by: Fred Bricon <fbricon@gmail.com>