### PR TITLE
Fix project initialization problems

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -121,7 +121,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 		MavenConfigurationImpl configurationImpl = (MavenConfigurationImpl)MavenPlugin.getMavenConfiguration();
 		configurationImpl.setDownloadSources(true);
 		configurationImpl.setNotCoveredMojoExecutionSeverity(ProblemSeverity.ignore.toString());
-		SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 105);
 		subMonitor.setTaskName(IMPORTING_MAVEN_PROJECTS);
 		Set<MavenProjectInfo> files = getMavenProjectInfo(subMonitor.split(5));
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
@@ -142,6 +142,8 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				} else if (project != null) {
 					//Project doesn't have the Maven nature, so we (re)import it
 					digestStore.updateDigest(pom.toPath());
+					// need to delete project due to m2e failing to create if linked and not the same name
+					project.delete(IProject.FORCE | IProject.NEVER_DELETE_PROJECT_CONTENT, subMonitor.split(5));
 					toImport.add(projectInfo);
 				}
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -175,6 +175,7 @@ public class ProjectsManager implements ISaveParticipant {
 				return status;
 			}
 		};
+		job.setRule(getWorkspaceRoot());
 		job.schedule();
 		return job;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -30,7 +30,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.Job;
@@ -177,7 +176,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		assertTrue(project.exists());
 		Job updateJob = projectsManager.updateWorkspaceFolders(Collections.singleton(new org.eclipse.core.runtime.Path(projectDir.toString())), Collections.emptySet());
 		updateJob.join(20000, monitor);
-		assertEquals(IStatus.OK, updateJob.getResult().getSeverity());
+		assertTrue("Failed to import preexistingProjectTest:\n" + updateJob.getResult().getException(), updateJob.getResult().isOK());
 	}
 
 	@Test
@@ -191,7 +190,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 
 		Job updateJob = projectsManager.updateWorkspaceFolders(Collections.singleton(new org.eclipse.core.runtime.Path(workspaceDir.toString())), Collections.emptySet());
 		updateJob.join(20000, monitor);
-		assertEquals(IStatus.OK, updateJob.getResult().getSeverity());
+		assertTrue("Failed to import testImportDifferentName:\n" + updateJob.getResult().getException(), updateJob.getResult().isOK());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #667 by 
1. Handle preexisting projects that can't be imported by m2e and delete the eclipse project before importing
2. Lock workspace when updating the workspace folders