### PR TITLE
Prevent NPE in DocumentAdapter.close(). Fixes #642

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DocumentAdapter.java
@@ -148,9 +148,11 @@ public class DocumentAdapter implements IBuffer, IDocumentListener {
 			}
 
 			fIsClosed= true;
-			fDocument.removeDocumentListener(this);
+			if (fDocument != null) {
+				fDocument.removeDocumentListener(this);
+			}
 
-			if (fTextFileBuffer != null) {
+			if (fTextFileBuffer != null && fFile != null) {
 				try {
 					ITextFileBufferManager manager= FileBuffers.getTextFileBufferManager();
 					manager.disconnect(fFile.getFullPath(), LocationKind.NORMALIZE, null);


### PR DESCRIPTION
Not sure how we can reach a state where the document is null while not being already closed.
I've added a couple null-checks, but no idea on how to test the fix.

Fixes #642

Signed-off-by: Fred Bricon <fbricon@gmail.com>