### PR TITLE
interface/class snippets should not be available inside method bodies

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -44,6 +44,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private CompletionProposalDescriptionProvider descriptionProvider;
 	private CompletionResponse response;
 	private boolean fIsTestCodeExcluded;
+	private CompletionContext context;
 
 	// Update SUPPORTED_KINDS when mapKind changes
 	// @formatter:off
@@ -130,6 +131,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	@Override
 	public void acceptContext(CompletionContext context) {
 		super.acceptContext(context);
+		this.context = context;
 		response.setContext(context);
 		this.descriptionProvider = new CompletionProposalDescriptionProvider(context);
 	}
@@ -216,6 +218,10 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	@Override
 	public boolean isTestCodeExcluded() {
 		return fIsTestCodeExcluded;
+	}
+
+	public CompletionContext getContext() {
+		return context;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -41,7 +41,6 @@ public class CompletionHandler{
 			completionItems = this.computeContentAssist(unit,
 					position.getPosition().getLine(),
 					position.getPosition().getCharacter(), monitor);
-            completionItems.addAll(SnippetCompletionProposal.getSnippets(unit));
 		} catch (OperationCanceledException ignorable) {
 			// No need to pollute logs when query is cancelled
 			monitor.setCanceled(true);
@@ -109,6 +108,7 @@ public class CompletionHandler{
 				try {
 					unit.codeComplete(offset, collector, subMonitor);
 					proposals.addAll(collector.getCompletionItems());
+					proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector.getContext(), subMonitor));
 				} catch (OperationCanceledException e) {
 					monitor.setCanceled(true);
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
@@ -110,21 +110,36 @@ public enum CodeGenerationTemplate {
 			CodeTemplatePreferences.CODETEMPLATE_METHODBODY_DEFAULT),
 
 	/**
+	 * Snippet `public class` content template
+	 */
+	CLASSSNIPPET_PUBLIC(
+			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
+			CodeTemplateContextType.CLASSSNIPPET_CONTEXTTYPE,
+			CodeTemplatePreferences.CODETEMPLATE_CLASSSNIPPET_PUBLIC),
+
+	/**
 	 * Snippet `class` content template
 	 */
-	CLASSSNIPPET(
+	CLASSSNIPPET_DEFAULT(
 			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
 			CodeTemplateContextType.CLASSSNIPPET_CONTEXTTYPE,
 			CodeTemplatePreferences.CODETEMPLATE_CLASSSNIPPET_DEFAULT),
 
 	/**
+	 * Snippet `public interface` content template
+	 */
+	INTERFACESNIPPET_PUBLIC(
+			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
+			CodeTemplateContextType.INTERFACESNIPPET_CONTEXTTYPE,
+			CodeTemplatePreferences.CODETEMPLATE_INTERFACESNIPPET_PUBLIC),
+
+	/**
 	 * Snippet `interface` content template
 	 */
-	INTERFACESNIPPET(
+	INTERFACESNIPPET_DEFAULT(
 			CodeTemplatePreferences.CODETEMPLATE_CODESNIPPET,
 			CodeTemplateContextType.INTERFACESNIPPET_CONTEXTTYPE,
 			CodeTemplatePreferences.CODETEMPLATE_INTERFACESNIPPET_DEFAULT);
-
 
 	private final String preferenceId;
 	private final String contextType;
@@ -288,10 +303,18 @@ class CodeTemplatePreferences {
 	/**
 	 * Default value for class snippet body content
 	 */
-	public static final String CODETEMPLATE_CLASSSNIPPET_DEFAULT = "${package_header}/**\n * ${type_name}\n */\npublic class ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_CLASSSNIPPET_DEFAULT = "${package_header}class ${type_name} {\n\n\t${cursor}\n}";
 
+	/**
+	 * Default value for public class snippet body content
+	 */
+	public static final String CODETEMPLATE_CLASSSNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic class ${type_name} {\n\n\t${cursor}\n}";
 	/**
 	 * Default value for interface snippet body content
 	 */
-	public static final String CODETEMPLATE_INTERFACESNIPPET_DEFAULT = "${package_header}/**\n * ${type_name}\n */\npublic interface ${type_name} {\n\n\t${cursor}\n}";
+	public static final String CODETEMPLATE_INTERFACESNIPPET_DEFAULT = "${package_header}interface ${type_name} {\n\n\t${cursor}\n}";
+	/**
+	 * Default value for public interface snippet body content
+	 */
+	public static final String CODETEMPLATE_INTERFACESNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic interface ${type_name} {\n\n\t${cursor}\n}";
 }


### PR DESCRIPTION
Fixes #681 

I have removed the class/interface snippets from the following contexts:

- javadoc
- package declaration
- imports
- method body 

The class snippets is sometimes allowed in the method body such as:
```
public class Test {
	void test() {
		class InnerTest {
		}
	}
}
```
- static (the class snippet is allowed, interface is not allowed)

I have also changed the snippets to not generate duplicated public keywords, as in the following place:
```
package org.sample;
public |
```

BTW all the client snippets have the same issue.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>