### PR TITLE
Add on-type formatting support.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -23,8 +23,12 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.corext.refactoring.util.TextEditUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
@@ -36,6 +40,7 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
@@ -50,6 +55,9 @@ import org.eclipse.text.edits.TextEdit;
  */
 public class FormatterHandler {
 
+	private static final char CLOSING_BRACE = '}';
+	private static final char NEW_LINE = '\n';
+
 	private PreferenceManager preferenceManager;
 
 	public FormatterHandler(PreferenceManager preferenceManager) {
@@ -57,61 +65,71 @@ public class FormatterHandler {
 	}
 
 	List<? extends org.eclipse.lsp4j.TextEdit> formatting(DocumentFormattingParams params, IProgressMonitor monitor) {
-		return format(params.getTextDocument().getUri(), params.getOptions(), null, monitor);
+		return format(params.getTextDocument().getUri(), params.getOptions(), (Range) null, monitor);
 	}
 
-	List<? extends org.eclipse.lsp4j.TextEdit> rangeFormatting(DocumentRangeFormattingParams params,
-			IProgressMonitor monitor) {
+	List<? extends org.eclipse.lsp4j.TextEdit> rangeFormatting(DocumentRangeFormattingParams params, IProgressMonitor monitor) {
 		return format(params.getTextDocument().getUri(), params.getOptions(), params.getRange(), monitor);
 	}
 
-	private List<org.eclipse.lsp4j.TextEdit> format(String uri, FormattingOptions options, Range range,
-			IProgressMonitor monitor) {
+	private List<org.eclipse.lsp4j.TextEdit> format(String uri, FormattingOptions options, Range range, IProgressMonitor monitor) {
 		if (!preferenceManager.getPreferences().isJavaFormatEnabled()) {
 			return Collections.emptyList();
 		}
 		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
-		if(cu == null ) {
+		if (cu == null) {
+			return Collections.emptyList();
+		}
+		IRegion region = null;
+		IDocument document = null;
+		try {
+			document = JsonRpcHelpers.toDocument(cu.getBuffer());
+			if (document != null) {
+				region = (range == null ? new Region(0, document.getLength()) : getRegion(range, document));
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+		}
+		if (region == null) {
+			return Collections.emptyList();
+		}
+
+		return format(cu, document, region, options, preferenceManager.getPreferences().isJavaFormatComments(), monitor);
+	}
+
+	private List<org.eclipse.lsp4j.TextEdit> format(ICompilationUnit cu, IDocument document, IRegion region, FormattingOptions options, boolean includeComments, IProgressMonitor monitor) {
+		if (cu == null || document == null || region == null || monitor.isCanceled()) {
 			return Collections.emptyList();
 		}
 
 		CodeFormatter formatter = ToolFactory.createCodeFormatter(getOptions(options, cu));
 
-		try {
-			IDocument document = JsonRpcHelpers.toDocument(cu.getBuffer());
-			String lineDelimiter = TextUtilities.getDefaultLineDelimiter(document);
-			IRegion region = (range == null ? new Region(0,document.getLength()) : getRegion(range,document));
-			// could not calculate region abort.
-			if (region == null || monitor.isCanceled()) {
-				return Collections.<org.eclipse.lsp4j.TextEdit>emptyList();
-			}
-			String sourceToFormat = document.get();
-			int kind;
-			if (cu.getResource() != null && cu.getResource().getName().equals(IModule.MODULE_INFO_JAVA)) {
-				kind = CodeFormatter.K_MODULE_INFO;
-			} else {
-				kind = CodeFormatter.K_COMPILATION_UNIT;
-			}
-			kind |= (preferenceManager.getPreferences().isJavaFormatComments() ? CodeFormatter.F_INCLUDE_COMMENTS : 0);
-			TextEdit format = formatter.format(kind, sourceToFormat, region.getOffset(), region.getLength(), 0, lineDelimiter);
-			if (format == null || format.getChildren().length == 0 || monitor.isCanceled()) {
-				// nothing to return
-				return Collections.<org.eclipse.lsp4j.TextEdit>emptyList();
-			}
-			MultiTextEdit flatEdit = TextEditUtil.flatten(format);
-			return convertEdits(flatEdit.getChildren(), document);
-		} catch (JavaModelException e) {
-			JavaLanguageServerPlugin.logException(e.getMessage(), e);
-			return Collections.emptyList();
+		String lineDelimiter = TextUtilities.getDefaultLineDelimiter(document);
+		String sourceToFormat = document.get();
+		int kind = getFormattingKind(cu, includeComments);
+		TextEdit format = formatter.format(kind, sourceToFormat, region.getOffset(), region.getLength(), 0, lineDelimiter);
+		if (format == null || format.getChildren().length == 0 || monitor.isCanceled()) {
+			// nothing to return
+			return Collections.<org.eclipse.lsp4j.TextEdit>emptyList();
 		}
+		MultiTextEdit flatEdit = TextEditUtil.flatten(format);
+		return convertEdits(flatEdit.getChildren(), document);
+	}
+
+	private int getFormattingKind(ICompilationUnit cu, boolean includeComments) {
+		int kind = includeComments ? CodeFormatter.F_INCLUDE_COMMENTS : 0;
+		if (cu.getResource() != null && cu.getResource().getName().equals(IModule.MODULE_INFO_JAVA)) {
+			kind |= CodeFormatter.K_MODULE_INFO;
+		} else {
+			kind |= CodeFormatter.K_COMPILATION_UNIT;
+		}
+		return kind;
 	}
 
 	private IRegion getRegion(Range range, IDocument document) {
 		try {
-			int offset = document.getLineOffset(range.getStart().getLine())
-					+ range.getStart().getCharacter();
-			int endOffset = document.getLineOffset(range.getEnd().getLine())
-					+ range.getEnd().getCharacter();
+			int offset = document.getLineOffset(range.getStart().getLine()) + range.getStart().getCharacter();
+			int endOffset = document.getLineOffset(range.getEnd().getLine()) + range.getEnd().getCharacter();
 			int length = endOffset - offset;
 			return new Region(offset, length);
 		} catch (BadLocationException e) {
@@ -123,9 +141,7 @@ public class FormatterHandler {
 	private static Map<String, String> getOptions(FormattingOptions options, ICompilationUnit cu) {
 		Map<String, String> eclipseOptions = cu.getJavaProject().getOptions(true);
 
-		Map<String, String> customOptions = options.entrySet().stream()
-			.filter(map -> chekIfValueIsNotNull(map.getValue()))
-			.collect(toMap(e -> e.getKey(), e -> getOptionValue(e.getValue())));
+		Map<String, String> customOptions = options.entrySet().stream().filter(map -> chekIfValueIsNotNull(map.getValue())).collect(toMap(e -> e.getKey(), e -> getOptionValue(e.getValue())));
 
 		eclipseOptions.putAll(customOptions);
 
@@ -162,26 +178,137 @@ public class FormatterHandler {
 	}
 
 	private static org.eclipse.lsp4j.TextEdit convertEdit(TextEdit edit, IDocument document) {
-		org.eclipse.lsp4j.TextEdit textEdit  = new org.eclipse.lsp4j.TextEdit();
+		org.eclipse.lsp4j.TextEdit textEdit = new org.eclipse.lsp4j.TextEdit();
 		if (edit instanceof ReplaceEdit) {
 			ReplaceEdit replaceEdit = (ReplaceEdit) edit;
 			textEdit.setNewText(replaceEdit.getText());
 			int offset = edit.getOffset();
-			textEdit.setRange( new Range(createPosition(document, offset),
-					createPosition(document, offset+edit.getLength())));
+			textEdit.setRange(new Range(createPosition(document, offset), createPosition(document, offset + edit.getLength())));
 		}
 		return textEdit;
 	}
 
 	private static Position createPosition(IDocument document, int offset) {
-		Position start =  new Position();
+		Position start = new Position();
 		try {
 			int lineOfOffset = document.getLineOfOffset(offset);
-			start.setLine( Integer.valueOf(lineOfOffset));
-			start.setCharacter(Integer.valueOf( offset - document.getLineOffset(lineOfOffset)));
+			start.setLine(Integer.valueOf(lineOfOffset));
+			start.setCharacter(Integer.valueOf(offset - document.getLineOffset(lineOfOffset)));
 		} catch (BadLocationException e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
 		return start;
 	}
+
+	public List<? extends org.eclipse.lsp4j.TextEdit> onTypeFormatting(DocumentOnTypeFormattingParams params, IProgressMonitor monitor) {
+		return format(params.getTextDocument().getUri(), params.getOptions(), params.getPosition(), params.getCh(), monitor);
+	}
+
+	private List<? extends org.eclipse.lsp4j.TextEdit> format(String uri, FormattingOptions options, Position position, String triggerChar, IProgressMonitor monitor) {
+		if (!preferenceManager.getPreferences().isJavaFormatOnTypeEnabled()) {
+			return Collections.emptyList();
+		}
+
+		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
+		if (cu == null) {
+			return Collections.emptyList();
+		}
+		IRegion region = null;
+		IDocument document = null;
+		try {
+			document = JsonRpcHelpers.toDocument(cu.getBuffer());
+			if (document != null && position != null) {
+				region = getRegion(cu, document, position, triggerChar);
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+		}
+		if (region == null) {
+			return Collections.emptyList();
+		}
+		return format(cu, document, region, options, false, monitor);
+	}
+
+	private IRegion getRegion(ICompilationUnit cu, IDocument document, Position position, String trigger) {
+		try {
+			int line = position.getLine();
+			int offset = document.getLineOffset(line);
+			int length = position.getCharacter();
+
+			char triggerChar = '\u0000';
+			if (trigger != null && !trigger.isEmpty()) {
+				triggerChar = trigger.charAt(0);
+				if (NEW_LINE == triggerChar && (document.getChar(offset + length) != triggerChar || length == 0) && line > 0) {
+					int prevLine = line - 1;
+					offset = document.getLineOffset(prevLine);
+					length = document.getLineLength(prevLine);
+					line = prevLine;
+				}
+			} else {
+				triggerChar = document.getChar(offset + length);
+			}
+
+			boolean emptyLine = false;
+			if (NEW_LINE == triggerChar) {
+				// get previous non-whitespace char (up to previous line)
+				int[] lines = (line > 0) ? new int[] { line, line - 1 } : new int[] { line };
+
+				lineLoop: for (int l : lines) {
+					int lineOffset = document.getLineOffset(l);
+					int maxPosition = document.getLineLength(l) - 1;
+
+					emptyLine = false;
+					for (int pos = maxPosition; pos >= 0; pos--) {
+						char ch = document.getChar(lineOffset + pos);
+						if (Character.isWhitespace(ch)) {
+							continue;
+						}
+						if (ch == CLOSING_BRACE) {
+							length = pos + 1;
+						} else {
+							length = maxPosition;
+						}
+						offset = lineOffset;
+						triggerChar = ch;
+						break lineLoop;
+					}
+					emptyLine = true;
+				}
+			}
+
+			if (triggerChar == CLOSING_BRACE) {
+				//Format whole block, from beginning of line to end of last line
+				CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(cu, CoreASTProvider.WAIT_YES, null);
+				NodeFinder finder = new NodeFinder(astRoot, offset, length);
+				ASTNode block = finder.getCoveredNode();
+				if (block == null) {
+					block = finder.getCoveringNode();
+				}
+				if (block != null) {
+					int blockStartPosition = block.getStartPosition();
+					int lineOfBlock = document.getLineOfOffset(blockStartPosition);
+					int lineOffset = document.getLineOffset(lineOfBlock);
+					int blockLength = block.getLength();
+
+					int endLine = document.getLineOfOffset(blockStartPosition + blockLength);
+					int endLineOffset = document.getLineOffset(endLine);
+					int endLineLength = document.getLineLength(endLine);
+					if (document.getChar(endLineOffset + endLineLength - 1) == NEW_LINE) {
+						endLineLength--;
+					}
+					int lastPosition = document.getLineOffset(endLine) + endLineLength;
+
+					int totalLength = lastPosition - lineOffset;
+					return new Region(lineOffset, totalLength);
+				}
+			} else if (!emptyLine) {
+				//format current non-empty line
+				return new Region(offset, length);
+			}
+		} catch (BadLocationException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+		}
+		return null;
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -142,6 +143,9 @@ final public class InitHandler {
 		}
 		if (!preferenceManager.getClientPreferences().isRangeFormattingDynamicRegistrationSupported()) {
 			capabilities.setDocumentRangeFormattingProvider(Boolean.TRUE);
+		}
+		if (!preferenceManager.getClientPreferences().isOnTypeFormattingDynamicRegistrationSupported()) {
+			capabilities.setDocumentOnTypeFormattingProvider(new DocumentOnTypeFormattingOptions(";", Arrays.asList("\n", "}")));
 		}
 		if (!preferenceManager.getClientPreferences().isCodeLensDynamicRegistrationSupported()) {
 			capabilities.setCodeLensProvider(new CodeLensOptions(true));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -16,6 +16,7 @@ import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -73,6 +74,7 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -109,7 +111,7 @@ import org.eclipse.lsp4j.services.WorkspaceService;
  * @author Gorkem Ercan
  *
  */
-public class JDTLanguageServer implements LanguageServer, TextDocumentService, WorkspaceService,JavaProtocolExtensions{
+public class JDTLanguageServer implements LanguageServer, TextDocumentService, WorkspaceService, JavaProtocolExtensions {
 
 	public static final String JAVA_LSP_JOIN_ON_COMPLETION = "java.lsp.joinOnCompletion";
 	/**
@@ -213,6 +215,10 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		}
 		if (preferenceManager.getClientPreferences().isRangeFormattingDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isJavaFormatEnabled(), Preferences.FORMATTING_RANGE_ID, Preferences.TEXT_DOCUMENT_RANGE_FORMATTING, null);
+		}
+		if (preferenceManager.getClientPreferences().isOnTypeFormattingDynamicRegistrationSupported()) {
+			toggleCapability(preferenceManager.getPreferences().isJavaFormatOnTypeEnabled(), Preferences.FORMATTING_ON_TYPE_ID, Preferences.TEXT_DOCUMENT_ON_TYPE_FORMATTING,
+					new DocumentOnTypeFormattingOptions(";", Arrays.asList("\n", "}")));
 		}
 		if (preferenceManager.getClientPreferences().isCodeLensDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isCodeLensEnabled(), Preferences.CODE_LENS_ID, Preferences.TEXT_DOCUMENT_CODE_LENS, new CodeLensOptions(true));
@@ -574,8 +580,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
 		logInfo(">> document/onTypeFormatting");
-		// Not yet implemented
-		return null;
+		FormatterHandler handler = new FormatterHandler(preferenceManager);
+		return computeAsync((monitor) -> handler.onTypeFormatting(params, monitor));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -75,6 +75,10 @@ public class ClientPreferences {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getRangeFormatting());
 	}
 
+	public boolean isOnTypeFormattingDynamicRegistrationSupported() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getOnTypeFormatting());
+	}
+
 	public boolean isCodeLensDynamicRegistrationSupported() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getCodeLens());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -74,6 +74,11 @@ public class Preferences {
 	 * Preference key to enable/disable formatter.
 	 */
 	public static final String JAVA_FORMAT_ENABLED_KEY = "java.format.enabled";
+
+	/**
+	 * Preference key to enable/disable formatter on-type.
+	 */
+	public static final String JAVA_FORMAT_ON_TYPE_ENABLED_KEY = "java.format.onType.enabled";
 
 	/**
 	 * Preference key to enable/disable organize imports on save
@@ -178,6 +183,7 @@ public class Preferences {
 
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
+	public static final String TEXT_DOCUMENT_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting";
 	public static final String TEXT_DOCUMENT_CODE_LENS = "textDocument/codeLens";
 	public static final String TEXT_DOCUMENT_SIGNATURE_HELP = "textDocument/signatureHelp";
 	public static final String TEXT_DOCUMENT_RENAME = "textDocument/rename";
@@ -193,6 +199,7 @@ public class Preferences {
 	public static final String WORKSPACE_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
 
 	public static final String FORMATTING_ID = UUID.randomUUID().toString();
+	public static final String FORMATTING_ON_TYPE_ID = UUID.randomUUID().toString();
 	public static final String FORMATTING_RANGE_ID = UUID.randomUUID().toString();
 	public static final String CODE_LENS_ID = UUID.randomUUID().toString();
 	public static final String SIGNATURE_HELP_ID = UUID.randomUUID().toString();
@@ -216,6 +223,7 @@ public class Preferences {
 	private boolean importMavenEnabled;
 	private boolean implementationsCodeLensEnabled;
 	private boolean javaFormatEnabled;
+	private boolean javaFormatOnTypeEnabled;
 	private boolean javaSaveActionsOrganizeImportsEnabled;
 	private boolean signatureHelpEnabled;
 	private boolean renameEnabled;
@@ -308,6 +316,7 @@ public class Preferences {
 		referencesCodeLensEnabled = true;
 		implementationsCodeLensEnabled = false;
 		javaFormatEnabled = true;
+		javaFormatOnTypeEnabled = false;
 		javaSaveActionsOrganizeImportsEnabled = false;
 		signatureHelpEnabled = false;
 		renameEnabled = true;
@@ -353,6 +362,9 @@ public class Preferences {
 
 		boolean javaFormatEnabled = getBoolean(configuration, JAVA_FORMAT_ENABLED_KEY, true);
 		prefs.setJavaFormatEnabled(javaFormatEnabled);
+
+		boolean javaFormatOnTypeEnabled = getBoolean(configuration, JAVA_FORMAT_ON_TYPE_ENABLED_KEY, false);
+		prefs.setJavaFormatOnTypeEnabled(javaFormatOnTypeEnabled);
 
 		boolean javaSaveActionAutoOrganizeImportsEnabled = getBoolean(configuration, JAVA_SAVE_ACTIONS_ORGANIZE_IMPORTS_KEY, false);
 		prefs.setJavaSaveActionAutoOrganizeImportsEnabled(javaSaveActionAutoOrganizeImportsEnabled);
@@ -631,5 +643,13 @@ public class Preferences {
 
 	public Collection<IPath> getRootPaths() {
 		return rootPaths;
+	}
+
+	public boolean isJavaFormatOnTypeEnabled() {
+		return javaFormatOnTypeEnabled;
+	}
+
+	public void setJavaFormatOnTypeEnabled(boolean javaFormatOnTypeEnabled) {
+		this.javaFormatOnTypeEnabled = javaFormatOnTypeEnabled;
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -152,10 +152,11 @@ public class JDTLanguageServerTest {
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, true);
 		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, true);
 		map.put(Preferences.EXECUTE_COMMAND_ENABLED_KEY, true);
+		map.put(Preferences.JAVA_FORMAT_ON_TYPE_ENABLED_KEY, true);
 		DidChangeConfigurationParams params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
-		verify(client, times(5)).registerCapability(any());
+		verify(client, times(6)).registerCapability(any());
 
 		//On 2nd call, no registration call should be emitted
 		reset(client);
@@ -168,10 +169,11 @@ public class JDTLanguageServerTest {
 		map.put(Preferences.JAVA_FORMAT_ENABLED_KEY, false);
 		map.put(Preferences.SIGNATURE_HELP_ENABLED_KEY, false);
 		map.put(Preferences.EXECUTE_COMMAND_ENABLED_KEY, false);
+		map.put(Preferences.JAVA_FORMAT_ON_TYPE_ENABLED_KEY, false);
 		params = new DidChangeConfigurationParams(map);
 
 		server.didChangeConfiguration(params);
-		verify(client, times(5)).unregisterCapability(any());
+		verify(client, times(6)).unregisterCapability(any());
 
 		//On 2nd call, no unregistration calls should be emitted
 		reset(client);
@@ -210,6 +212,7 @@ public class JDTLanguageServerTest {
 		when(clientPreferences.isRangeFormattingDynamicRegistrationSupported()).thenReturn(enable);
 		when(clientPreferences.isSignatureHelpDynamicRegistrationSupported()).thenReturn(enable);
 		when(clientPreferences.isExecuteCommandDynamicRegistrationSupported()).thenReturn(enable);
+		when(clientPreferences.isOnTypeFormattingDynamicRegistrationSupported()).thenReturn(enable);
 	}
 
 }


### PR DESCRIPTION
Fixes #569

Formatting is triggered when typing `}`, `;` or on new line.
Formats the current line or, in case a `}`  was typed, the previous
block.

Signed-off-by: Fred Bricon <fbricon@gmail.com>