### PR TITLE
Fix renaming issue for default project.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -60,6 +60,7 @@ public class BuildWorkspaceHandler {
 			if (monitor.isCanceled()) {
 				return BuildWorkspaceStatus.CANCELLED;
 			}
+			projectsManager.cleanupResources(projectsManager.getDefaultProject());
 			ResourcesPlugin.getWorkspace().build(forceReBuild ? IncrementalProjectBuilder.FULL_BUILD : IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
 			List<IMarker> problemMarkers = getProblemMarkers(monitor);
 			publishDiagnostics(problemMarkers);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandler.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -347,6 +348,12 @@ public class DocumentLifeCycleHandler {
 				sharedASTProvider.disposeAST();
 			}
 			unit.discardWorkingCopy();
+			if (JDTUtils.isDefaultProject(unit)) {
+				File f = new File(unit.getUnderlyingResource().getLocationURI());
+				if (!f.exists()) {
+					unit.delete(true, null);
+				}
+			}
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Error while handling document close", e);
 		}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/WithError.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/WithError.java
@@ -1,0 +1,6 @@
+public class WrongName {
+	public static void main(String[] args)
+    {
+        String s = "1";
+        System.out.println("Hello World!" + s);
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -20,28 +21,21 @@ import java.nio.charset.StandardCharsets;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
-/**
- * @author xuzho
- *
- */
-@RunWith(MockitoJUnitRunner.class)
 public class BuildWorkspaceHandlerTest extends AbstractProjectsManagerBasedTest {
-	@Mock
-	private JavaClientConnection connection;
-	@InjectMocks
+	private JavaLanguageClient client = mock(JavaLanguageClient.class);
+	private JavaClientConnection javaClient = new JavaClientConnection(client);
+
 	private BuildWorkspaceHandler handler;
 	private IFile file;
 
 	@Before
 	public void setUp() throws Exception {
+		handler = new BuildWorkspaceHandler(javaClient, projectsManager);
 		importProjects("maven/salut2");
 		file = linkFilesToDefaultProject("singlefile/Single.java");
 	}


### PR DESCRIPTION
https://github.com/redhat-developer/vscode-java/issues/578

For default project, every file will have a section such as:
```xml
	<linkedResources>
		<link>
			<name>src/Test.java</name>
			<type>1</type>
			<location>d:/Workspace/examples/repro/src/Test.java</location>
		</link>
	</linkedResources>
```

This section will not be deleted when renaming, thus causes building error. 

I believe several building errors related to this one. 