### PR TITLE
Issue 522 - Allow custom notifications

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.services.LanguageClient;
 
@@ -179,4 +180,14 @@ public class JavaClientConnection {
 		}
 	}
 
+	/**
+	 * Sends a Notification from a server to a client
+	 *
+	 * @param method
+	 * @param parameter
+	 *
+	 */
+	public void notify(String method, Object parameter) {
+		  ((Endpoint)client).notify(method, parameter);
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ServerToClientNotificationTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ServerToClientNotificationTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.core.ElementChangedEvent;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IElementChangedListener;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.Severity;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServerToClientNotificationTest extends AbstractProjectsManagerBasedTest {
+	private JavaClientConnection javaClient;
+
+	@Before
+	public void setup() throws Exception {
+		mockPreferences();
+
+		javaClient = new JavaClientConnection(client);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		javaClient.disconnect();
+		for (ICompilationUnit cu : JavaCore.getWorkingCopies(null)) {
+			cu.discardWorkingCopy();
+		}
+	}
+
+	private Preferences mockPreferences() {
+		Preferences mockPreferences = Mockito.mock(Preferences.class);
+		Mockito.when(preferenceManager.getPreferences()).thenReturn(mockPreferences);
+		Mockito.when(preferenceManager.getPreferences(Mockito.any())).thenReturn(mockPreferences);
+		Mockito.when(mockPreferences.getIncompleteClasspathSeverity()).thenReturn(Severity.ignore);
+		return mockPreferences;
+	}
+
+	@Test
+	public void testSendNotification() throws Exception {
+		IElementChangedListener listener = new IElementChangedListener() {
+
+			@Override
+			public void elementChanged(ElementChangedEvent event) {
+				// This should sent Java Model events to a client
+				javaClient.notify("notify", event);
+			}
+		};
+		try {
+			JavaCore.addElementChangedListener(listener);
+			IJavaProject javaProject = newDefaultProject();
+			IPackageFragmentRoot sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
+			IPackageFragment pack1 = sourceFolder.createPackageFragment("java", false, null);
+
+			// @formatter:off
+			String standaloneFileContent =
+					"package java;\n"+
+					"public class Foo extends UnknownType {"+
+					"	public void method1(){\n"+
+					"		super.whatever();"+
+					"	}\n"+
+					"}";
+			// @formatter:on
+			ICompilationUnit cu1 = pack1.createCompilationUnit("Foo.java", standaloneFileContent, false, null);
+
+			// Check if all the events are received and events aren't nulls
+			List<ElementChangedEvent> eventReports = getClientRequests("notify");
+			assertEquals(7, eventReports.size());
+
+			for (ElementChangedEvent notification : eventReports) {
+				assertNotNull(notification);
+			}
+		} finally {
+			JavaCore.removeElementChangedListener(listener);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private <T> List<T> getClientRequests(String name) {
+		List<?> requests = clientRequests.get(name);
+		return requests != null ? (List<T>) requests : Collections.emptyList();
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -403,7 +403,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 
 		openDocument(cu1, cu1.getSource(), 1);
 
-		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("publishDiagnostics");
+		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(1, diagnosticReports.size());
 		PublishDiagnosticsParams diagParam = diagnosticReports.get(0);
 		assertEquals(0, diagParam.getDiagnostics().size());
@@ -420,13 +420,13 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		Job.getJobManager().join(DocumentLifeCycleHandler.DOCUMENT_LIFE_CYCLE_JOBS, monitor);
 		assertEquals(project, cu.getJavaProject().getProject());
 		assertEquals(source, cu.getSource());
-		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("publishDiagnostics");
+		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(1, diagnosticReports.size());
 		PublishDiagnosticsParams diagParam = diagnosticReports.get(0);
 		assertEquals(1, diagParam.getDiagnostics().size());
 		closeDocument(cu);
 		Job.getJobManager().join(DocumentLifeCycleHandler.DOCUMENT_LIFE_CYCLE_JOBS, monitor);
-		diagnosticReports = getClientRequests("publishDiagnostics");
+		diagnosticReports = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(2, diagnosticReports.size());
 		diagParam = diagnosticReports.get(1);
 		assertEquals(0, diagParam.getDiagnostics().size());
@@ -452,7 +452,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 
 		openDocument(cu1, cu1.getSource(), 1);
 
-		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("publishDiagnostics");
+		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(1, diagnosticReports.size());
 		PublishDiagnosticsParams diagParam = diagnosticReports.get(0);
 		assertEquals("Unexpected number of errors " + diagParam.getDiagnostics(), 1, diagParam.getDiagnostics().size());
@@ -485,7 +485,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 
 		openDocument(cu1, cu1.getSource(), 1);
 
-		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("publishDiagnostics");
+		List<PublishDiagnosticsParams> diagnosticReports = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(1, diagnosticReports.size());
 		PublishDiagnosticsParams diagParam = diagnosticReports.get(0);
 
@@ -705,7 +705,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 	}
 
 	private void assertNewProblemReported(ExpectedProblemReport... expectedReports) {
-		List<PublishDiagnosticsParams> diags = getClientRequests("publishDiagnostics");
+		List<PublishDiagnosticsParams> diags = getClientRequests("textDocument/publishDiagnostics");
 		assertEquals(expectedReports.length, diags.size());
 
 		for (int i = 0; i < expectedReports.length; i++) {


### PR DESCRIPTION
The public `void notify(String method, Object parameter)` method is added to `JavaClientConnection` thus allowing sending the notifications from a Server to a Client

Fixes #522 
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>