### PR TITLE
Experimental client-side command executions

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -42,7 +42,8 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.managers;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.preferences;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.corrections;x-internal:=true,
- org.eclipse.jdt.ls.core.internal.corrections.proposals;x-internal:=true
+ org.eclipse.jdt.ls.core.internal.corrections.proposals;x-internal:=true,
+ org.eclipse.jdt.ls.core.internal.lsp;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-ClassPath: lib/jsoup-1.9.2.jar,
  lib/remark-1.0.0.jar,
  .

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
+ *     Pivotal Inc. - added executeClientCommand API.
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -13,9 +13,11 @@ package org.eclipse.jdt.ls.core.internal;
 import java.util.List;
 
 import org.eclipse.jdt.ls.core.internal.handlers.LogHandler;
+import org.eclipse.jdt.ls.core.internal.lsp.ExecuteCommandProposedClient;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -27,9 +29,12 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.services.LanguageClient;
 
+import com.google.common.collect.ImmutableList;
+
 public class JavaClientConnection {
 
-	public interface JavaLanguageClient extends LanguageClient {
+	public interface JavaLanguageClient extends LanguageClient, ExecuteCommandProposedClient {
+
 		/**
 		 * The show message notification is sent from a server to a client to ask
 		 * the client to display a particular message in the user interface.
@@ -54,6 +59,10 @@ public class JavaClientConnection {
 		this.client = client;
 		logHandler = new LogHandler();
 		logHandler.install(this);
+	}
+
+	public Object executeCommand(String id, Object... params) {
+		return this.client.executeCommand(new ExecuteCommandParams(id, ImmutableList.copyOf(params))).join();
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -61,8 +61,8 @@ public class JavaClientConnection {
 		logHandler.install(this);
 	}
 
-	public Object executeCommand(String id, Object... params) {
-		return this.client.executeCommand(new ExecuteCommandParams(id, ImmutableList.copyOf(params))).join();
+	public Object executeClientCommand(String id, Object... params) {
+		return this.client.executeClientCommand(new ExecuteCommandParams(id, ImmutableList.copyOf(params))).join();
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -10,7 +10,11 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.ls.core.internal.handlers.LogHandler;
 import org.eclipse.jdt.ls.core.internal.lsp.ExecuteCommandProposedClient;
@@ -59,6 +63,10 @@ public class JavaClientConnection {
 		this.client = client;
 		logHandler = new LogHandler();
 		logHandler.install(this);
+	}
+
+	public Object executeClientCommand(Duration timeout, String id, Object... params) throws InterruptedException, ExecutionException, TimeoutException {
+		return this.client.executeClientCommand(new ExecuteCommandParams(id, ImmutableList.copyOf(params))).get(timeout.toNanos(), TimeUnit.NANOSECONDS);
 	}
 
 	public Object executeClientCommand(String id, Object... params) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc. and others.
+ * Copyright (c) 2018 Pivotal Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Red Hat Inc. - initial API and implementation
+ *     Pivotal Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.lsp;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
@@ -18,6 +18,6 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 public interface ExecuteCommandProposedClient {
 
 	@JsonRequest("workspace/executeClientCommand")
-	CompletableFuture<Object> executeCommand(ExecuteCommandParams params);
+	CompletableFuture<Object> executeClientCommand(ExecuteCommandParams params);
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
@@ -17,7 +17,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 public interface ExecuteCommandProposedClient {
 
-	@JsonRequest("workspace/executeCommand")
+	@JsonRequest("workspace/executeClientCommand")
 	CompletableFuture<Object> executeCommand(ExecuteCommandParams params);
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ExecuteCommandProposedClient.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.lsp;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+public interface ExecuteCommandProposedClient {
+
+	@JsonRequest("workspace/executeCommand")
+	CompletableFuture<Object> executeCommand(ExecuteCommandParams params);
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ExecuteClientCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ExecuteClientCommandTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc. and others.
+ * Copyright (c) 2018 Pivotal Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Red Hat Inc. - initial API and implementation
+ *     Pivotal Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
@@ -97,7 +97,7 @@ public class ExecuteClientCommandTest {
 		try {
 			javaClient.executeClientCommand(Duration.ofMillis(10), "whatever");
 			fail("Should have thrown");
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			assertEquals(TimeoutException.class, e.getClass());
 		}
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ExecuteClientCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ExecuteClientCommandTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.google.common.collect.ImmutableList;
+
+public class ExecuteClientCommandTest {
+
+	private JavaLanguageClient client = mock(JavaLanguageClient.class);
+	private JavaClientConnection javaClient = new JavaClientConnection(client);
+
+	@Test
+	public void testExecuteClientCommandNoArgs() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler("send.it.back", params -> params.getArguments()));
+		Object response = javaClient.executeClientCommand("send.it.back");
+		assertEquals(ImmutableList.of(), response);
+	}
+
+	@Test
+	public void testExecuteClientCommandNoArgsAndLongEnoughTimeout() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler("send.it.back", params -> params.getArguments()));
+		Object response = javaClient.executeClientCommand(Duration.ofDays(1), "send.it.back");
+		assertEquals(ImmutableList.of(), response);
+	}
+
+	@Test
+	public void testExecuteClientCommandThrows() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler(params -> {
+			throw new IllegalArgumentException("BOOM!");
+		}));
+		try {
+			javaClient.executeClientCommand("whatever");
+			fail("Should have thrown");
+		} catch (Throwable e) {
+			e = getDeepestCause(e);
+			assertEquals("BOOM!", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testExecuteClientCommandThrowsAndLongEnoughTimeout() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler(params -> {
+			throw new IllegalArgumentException("BOOM!");
+		}));
+		try {
+			javaClient.executeClientCommand(Duration.ofDays(1), "whatever");
+			fail("Should have thrown");
+		} catch (Throwable e) {
+			e = getDeepestCause(e);
+			assertEquals("BOOM!", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testExecuteClientCommandSomeArgs() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler("send.it.back", params -> params.getArguments()));
+		Object[] params = { "one", 2, ImmutableList.of(3) };
+		Object response = javaClient.executeClientCommand("send.it.back", params);
+		assertEquals(ImmutableList.copyOf(params), response);
+	}
+
+	@Test
+	public void testExecuteClientCommandSomeArgsAndLongEnoughTimeout() throws Exception {
+		when(client.executeClientCommand(any())).thenAnswer(handler("send.it.back", params -> params.getArguments()));
+		Object[] params = { "one", 2, ImmutableList.of(3) };
+		Object response = javaClient.executeClientCommand(Duration.ofDays(1), "send.it.back", params);
+		assertEquals(ImmutableList.copyOf(params), response);
+	}
+
+	@Test
+	public void testExecuteClientCommandTimesOut() throws Exception {
+		when(client.executeClientCommand(any())).thenReturn(new CompletableFuture<>()); //Future never resolves
+		try {
+			javaClient.executeClientCommand(Duration.ofMillis(10), "whatever");
+			fail("Should have thrown");
+		} catch (Exception e) {
+			assertEquals(TimeoutException.class, e.getClass());
+		}
+	}
+
+	///////////////////// Harness, helper, setup etc. below /////////////////////////////////////
+
+	interface SyncHandler {
+		Object executeClientCommand(ExecuteCommandParams params);
+	}
+
+	private static <T> Answer<T> handler(String command, SyncHandler h) {
+		return handler((ExecuteCommandParams params) -> {
+			if (params.getCommand().equals(command)) {
+				return h.executeClientCommand(params);
+			}
+			throw new IllegalArgumentException("Unknown command: " + params.getCommand());
+		});
+	}
+
+	/**
+	 * Convenience method to wrap a 'nice', type-checked SyncHandler into a mockito
+	 * {@link Answer}.
+	 */
+	private static <T> Answer<T> handler(SyncHandler h) {
+		return new Answer<T>() {
+			@SuppressWarnings("unchecked")
+			@Override
+			public T answer(InvocationOnMock invocation) throws Throwable {
+				try {
+					Object[] args = invocation.getArguments();
+					assertEquals(1, args.length);
+					ExecuteCommandParams params = (ExecuteCommandParams) args[0];
+					return (T) CompletableFuture.completedFuture(h.executeClientCommand(params));
+				} catch (Throwable e) {
+					CompletableFuture<T> fail = new CompletableFuture<>();
+					fail.completeExceptionally(e);
+					return (T) fail;
+				}
+			}
+		};
+	}
+
+	private static Throwable getDeepestCause(Throwable e) {
+		Throwable cause = e;
+		Throwable parent = e.getCause();
+		while (parent != null && parent != e) {
+			cause = parent;
+			parent = cause.getCause();
+		}
+		return cause;
+	}
+}


### PR DESCRIPTION
This is one half of a proposed protocol extension that allows language server to execute commands on the server. 

It requires another PR to implement support for handling the new `workspace/executeCommand` message on the client side.

This fits in with in the discussion at https://github.com/eclipse/eclipse.jdt.ls/issues/595