### PR TITLE
Adding annotation processing support

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -32,7 +32,9 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.xtend.lib,
  org.eclipse.xtext.xbase.lib,
- org.eclipse.core.filesystem;bundle-version="1.7.0"
+ org.eclipse.core.filesystem;bundle-version="1.7.0",
+ org.eclipse.jdt.apt.pluggable.core;bundle-version="1.2.0",
+ org.jboss.tools.maven.apt.core;bundle-version="1.3.0"
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.commands;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.contentassist;x-friends:="org.eclipse.jdt.ls.tests",
@@ -48,3 +50,4 @@ Bundle-ClassPath: lib/jsoup-1.9.2.jar,
  lib/remark-1.0.0.jar,
  .
 Bundle-Vendor: %Bundle-Vendor
+Automatic-Module-Name: org.eclipse.jdt.ls.core

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
@@ -229,7 +229,7 @@ public class DocumentLifeCycleHandler {
 	public void handleOpen(DidOpenTextDocumentParams params) {
 		String uri = params.getTextDocument().getUri();
 		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(uri);
-		if (unit == null || unit.getResource() == null) {
+		if (unit == null || unit.getResource() == null || unit.getResource().isDerived()) {
 			return;
 		}
 		try {
@@ -291,7 +291,7 @@ public class DocumentLifeCycleHandler {
 	public void handleChanged(DidChangeTextDocumentParams params) {
 		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
 
-		if (unit == null || !unit.isWorkingCopy() || params.getContentChanges().isEmpty()) {
+		if (unit == null || !unit.isWorkingCopy() || params.getContentChanges().isEmpty() || unit.getResource().isDerived()) {
 			return;
 		}
 
@@ -340,7 +340,7 @@ public class DocumentLifeCycleHandler {
 			return;
 		}
 		try {
-			if (JDTUtils.isDefaultProject(unit) || !JDTUtils.isOnClassPath(unit)) {
+			if (JDTUtils.isDefaultProject(unit) || !JDTUtils.isOnClassPath(unit) || unit.getResource().isDerived()) {
 				new DiagnosticsHandler(connection, unit).clearDiagnostics();
 			}
 			if (unit.equals(sharedASTProvider.getActiveJavaElement())) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -44,6 +44,7 @@ import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 public class PreferenceManager {
 
 	private Preferences preferences ;
+	private static final String M2E_APT_ID = "org.jboss.tools.maven.apt";
 	private ClientPreferences clientPreferences;
 	private IMavenConfiguration mavenConfig;
 	private ListenerList<IPreferencesChangeListener> preferencesChangeListeners;
@@ -73,6 +74,11 @@ public class PreferenceManager {
 		defEclipsePrefs.put(CodeStyleConfiguration.ORGIMPORTS_IMPORTORDER, String.join(";", Preferences.JAVA_IMPORT_ORDER_DEFAULT));
 		defEclipsePrefs.put(CodeStyleConfiguration.ORGIMPORTS_ONDEMANDTHRESHOLD, "99");
 		defEclipsePrefs.put(CodeStyleConfiguration.ORGIMPORTS_STATIC_ONDEMANDTHRESHOLD, "99");
+
+		IEclipsePreferences m2eAptPrefs = DefaultScope.INSTANCE.getNode(M2E_APT_ID);
+		if (m2eAptPrefs != null) {
+			m2eAptPrefs.put(M2E_APT_ID + ".mode", "jdt_apt");
+		}
 	}
 
 	public void update(Preferences preferences) {

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -40,6 +40,10 @@
             <unit id="org.eclipse.xtext.sdk.feature.group" version="2.13.0.v20171020-0920"/>
             <repository location="http://download.eclipse.org/releases/photon/"/>
         </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.5.0.201804060341"/>
+			<repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.0-2018-04-06_03-47-50-H10"/>
+		</location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/org.eclipse.jdt.ls.tests/projects/maven/autovalued/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/autovalued/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>foo.bar</groupId>
+	<artifactId>autovalued</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<properties>
+		<maven.compiler.source>9</maven.compiler.source>
+		<maven.compiler.target>9</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>com.google.auto.value</groupId>
+			<artifactId>auto-value-annotations</artifactId>
+			<version>1.6</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.auto.value</groupId>
+			<artifactId>auto-value</artifactId>
+			<version>1.6</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/autovalued/src/main/java/foo/bar/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/autovalued/src/main/java/foo/bar/Foo.java
@@ -1,0 +1,14 @@
+package foo.bar;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class Foo {
+    abstract String bar();
+    abstract int meh();
+
+    public static void main(String[] args) {
+        Foo foo = new AutoValue_Foo("bar", 10);
+        System.err.println(foo);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -153,6 +153,15 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		assertNoErrors(project);
 	}
 
+	@Test
+	public void testAnnotationProcessing() throws Exception {
+		IProject project = importMavenProject("autovalued");
+		assertIsJavaProject(project);
+		IFile autovalueFoo = project.getFile("target/generated-sources/annotations/foo/bar/AutoValue_Foo.java");
+		assertTrue(autovalueFoo.getRawLocation() + " was not generated", autovalueFoo.exists());
+		assertNoErrors(project);
+	}
+
 	private static class MavenUpdateProjectJobSpy extends JobChangeAdapter {
 
 		int updateProjectJobCalled;


### PR DESCRIPTION
- adds m2e-apt to the server distro (requires CQ approval)
- ignores derived resources from didOpen/didChange/didSave calls, effectively removing diagnostics for those, as, after the server generates those files, the client detects changes, so sends textedits to the server to re-modify them, causing weird errors.

Fixes #128 

Signed-off-by: Fred Bricon <fbricon@gmail.com>