### PR TITLE
Fix completionItem URI

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResolveHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponse;
@@ -101,7 +102,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		$.setKind(mapKind(proposal.getKind()));
 		Map<String, String> data = new HashMap<>();
 		// append data field so that resolve request can use it.
-		data.put(CompletionResolveHandler.DATA_FIELD_URI,unit.getResource().getLocationURI().toString());
+		data.put(CompletionResolveHandler.DATA_FIELD_URI, JDTUtils.toURI(unit));
 		data.put(CompletionResolveHandler.DATA_FIELD_REQUEST_ID,String.valueOf(response.getId()));
 		data.put(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID,String.valueOf(index));
 		$.setData(data);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -187,6 +187,31 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		}
 	}
 
+	@Test
+	public void testCompletion_dataFieldURI() throws Exception {
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n"+
+				"	void foo() {\n"+
+				"		Objec\n"+
+				"	}\n"+
+				"}\n");
+		int[] loc = findCompletionLocation(unit, "Objec");
+		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+		assertNotNull(list);
+		assertFalse("No proposals were found",list.getItems().isEmpty());
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		for ( CompletionItem item : items) {
+			@SuppressWarnings("unchecked")
+			Map<String,String> data = (Map<String, String>) item.getData();
+			assertNotNull(data);
+			String uri = data.get(CompletionResolveHandler.DATA_FIELD_URI);
+			assertTrue(isNotBlank(uri));
+			assertTrue("unexpected URI prefix: " + uri, uri.matches("file://.*/src/java/Foo\\.java"));
+		}
+	}
+
 
 	@Test
 	public void testCompletion_constructor() throws Exception{


### PR DESCRIPTION
fix `completionItem.data.uri`, adding missing `//` to `file:/` prefix

Signed-off-by: Pixy Yuan <pixy.bupt@gmail.com>