### PR TITLE
Make javadoc and signature methods `public static` to call from JDT LS extensions

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2018 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -103,13 +103,13 @@ public class HoverInfoProvider {
 			}
 			boolean resolved = isResolved(curr, monitor);
 			if (resolved) {
-				MarkedString signature = this.computeSignature(curr);
+				MarkedString signature = computeSignature(curr);
 				if (signature != null) {
 					res.add(Either.forRight(signature));
 				}
-				String javadoc = computeJavadocHover(curr);
-				if (javadoc != null) {
-					res.add(Either.forLeft(javadoc));
+				MarkedString javadoc = computeJavadoc(curr);
+				if (javadoc != null && javadoc.getValue() != null) {
+					res.add(Either.forLeft(javadoc.getValue()));
 				}
 			}
 		} catch (Exception e) {
@@ -163,7 +163,7 @@ public class HoverInfoProvider {
 		return res[0];
 	}
 
-	private MarkedString computeSignature(IJavaElement element)  {
+	public static MarkedString computeSignature(IJavaElement element)  {
 		if (element == null) {
 			return null;
 		}
@@ -178,7 +178,7 @@ public class HoverInfoProvider {
 	}
 
 
-	private String computeJavadocHover(IJavaElement element) throws CoreException {
+	public static MarkedString computeJavadoc(IJavaElement element) throws CoreException {
 		IMember member;
 		if (element instanceof ITypeParameter) {
 			member= ((ITypeParameter) element).getDeclaringMember();
@@ -189,7 +189,7 @@ public class HoverInfoProvider {
 			if(r == null ) {
 				return null;
 			}
-			return getString(r);
+			return new MarkedString(LANGUAGE_ID, getString(r));
 		} else {
 			return null;
 		}
@@ -198,7 +198,7 @@ public class HoverInfoProvider {
 		if(r == null ) {
 			return null;
 		}
-		return getString(r);
+		return new MarkedString(LANGUAGE_ID, getString(r));
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/TestJavadoc.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/TestJavadoc.java
@@ -1,7 +1,18 @@
 package org.sample;
 
+/**
+ * Test javadoc class
+ */
 public class TestJavadoc {
+	
+	/**
+	 * Foo field
+	 */
+	public int fooField;
 
+	/**
+	 * Foo method
+	 */
 	private String foo() {
 		Inner inner = new Inner();
 		return inner.test;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentTest.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Pivotal, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Pivotal, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.javadoc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.HoverInfoProvider;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.MarkedString;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for javadoc and signature of java elements
+ *
+ * @author Alex Boyko
+ *
+ */
+public class JavadocContentTest extends AbstractProjectsManagerBasedTest {
+
+	private IJavaProject project;
+
+	@Before
+	public void setup() throws Exception {
+		importProjects("eclipse/hello");
+		project = JavaCore.create(WorkspaceHelper.getProject("hello"));
+	}
+
+	@Override
+	@After
+	public void cleanUp() throws Exception {
+		super.cleanUp();
+	}
+
+	@Test
+	public void testClassJavadoc() throws Exception {
+		IType type = project.findType("org.sample.TestJavadoc");
+		assertNotNull(type);
+		MarkedString signature = HoverInfoProvider.computeSignature(type);
+		assertEquals("org.sample.TestJavadoc", signature.getValue());
+		MarkedString javadoc = HoverInfoProvider.computeJavadoc(type);
+		assertEquals("Test javadoc class", javadoc.getValue());
+	}
+
+	@Test
+	public void testFieldJavadoc() throws Exception {
+		IType type = project.findType("org.sample.TestJavadoc");
+		assertNotNull(type);
+		IField field = type.getField("fooField");
+		assertNotNull(field);
+		MarkedString signature = HoverInfoProvider.computeSignature(field);
+		assertEquals("int fooField", signature.getValue());
+		MarkedString javadoc = HoverInfoProvider.computeJavadoc(field);
+		assertEquals("Foo field", javadoc.getValue());
+	}
+
+	@Test
+	public void testMethodJavadoc() throws Exception {
+		IType type = project.findType("org.sample.TestJavadoc");
+		assertNotNull(type);
+		IMethod method = type.getMethod("foo", new String[0]);
+		assertNotNull(method);
+		MarkedString signature = HoverInfoProvider.computeSignature(method);
+		assertEquals("String org.sample.TestJavadoc.foo()", signature.getValue());
+		MarkedString javadoc = HoverInfoProvider.computeJavadoc(method);
+		assertEquals("Foo method", javadoc.getValue());
+	}
+}


### PR DESCRIPTION
JDT LS extension may require this package to construct the signature of a Java element.