### PR TITLE
Process non-java files

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DidChangeWatchedFilesRegistrationOptions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DidChangeWatchedFilesRegistrationOptions.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Describe options to be used when registered for text document change events.
+ */
+@SuppressWarnings("all")
+public class DidChangeWatchedFilesRegistrationOptions {
+	/**
+	 * The watchers to register.
+	 */
+  @NonNull
+	private List<FileSystemWatcher> watchers;
+
+  public DidChangeWatchedFilesRegistrationOptions() {
+		this(new ArrayList<FileSystemWatcher>());
+  }
+
+	public DidChangeWatchedFilesRegistrationOptions(@NonNull final List<FileSystemWatcher> watchers) {
+		this.watchers = watchers;
+  }
+
+  @Pure
+  @NonNull
+	public List<FileSystemWatcher> getWatchers() {
+		return this.watchers;
+  }
+
+	public void setChanges(@NonNull final List<FileSystemWatcher> watchers) {
+		this.watchers = watchers;
+  }
+
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+		b.add("watchers", this.watchers);
+    return b.toString();
+  }
+
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+		return true;
+	}
+    if (obj == null) {
+		return false;
+	}
+    if (getClass() != obj.getClass()) {
+		return false;
+	}
+		DidChangeWatchedFilesRegistrationOptions other = (DidChangeWatchedFilesRegistrationOptions) obj;
+		if (this.watchers == null) {
+			if (other.watchers != null) {
+		return false;
+	}
+		} else if (!this.watchers.equals(other.watchers)) {
+		return false;
+	}
+    return true;
+  }
+
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+		result = prime * result + ((this.watchers == null) ? 0 : this.watchers.hashCode());
+    return result;
+  }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/FileSystemWatcher.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/FileSystemWatcher.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+public class FileSystemWatcher {
+
+	public static final int WATCH_KIND_DEFAULT = 7;
+	/**
+	 * The glob pattern to watch
+	 */
+	private String globPattern;
+
+	/**
+	 * The kind of events of interest. If omitted it defaults to WatchKind.Create |
+	 * WatchKind.Change | WatchKind.Delete which is 7.
+	 */
+	private int kind;
+
+	public FileSystemWatcher(String globPattern, int kind) {
+		this.globPattern = globPattern;
+		this.kind = kind;
+	}
+
+	public FileSystemWatcher() {
+	}
+
+	/**
+	 * @return the globPattern
+	 */
+	public String getGlobPattern() {
+		return globPattern;
+	}
+
+	/**
+	 * @param globPattern
+	 *            the globPattern to set
+	 */
+	public void setGlobPattern(String globPattern) {
+		this.globPattern = globPattern;
+	}
+
+	/**
+	 * @return the kind
+	 */
+	public int getKind() {
+		return kind;
+	}
+
+	/**
+	 * @param kind
+	 *            the kind to set
+	 */
+	public void setKind(int kind) {
+		this.kind = kind;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((globPattern == null) ? 0 : globPattern.hashCode());
+		result = prime * result + kind;
+		return result;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		FileSystemWatcher other = (FileSystemWatcher) obj;
+		if (globPattern == null) {
+			if (other.globPattern != null) {
+				return false;
+			}
+		} else if (!globPattern.equals(other.globPattern)) {
+			return false;
+		}
+		if (kind != other.kind) {
+			return false;
+		}
+		return true;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -306,6 +306,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
+		pm.registerWatchers();
 		logInfo(">>New configuration: " + settings);
 	}
 
@@ -654,7 +655,6 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		logInfo(">> java/didChangeWorkspaceFolders");
 		WorkspaceFolderChangeHandler handler = new WorkspaceFolderChangeHandler(pm);
 		handler.update(params);
-
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -99,6 +99,10 @@ public class ClientPreferences {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getWorkspace().getSymbol());
 	}
 
+	public boolean isWorkspaceChangeWatchedFilesDynamicRegistered() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getWorkspace().getDidChangeWatchedFiles());
+	}
+
 	public boolean isDocumentSymbolDynamicRegistered() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getDocumentSymbol());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -159,6 +159,7 @@ public class Preferences {
 	public static final String TEXT_DOCUMENT_RENAME = "textDocument/rename";
 	public static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
 	public static final String WORKSPACE_SYMBOL = "workspace/symbol";
+	public static final String WORKSPACE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
 	public static final String DOCUMENT_SYMBOL = "textDocument/documentSymbol";
 	public static final String CODE_ACTION = "textDocument/codeAction";
 	public static final String DEFINITION = "textDocument/definition";
@@ -181,6 +182,7 @@ public class Preferences {
 	public static final String REFERENCES_ID = UUID.randomUUID().toString();
 	public static final String DOCUMENT_HIGHLIGHT_ID = UUID.randomUUID().toString();
 	public static final String WORKSPACE_CHANGE_FOLDERS_ID = UUID.randomUUID().toString();
+	public static final String WORKSPACE_WATCHED_FILES_ID = UUID.randomUUID().toString();
 
 	private Map<String, Object> configuration;
 	private Severity incompleteClasspathSeverity;


### PR DESCRIPTION
Fixes https://github.com/eclipse/eclipse.jdt.ls/issues/583

We can remove the following lines in vscode-java:

workspace.createFileSystemWatcher('**/*.java'),
workspace.createFileSystemWatcher('**/src/**')

Maybe we could also add the remaining file watchers as a property.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>