### PR TITLE
Fix perf issue by preventing unnecessary building when open workspace.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -62,7 +62,7 @@ public class BuildWorkspaceHandler {
 				}
 			}
 			ResourcesPlugin.getWorkspace().build(forceReBuild ? IncrementalProjectBuilder.FULL_BUILD : IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			List<IMarker> problemMarkers = workspaceDiagnosticsHandler.publichDiagnostic(monitor);
+			List<IMarker> problemMarkers = workspaceDiagnosticsHandler.publishDiagnostics(monitor);
 			List<String> errors = problemMarkers.stream().filter(m -> m.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR).map(e -> convertMarker(e)).collect(Collectors.toList());
 			if (errors.isEmpty()) {
 				return BuildWorkspaceStatus.SUCCEED;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandler.java
@@ -13,38 +13,25 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logError;
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaModelMarker;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
-import org.eclipse.lsp4j.Range;
 
 /**
  * @author xuzho
@@ -53,10 +40,12 @@ import org.eclipse.lsp4j.Range;
 public class BuildWorkspaceHandler {
 	private JavaClientConnection connection;
 	private final ProjectsManager projectsManager;
+	private final WorkspaceDiagnosticsHandler workspaceDiagnosticsHandler;
 
-	public BuildWorkspaceHandler(JavaClientConnection connection, ProjectsManager projectsManager) {
+	public BuildWorkspaceHandler(JavaClientConnection connection, ProjectsManager projectsManager, WorkspaceDiagnosticsHandler workspaceDiagnosticHandler) {
 		this.connection = connection;
 		this.projectsManager = projectsManager;
+		this.workspaceDiagnosticsHandler = workspaceDiagnosticHandler;
 	}
 
 	public BuildWorkspaceStatus buildWorkspace(boolean forceReBuild, IProgressMonitor monitor) {
@@ -73,8 +62,7 @@ public class BuildWorkspaceHandler {
 				}
 			}
 			ResourcesPlugin.getWorkspace().build(forceReBuild ? IncrementalProjectBuilder.FULL_BUILD : IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
-			List<IMarker> problemMarkers = getProblemMarkers(monitor);
-			publishDiagnostics(problemMarkers);
+			List<IMarker> problemMarkers = workspaceDiagnosticsHandler.publichDiagnostic(monitor);
 			List<String> errors = problemMarkers.stream().filter(m -> m.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR).map(e -> convertMarker(e)).collect(Collectors.toList());
 			if (errors.isEmpty()) {
 				return BuildWorkspaceStatus.SUCCEED;
@@ -89,58 +77,6 @@ public class BuildWorkspaceHandler {
 			return BuildWorkspaceStatus.FAILED;
 		} catch (OperationCanceledException e) {
 			return BuildWorkspaceStatus.CANCELLED;
-		}
-	}
-
-	private static List<IMarker> getProblemMarkers(IProgressMonitor monitor) throws CoreException {
-		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		List<IMarker> markers = new ArrayList<>();
-		for (IProject project : projects) {
-			if (monitor.isCanceled()) {
-				throw new OperationCanceledException();
-			}
-			markers.addAll(Arrays.asList(project.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)));
-		}
-		return markers;
-	}
-
-	private void publishDiagnostics(List<IMarker> markers) {
-		Map<IResource, List<IMarker>> map = markers.stream().collect(Collectors.groupingBy(IMarker::getResource));
-		for (Map.Entry<IResource, List<IMarker>> entry : map.entrySet()) {
-			IResource resource = entry.getKey();
-			// ignore problems caused by standalone files
-			if (JavaLanguageServerPlugin.getProjectsManager().getDefaultProject().equals(resource.getProject())) {
-				continue;
-			}
-			if (resource instanceof IProject) {
-				String uri = JDTUtils.getFileURI(resource);
-				Range range = new Range(new Position(0, 0), new Position(0, 0));
-				List<Diagnostic> diagnostics = WorkspaceDiagnosticsHandler.toDiagnosticArray(range, entry.getValue().toArray(new IMarker[0]));
-				connection.publishDiagnostics(new PublishDiagnosticsParams(ResourceUtils.toClientUri(uri), diagnostics));
-				continue;
-			}
-			IFile file = resource.getAdapter(IFile.class);
-			if (file == null) {
-				continue;
-			}
-			IDocument document = null;
-			String uri = JDTUtils.getFileURI(resource);
-			if (JavaCore.isJavaLikeFileName(file.getName())) {
-				ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
-				try {
-					document = JsonRpcHelpers.toDocument(cu.getBuffer());
-				} catch (JavaModelException e) {
-					logException("Failed to publish diagnostics.", e);
-				}
-			}
-			else if (projectsManager.isBuildFile(file)) {
-				document = JsonRpcHelpers.toDocument(file);
-			}
-
-			if (document != null) {
-				List<Diagnostic> diagnostics = WorkspaceDiagnosticsHandler.toDiagnosticsArray(document, entry.getValue().toArray(new IMarker[0]));
-				connection.publishDiagnostics(new PublishDiagnosticsParams(ResourceUtils.toClientUri(uri), diagnostics));
-			}
 		}
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -221,6 +221,7 @@ final public class InitHandler {
 				try {
 					projectsManager.setAutoBuilding(false);
 					projectsManager.initializeProjects(roots, subMonitor);
+					projectsManager.setAutoBuilding(preferenceManager.getPreferences().isAutobuildEnabled());
 					JavaLanguageServerPlugin.logInfo("Workspace initialized in " + (System.currentTimeMillis() - start) + "ms");
 					connection.sendStatus(ServiceStatus.Started, "Ready");
 				} catch (OperationCanceledException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
@@ -66,7 +65,6 @@ final public class InitHandler {
 	private ProjectsManager projectsManager;
 	private JavaClientConnection connection;
 	private PreferenceManager preferenceManager;
-	private static WorkspaceDiagnosticsHandler workspaceDiagnosticsHandler;
 
 	public InitHandler(ProjectsManager manager, PreferenceManager preferenceManager, JavaClientConnection connection) {
 		this.projectsManager = manager;
@@ -123,7 +121,6 @@ final public class InitHandler {
 		}
 		preferenceManager.getPreferences().setRootPaths(rootPaths);
 		triggerInitialization(rootPaths);
-		addWorkspaceDiagnosticsHandler();
 		Integer processId = param.getProcessId();
 		if (processId != null) {
 			JavaLanguageServerPlugin.getLanguageServer().setParentProcessId(processId.longValue());
@@ -262,17 +259,4 @@ final public class InitHandler {
 		return null;
 	}
 
-	@Deprecated
-	public static void removeWorkspaceDiagnosticsHandler() {
-		if (workspaceDiagnosticsHandler != null) {
-			ResourcesPlugin.getWorkspace().removeResourceChangeListener(workspaceDiagnosticsHandler);
-			workspaceDiagnosticsHandler = null;
-		}
-	}
-
-	public void addWorkspaceDiagnosticsHandler() {
-		removeWorkspaceDiagnosticsHandler();
-		workspaceDiagnosticsHandler = new WorkspaceDiagnosticsHandler(connection, projectsManager);
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(workspaceDiagnosticsHandler, IResourceChangeEvent.POST_CHANGE);
-	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -212,7 +212,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		
 		computeAsync((monitor) -> {
 			try {
-				workspaceDiagnosticsHandler.publichDiagnostic(monitor);
+				workspaceDiagnosticsHandler.publishDiagnostics(monitor);
 			} catch (CoreException e) {
 				logException(e.getMessage(), e);
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -124,6 +124,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	private LanguageServerWorkingCopyOwner workingCopyOwner;
 	private PreferenceManager preferenceManager;
 	private DocumentLifeCycleHandler documentLifeCycleHandler;
+	private WorkspaceDiagnosticsHandler workspaceDiagnosticsHandler;
 
 	private Set<String> registeredCapabilities = new HashSet<>(3);
 
@@ -205,6 +206,18 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		// we do not have the user setting initialized yet at this point but we should
 		// still call to enable defaults in case client does not support configuration changes
 		syncCapabilitiesToSettings();
+
+		workspaceDiagnosticsHandler = new WorkspaceDiagnosticsHandler(this.client, pm);
+		workspaceDiagnosticsHandler.addResourceChangeListener();
+		
+		computeAsync((monitor) -> {
+			try {
+				workspaceDiagnosticsHandler.publichDiagnostic(monitor);
+			} catch (CoreException e) {
+				logException(e.getMessage(), e);
+			}
+			return new Object();
+		});
 	}
 
 	/**
@@ -244,7 +257,10 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		logInfo(">> shutdown");
 		return computeAsync((monitor) -> {
 			try {
-				InitHandler.removeWorkspaceDiagnosticsHandler();
+				if (workspaceDiagnosticsHandler != null) {
+					workspaceDiagnosticsHandler.removeResourceChangeListener();
+					workspaceDiagnosticsHandler = null;
+				}
 				ResourcesPlugin.getWorkspace().save(true, monitor);
 			} catch (CoreException e) {
 				logException(e.getMessage(), e);
@@ -681,7 +697,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<BuildWorkspaceStatus> buildWorkspace(boolean forceReBuild) {
 		logInfo(">> java/buildWorkspace (" + (forceReBuild ? "full)" : "incremental)"));
-		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(client, pm);
+		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(client, pm, workspaceDiagnosticsHandler);
 		return computeAsync((monitor) -> handler.buildWorkspace(forceReBuild, monitor));
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -205,12 +205,6 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		// we do not have the user setting initialized yet at this point but we should
 		// still call to enable defaults in case client does not support configuration changes
 		syncCapabilitiesToSettings();
-		try {
-			boolean autoBuildChanged = pm.setAutoBuilding(preferenceManager.getPreferences().isAutobuildEnabled());
-			buildWorkspace(autoBuildChanged);
-		} catch (CoreException e) {
-			JavaLanguageServerPlugin.logException(e.getMessage(), e);
-		}
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -143,7 +143,7 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 		return false;
 	}
 
-	public List<IMarker> publichDiagnostic(IProgressMonitor monitor) throws CoreException {
+	public List<IMarker> publishDiagnostics(IProgressMonitor monitor) throws CoreException {
 		List<IMarker> problemMarkers = getProblemMarkers(monitor);
 		publishDiagnostics(problemMarkers);
 		return problemMarkers;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
@@ -35,7 +35,7 @@ public class BuildWorkspaceHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Before
 	public void setUp() throws Exception {
-		handler = new BuildWorkspaceHandler(javaClient, projectsManager);
+		handler = new BuildWorkspaceHandler(javaClient, projectsManager, new WorkspaceDiagnosticsHandler(javaClient, projectsManager));
 		importProjects("maven/salut2");
 		file = linkFilesToDefaultProject("singlefile/Single.java");
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -245,8 +245,6 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@Test
 	public void testProjectConfigurationIsNotUpToDate() throws Exception {
-		InitHandler initHandler = new InitHandler(projectsManager, preferenceManager, connection);
-		initHandler.addWorkspaceDiagnosticsHandler();
 		//import project
 		importProjects("maven/salut");
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -60,6 +61,11 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@InjectMocks
 	private WorkspaceDiagnosticsHandler handler;
+
+	@Before
+	public void setup() throws Exception {
+		handler.addResourceChangeListener();
+	}
 
 	@Test
 	public void testToDiagnosticsArray() throws Exception {
@@ -112,8 +118,6 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@Test
 	public void testTaskMarkers() throws Exception {
-		InitHandler initHandler = new InitHandler(projectsManager, preferenceManager, connection);
-		initHandler.addWorkspaceDiagnosticsHandler();
 		//import project
 		importProjects("eclipse/hello");
 		ArgumentCaptor<PublishDiagnosticsParams> captor = ArgumentCaptor.forClass(PublishDiagnosticsParams.class);
@@ -179,8 +183,6 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@Test
 	public void testMarkerListening() throws Exception {
-		InitHandler initHandler = new InitHandler(projectsManager, preferenceManager, connection);
-		initHandler.addWorkspaceDiagnosticsHandler();
 		//import project
 		importProjects("maven/broken");
 
@@ -220,8 +222,6 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@Test
 	public void testProjectLevelMarkers() throws Exception {
-		InitHandler initHandler = new InitHandler(projectsManager, preferenceManager, connection);
-		initHandler.addWorkspaceDiagnosticsHandler();
 		//import project
 		importProjects("maven/broken");
 		ArgumentCaptor<PublishDiagnosticsParams> captor = ArgumentCaptor.forClass(PublishDiagnosticsParams.class);
@@ -307,7 +307,7 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 
 	@After
 	public void removeResourceChangeListener() {
-		InitHandler.removeWorkspaceDiagnosticsHandler();
+		handler.removeResourceChangeListener();
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -45,7 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -59,11 +58,11 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 	@Mock
 	private JavaClientConnection connection;
 
-	@InjectMocks
 	private WorkspaceDiagnosticsHandler handler;
 
 	@Before
 	public void setup() throws Exception {
+		handler = new WorkspaceDiagnosticsHandler(connection, projectsManager);
 		handler.addResourceChangeListener();
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.handlers.BuildWorkspaceHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.WorkspaceDiagnosticsHandler;
 import org.junit.Test;
 
 /**
@@ -57,7 +58,7 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		java.io.File physicalFile = new java.io.File(file.getLocationURI());
 		physicalFile.delete();
 
-		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(javaClient, projectsManager);
+		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(javaClient, projectsManager, new WorkspaceDiagnosticsHandler(javaClient, projectsManager));
 		BuildWorkspaceStatus result = handler.buildWorkspace(true, monitor);
 
 		waitForBackgroundJobs();


### PR DESCRIPTION
@gorkem @fbricon 

The force build on initialized will block the LSP protocol to wait for its response. And this action is not necessary to triggered every time when the auto build is true. 
Restore the auto building value will make building as a worker thread and response to the client quickly. 

With this change, eclipse.jdt.ls will match the performance of eclipse on import/reopen scenario. 