### PR TITLE
Remove problematic cache in ContentProviderManager

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -36,8 +36,7 @@
       <contentProvider
             class="org.eclipse.jdt.ls.core.internal.SourceContentProvider"
             id="sourceContentProvider"
-            priority="0"
-            cacheable="false">
+            priority="0">
       </contentProvider>
    </extension>
    <extension
@@ -46,8 +45,7 @@
             class="org.eclipse.jdt.ls.core.internal.DisassemblerContentProvider"
             id="disassemblerContentProvider"
             priority="2147483647"
-            uriPattern=".+\.class.*"
-            cacheable="true">
+            uriPattern=".+\.class.*">
       </contentProvider>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.contentProvider.exsd
+++ b/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.contentProvider.exsd
@@ -83,8 +83,13 @@
          <attribute name="cacheable" type="boolean">
             <annotation>
                <documentation>
-                  Indicates that the server can safely cache content for a period of time. true by default.
+                  DEPRECATED: This attribute is now ignored. 
+ 
+Indicates that the server can safely cache content for a period of time. true by default.
                </documentation>
+               <appinfo>
+                  <meta.attribute deprecated="true"/>
+               </appinfo>
             </annotation>
          </attribute>
       </complexType>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -23,8 +23,6 @@ import java.net.PasswordAuthentication;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -43,9 +41,7 @@ import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
-import org.eclipse.jdt.ls.core.internal.preferences.IPreferencesChangeListener;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
-import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
@@ -89,21 +85,6 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 
 	private PreferenceManager preferenceManager;
 
-	private IPreferencesChangeListener preferencesChangeListener = new IPreferencesChangeListener() {
-
-		@Override
-		public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
-			if (contentProviderManager == null) {
-				return;
-			}
-			List<String> oldIds = oldPreferences == null ? null : oldPreferences.getPreferredContentProviderIds();
-			List<String> newIds = newPreferences == null ? null : newPreferences.getPreferredContentProviderIds();
-			if (!Objects.equals(oldIds, newIds)) {
-				contentProviderManager.clearCache();
-			}
-		}
-	};
-
 	public static LanguageServer getLanguageServer() {
 		return pluginInstance == null ? null : pluginInstance.languageServer;
 	}
@@ -139,7 +120,6 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 			logException(e.getMessage(), e);
 		}
 		contentProviderManager = new ContentProviderManager(preferenceManager);
-		preferenceManager.addPreferencesChangeListener(preferencesChangeListener);
 		logInfo(getClass() + " is started");
 		configureProxy();
 	}
@@ -268,9 +248,6 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		JavaLanguageServerPlugin.context = null;
 		ResourcesPlugin.getWorkspace().removeSaveParticipant(PLUGIN_ID);
 		projectsManager = null;
-		if (preferenceManager != null) {
-			preferenceManager.removePreferencesChangeListener(preferencesChangeListener);
-		}
 		contentProviderManager = null;
 		languageServer = null;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -66,6 +67,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Before
+	@After
 	public void resetFakeContentProvider() {
 		FakeContentProvider.preferences = null;
 		FakeContentProvider.returnValue = null;
@@ -233,12 +235,12 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
-	public void testCaching() {
-		FakeContentProvider.returnValue = "cached";
-		assertEquals("cached", provider.getContent(sourcelessURI, monitor));
+	public void testNoCaching() {
+		FakeContentProvider.returnValue = "some value";
+		assertEquals(FakeContentProvider.returnValue, provider.getContent(sourcelessURI, monitor));
 
 		FakeContentProvider.returnValue = "something else";
-		assertEquals("cached", provider.getContent(sourcelessURI, monitor));
+		assertEquals(FakeContentProvider.returnValue, provider.getContent(sourcelessURI, monitor));
 	}
 
 	private void expectLoggedError(String expected) {


### PR DESCRIPTION
Fixes #557

It's now each IContentProvider's responsibility to implement their own caching mechanism, if needed.

Signed-off-by: Fred Bricon <fbricon@gmail.com>