### PR TITLE
Exclude **/META-INF/maven/** folders from import

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -202,9 +202,10 @@ public class Preferences {
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new ArrayList<>();
-		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/node_modules");
-		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/.metadata");
-		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/archetype-resources");
+		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/node_modules/**");
+		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/.metadata/**");
+		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/archetype-resources/**");
+		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/META-INF/maven/**");
 		JAVA_COMPLETION_FAVORITE_MEMBERS_DEFAULT = new ArrayList<>();
 		JAVA_COMPLETION_FAVORITE_MEMBERS_DEFAULT.add("org.junit.Assert.*:");
 		JAVA_COMPLETION_FAVORITE_MEMBERS_DEFAULT.add("org.junit.Assume.*:");

--- a/org.eclipse.jdt.ls.tests/projects/maven/unzipped-sources/META-INF/maven/unzipped-sources/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/unzipped-sources/META-INF/maven/unzipped-sources/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>unzipped-sources</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.4</version>
+		</dependency>
+		<!-- ensure javadoc file is available, hence attached to the commons-cli jar -->
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.4</version>
+			<classifier>javadoc</classifier>
+		</dependency>
+	</dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -76,6 +77,12 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		} finally {
 			javaImportExclusions.remove(PROJECT1_PATTERN);
 		}
+	}
+
+	@Test
+	public void testUnzippedSourceImportExclusions() throws Exception {
+		List<IProject> projects = importProjects("maven/unzipped-sources");
+		assertEquals(Arrays.asList(projectsManager.getDefaultProject()), projects);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #539

It turns out exclusion patterns without the `**` suffix are not enough to actually exclude projects in case of Maven import 

Signed-off-by: Fred Bricon <fbricon@gmail.com>