### PR TITLE
Update TP to latest, pre-M5, Photon bits

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -1,20 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="107">
+<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="108">
     <locations>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.mockito.mockito-all" version="1.9.5"/>
             <repository location="http://download.eclipse.org/scout/releases/4.0/testing"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.1.v20170928-1321"/>
-            <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.1.v20170928-1321"/>
-            <unit id="org.eclipse.equinox.executable.feature.group" version="3.7.1.v20170928-1359"/>
-            <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="1.4.1.v20170928-1405"/>
-            <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.1.1.v20170906-1259"/>
-            <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.3.1.v20170928-1405"/>
-            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.1.v20170928-1405"/>
-            <unit id="org.eclipse.jdt.source.feature.group" version="3.13.1.v20171009-0410"/>
-            <unit id="org.eclipse.sdk.feature.group" version="4.7.1.v20171009-0537"/>
             <unit id="org.eclipse.xtend.sdk.feature.group" version="2.12.0.v20170519-1412"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="2.12.0.v20170519-1412"/>
             <repository location="http://download.eclipse.org/releases/oxygen"/>
@@ -37,8 +28,20 @@
             <repository location="http://download.eclipse.org/buildship/updates/e47/releases/2.x/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180124-2208"/>
-            <repository location="https://ci.eclipse.org/m2e/job/m2e-master/238/artifact/org.eclipse.m2e.site/target/repository/"/>
+            <unit id="org.eclipse.m2e.feature.feature.group" version="1.9.0.20180125-1730"/>
+            <repository location="https://ci.eclipse.org/m2e/job/m2e-master/239/artifact/org.eclipse.m2e.site/target/repository/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.5.0.v20180123-1456"/>
+            <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.14.0.v20180119-2027"/>
+            <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.0.v20180124-1426"/>
+            <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="1.5.0.v20180122-2220"/>
+            <unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.2.0.v20180103-0918"/>
+            <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.4.0.v20180122-2220"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.14.0.v20180124-1426"/>
+            <unit id="org.eclipse.jdt.source.feature.group" version="3.14.0.v20180124-2000"/>
+            <unit id="org.eclipse.sdk.feature.group" version="4.8.0.v20180124-2000"/>
+            <repository location="http://download.eclipse.org/eclipse/updates/4.8-I-builds/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="test" output="binTest">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/test/foo/bar/AbstractTest.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/test/foo/bar/AbstractTest.java
@@ -1,0 +1,4 @@
+package foo.bar;
+
+public abstract class AbstractTest{
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/test/foo/bar/BaseTest.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/test/foo/bar/BaseTest.java
@@ -1,0 +1,4 @@
+package foo.bar;
+
+public class BaseTest {
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -56,10 +56,10 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 
 	@Test
 	public void testWorkspaceSearch() {
-		String query = "Abstract";
+		String query = "Array";
 		List<SymbolInformation> results = handler.search(query, monitor);
 		assertNotNull(results);
-		assertEquals("Found " + results.size() + " results", 33, results.size());
+		assertEquals("Unexpected results", 11, results.size());
 		Range defaultRange = JDTUtils.newRange();
 		for (SymbolInformation symbol : results) {
 			assertNotNull("Kind is missing", symbol.getKind());
@@ -67,7 +67,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 			assertTrue(symbol.getName().startsWith(query));
 			Location location = symbol.getLocation();
 			assertEquals(defaultRange, location.getRange());
-			//No class in the workspace project starts with Abstract, so everything comes from the JDK
+			//No class in the workspace project starts with Array, so everything comes from the JDK
 			assertTrue("Unexpected uri "+ location.getUri(), location.getUri().startsWith("jdt://"));
 		}
 	}


### PR DESCRIPTION
- Fixes slow performance when compiling/runnning against Java 9 (https://github.com/redhat-developer/vscode-java/issues/398)
- Fixes broken navigation in module-info.java (#501)
- Fixes broken hover in module-info.java (#397)

Perhaps more importantly, brings test classpath isolation to Maven and Eclipse projects \o/


Signed-off-by: Fred Bricon <fbricon@gmail.com>