### PR TITLE
Make it possible to apply all formatter options

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
@@ -193,7 +193,7 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 			"@Deprecated package org.sample;\n\n" +
 				"public class Baz {\n"+
 				"    /**Java doc @param a some parameter*/\n"+
-				"    void foo(int a){\n"+
+				"\tvoid foo(int a){;;\n"+
 				"}\n"+
 				"}\n"
 			//@formatter:on
@@ -201,9 +201,10 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 
 		String uri = JDTUtils.toURI(unit);
 		TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri);
-		FormattingOptions options = new FormattingOptions(2, false);
+		FormattingOptions options = new FormattingOptions(2, true);
 		options.putNumber("org.eclipse.jdt.core.formatter.blank_lines_before_package", Integer.valueOf(2));
 		options.putString("org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package", "do not insert");
+		options.putBoolean("org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line", Boolean.TRUE);
 		DocumentFormattingParams params = new DocumentFormattingParams(textDocument, options);
 		List<? extends TextEdit> edits = server.formatting(params).get();
 		assertNotNull(edits);
@@ -214,9 +215,11 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 				"@Deprecated package org.sample;\n"+
 				"\n"+
 				"public class Baz {\n"+
-				"\t/**Java doc @param a some parameter*/\n"+
-				"\tvoid foo(int a) {\n"+
-				"\t}\n"+
+				"  /**Java doc @param a some parameter*/\n"+
+				"  void foo(int a) {\n"+
+				"    ;\n"+
+				"    ;\n"+
+				"  }\n"+
 				"}\n";
 		String newText = TextEditUtil.apply(unit, edits);
 		assertEquals(expectedText, newText);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
@@ -185,4 +185,40 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 		String newText = TextEditUtil.apply(unit, edits);
 		assertEquals(expectedText, newText);
 	}
+
+	@Test
+	public void testDocumentFormattingWithCustomOption() throws Exception {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Baz.java",
+			//@formatter:off
+			"@Deprecated package org.sample;\n\n" +
+				"public class Baz {\n"+
+				"    /**Java doc @param a some parameter*/\n"+
+				"    void foo(int a){\n"+
+				"}\n"+
+				"}\n"
+			//@formatter:on
+		);
+
+		String uri = JDTUtils.toURI(unit);
+		TextDocumentIdentifier textDocument = new TextDocumentIdentifier(uri);
+		FormattingOptions options = new FormattingOptions(2, false);
+		options.putNumber("org.eclipse.jdt.core.formatter.blank_lines_before_package", Integer.valueOf(2));
+		options.putString("org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package", "do not insert");
+		DocumentFormattingParams params = new DocumentFormattingParams(textDocument, options);
+		List<? extends TextEdit> edits = server.formatting(params).get();
+		assertNotNull(edits);
+
+		String expectedText =
+			"\n"+
+				"\n"+
+				"@Deprecated package org.sample;\n"+
+				"\n"+
+				"public class Baz {\n"+
+				"\t/**Java doc @param a some parameter*/\n"+
+				"\tvoid foo(int a) {\n"+
+				"\t}\n"+
+				"}\n";
+		String newText = TextEditUtil.apply(unit, edits);
+		assertEquals(expectedText, newText);
+	}
 }


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
This PR proposes not to avoid all options from `FormattingOptions` to format the code.

It is needed for https://github.com/eclipse/che/issues/8572