### PR TITLE
On workspace/didChangeConfiguration, only trigger a clean build if JVM changed

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -292,8 +291,11 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
 		try {
-			if (pm.setAutoBuilding(preferenceManager.getPreferences().isAutobuildEnabled()) || jvmChanged) {
-				ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.CLEAN_BUILD, null);
+			boolean autoBuildChanged = pm.setAutoBuilding(preferenceManager.getPreferences().isAutobuildEnabled());
+			if (jvmChanged) {
+				buildWorkspace(true);
+			} else if (autoBuildChanged) {
+				buildWorkspace(false);
 			}
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
@@ -673,7 +675,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	 */
 	@Override
 	public CompletableFuture<BuildWorkspaceStatus> buildWorkspace(boolean forceReBuild) {
-		logInfo(">> java/buildWorkspace");
+		logInfo(">> java/buildWorkspace (" + (forceReBuild ? "full)" : "incremental)"));
 		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(client, pm);
 		return computeAsync((cc) -> handler.buildWorkspace(forceReBuild, toMonitor(cc)));
 	}


### PR DESCRIPTION
...else trigger an incremental build (if incremental build enabled).

See https://github.com/redhat-developer/vscode-java/issues/451

Signed-off-by: Fred Bricon <fbricon@gmail.com>