### PR TITLE
CodeLensHandlerTest.testGetCodeLensSymbolsForClass fails on Windows

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -121,7 +121,7 @@ public final class ResourceUtils {
 	 * Fix uris by adding missing // to single file:/ prefix
 	 */
 	public static String fixURI(URI uri) {
-		if (Platform.OS_WIN32.equals(Platform.getOS())) {
+		if (Platform.OS_WIN32.equals(Platform.getOS()) && URIUtil.isFileURI(uri)) {
 			uri = URIUtil.toFile(uri).toURI();
 		}
 		String uriString = uri.toString();


### PR DESCRIPTION
Fixes #597 

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>