### PR TITLE
Fix the URI during workspace symbols

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -54,7 +54,7 @@ public class WorkspaceSymbolHandler{
 						if (match.getType().isBinary()) {
 							location = JDTUtils.toLocation(match.getType().getClassFile());
 						}  else {
-							location = JDTUtils.toLocation(match.getType().getResource().getLocationURI().toString());
+							location = JDTUtils.toLocation(match.getType());
 						}
 					} catch (Exception e) {
 						JavaLanguageServerPlugin.logException("Unable to determine location for " +  match.getSimpleTypeName(), e);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +74,23 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
+	public void testWorkspaceSearchOnFileInWorkspace() {
+		String query = "Baz";
+		List<SymbolInformation> results = handler.search(query, monitor);
+		assertNotNull(results);
+		assertEquals("Unexpected results", 2, results.size());
+		Range defaultRange = JDTUtils.newRange();
+		for (SymbolInformation symbol : results) {
+			assertNotNull("Kind is missing", symbol.getKind());
+			assertNotNull("ContainerName is missing", symbol.getContainerName());
+			assertTrue(symbol.getName().startsWith(query));
+			Location location = symbol.getLocation();
+			assertNotEquals("Range should not equal the default range", defaultRange, location.getRange());
+			assertTrue("Unexpected uri " + location.getUri(), location.getUri().startsWith("file://"));
+		}
+	}
+
+	@Test
 	public void testProjectSearch() {
 		String query = "IFoo";
 		List<SymbolInformation> results = handler.search(query, monitor);
@@ -83,7 +101,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		assertEquals("java", symbol.getContainerName());
 		assertEquals(query, symbol.getName());
 		Location location = symbol.getLocation();
-		assertEquals(JDTUtils.newRange(), location.getRange());
+		assertNotEquals("Range should not equal the default range", JDTUtils.newRange(), location.getRange());
 		assertTrue("Unexpected uri "+ location.getUri(), location.getUri().endsWith("Foo.java"));
 	}
 


### PR DESCRIPTION
Adds a fix for the URI during workspace symbols. Previously what was happening is the response would be "file:/" with only one slash.

Fixes #561 

Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>