### PR TITLE
Add textdocument/implementation support.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -488,6 +488,16 @@ public final class JDTUtils {
 		return new Range(new Position(), new Position());
 	}
 
+	/**
+	 * Creates a new {@link Range} with its start and end {@link Position}s set to
+	 * the given line
+	 *
+	 * @return a new {@link Range};
+	 */
+	public static Range newLineRange(int line, int start, int end) {
+		return new Range(new Position(line, start), new Position(line, end));
+	}
+
 	private static void setPosition(Position position, int[] coords) {
 		assert coords.length == 2;
 		position.setLine(coords[0]);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationCollector.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationCollector.java
@@ -1,0 +1,276 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat, Inc. - decouple implementation search from jdt.ui
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
+import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.util.JdtFlags;
+import org.eclipse.jdt.internal.corext.util.MethodOverrideTester;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.Messages;
+import org.eclipse.jface.text.IRegion;
+
+
+/**
+ * Searches for {@link IJavaElement} implementations.
+ *
+ * Parts of the search logic was borrowed from
+ * org.eclipse.jdt.internal.ui.javaeditor.JavaElementImplementationHyperlink.java
+ *
+ */
+public class ImplementationCollector<T> {
+
+
+	/**
+	 * Maps {@link IJavaElement} and position coordinates results to a type
+	 *
+	 * @param <T>
+	 */
+	public static interface ResultMapper<T> {
+
+		T convert(IJavaElement element, int offset, int position);
+	}
+
+	private static final String JavaElementImplementationHyperlink_search_implementors = "Searching for implementors...";
+	private static final String JavaElementImplementationHyperlink_search_method_implementors = "Searching for implementors of ''{0}''...";
+	private final IRegion region;
+	private final IJavaElement javaElement;
+	private ResultMapper<T> mapper;
+
+	/**
+	 * @param region the region of the link
+	 * @param javaElement the element (type or method) to open
+	 */
+	public ImplementationCollector(IRegion region, IJavaElement javaElement, ResultMapper<T> mapper) {
+		Assert.isNotNull(region);
+		Assert.isNotNull(javaElement);
+		Assert.isNotNull(mapper);
+		Assert.isTrue(javaElement instanceof IType || javaElement instanceof IMethod);
+		this.region = region;
+		this.javaElement = javaElement;
+		this.mapper = mapper;
+	}
+
+	/**
+	 * Finds the implementations for the method or type.
+	 * 
+	 * @return an unmodifiable {@link List} of T, never <code>null</code>.
+	 */
+	public List<T> findImplementations(IProgressMonitor monitor) throws CoreException {
+		if (monitor == null) {
+			monitor = new NullProgressMonitor();
+		}
+		monitor.setTaskName(JavaElementImplementationHyperlink_search_implementors);
+		List<T> implementations = null;
+		if (javaElement instanceof IMethod) {
+			implementations = findMethodImplementations(monitor);
+		} else if (javaElement instanceof IType) {
+			implementations = findTypeImplementations(monitor);
+		}
+		return implementations == null ? Collections.emptyList() : Collections.unmodifiableList(implementations);
+	}
+
+	private List<T> findTypeImplementations(IProgressMonitor monitor) throws JavaModelException {
+		IType type = (IType) javaElement;
+		List<T> results = null;
+		try {
+			String typeLabel = JavaElementLabelsCore.getElementLabel(type, JavaElementLabelsCore.DEFAULT_QUALIFIED);
+			monitor.beginTask(Messages.format(JavaElementImplementationHyperlink_search_method_implementors, typeLabel), 10);
+			IType[] allTypes = type.newTypeHierarchy(monitor).getAllSubtypes(type);
+			results = Arrays.stream(allTypes).map(el -> mapper.convert(el, 0, 0)).filter(Objects::nonNull).collect(Collectors.toList());
+			if (monitor.isCanceled()) {
+				throw new OperationCanceledException();
+			}
+		} finally {
+			monitor.done();
+		}
+		return results;
+	}
+
+	private List<T> findMethodImplementations(IProgressMonitor monitor) throws CoreException {
+		IMethod method = (IMethod) javaElement;
+		try {
+			if (cannotBeOverriddenMethod(method)) {
+				return null;
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException("Find method implementations failure ", e);
+			return null;
+		}
+		ITypeRoot typeRoot = (ICompilationUnit) method.getAncestor(IJavaElement.COMPILATION_UNIT);
+		if (typeRoot == null) {
+			typeRoot = (IClassFile) method.getAncestor(IJavaElement.CLASS_FILE);
+		}
+
+		CompilationUnit ast = CoreASTProvider.getInstance().getAST(typeRoot, CoreASTProvider.WAIT_YES, monitor);
+		if (ast == null) {
+			return null;
+		}
+
+		ASTNode node = NodeFinder.perform(ast, region.getOffset(), region.getLength());
+		ITypeBinding parentTypeBinding = null;
+		if (node instanceof SimpleName) {
+			ASTNode parent = node.getParent();
+			if (parent instanceof MethodInvocation) {
+				Expression expression = ((MethodInvocation) parent).getExpression();
+				if (expression == null) {
+					parentTypeBinding= Bindings.getBindingOfParentType(node);
+				} else {
+					parentTypeBinding = expression.resolveTypeBinding();
+				}
+			} else if (parent instanceof SuperMethodInvocation) {
+				// Directly go to the super method definition
+				return Collections.singletonList(mapper.convert(method, 0, 0));
+			} else if (parent instanceof MethodDeclaration) {
+				parentTypeBinding = Bindings.getBindingOfParentType(node);
+			}
+		}
+		final IType receiverType = getType(parentTypeBinding);
+		if (receiverType == null) {
+			return null;
+		}
+
+		final List<T> results = new ArrayList<>();
+		try {
+			String methodLabel = JavaElementLabelsCore.getElementLabel(method, JavaElementLabelsCore.DEFAULT_QUALIFIED);
+			monitor.beginTask(Messages.format(JavaElementImplementationHyperlink_search_method_implementors, methodLabel), 10);
+			SearchRequestor requestor = new SearchRequestor() {
+				@Override
+				public void acceptSearchMatch(SearchMatch match) throws CoreException {
+					if (match.getAccuracy() == SearchMatch.A_ACCURATE) {
+						Object element = match.getElement();
+						if (element instanceof IMethod) {
+							IMethod methodFound = (IMethod) element;
+							if (!JdtFlags.isAbstract(methodFound)) {
+								T result = mapper.convert(methodFound, match.getOffset(), match.getLength());
+								if (result != null) {
+									results.add(result);
+								}
+							}
+						}
+					}
+				}
+			};
+
+			IJavaSearchScope hierarchyScope;
+			if (receiverType.isInterface()) {
+				hierarchyScope = SearchEngine.createHierarchyScope(method.getDeclaringType());
+			} else {
+				if (isFullHierarchyNeeded(new SubProgressMonitor(monitor, 3), method, receiverType)) {
+					hierarchyScope = SearchEngine.createHierarchyScope(receiverType);
+				} else {
+					boolean isMethodAbstract = JdtFlags.isAbstract(method);
+					hierarchyScope = SearchEngine.createStrictHierarchyScope(null, receiverType, true, isMethodAbstract, null);
+				}
+			}
+
+			int limitTo = IJavaSearchConstants.DECLARATIONS | IJavaSearchConstants.IGNORE_DECLARING_TYPE | IJavaSearchConstants.IGNORE_RETURN_TYPE;
+			SearchPattern pattern = SearchPattern.createPattern(method, limitTo);
+			Assert.isNotNull(pattern);
+			SearchParticipant[] participants = new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() };
+			SearchEngine engine = new SearchEngine();
+			engine.search(pattern, participants, hierarchyScope, requestor, new SubProgressMonitor(monitor, 7));
+			if (monitor.isCanceled()) {
+				throw new OperationCanceledException();
+			}
+		} finally {
+			monitor.done();
+		}
+		return results;
+	}
+
+
+	private static IType getType(ITypeBinding typeBinding) {
+		if (typeBinding == null) {
+			return null;
+		}
+		if (typeBinding.isTypeVariable()) {
+			ITypeBinding[] typeBounds= typeBinding.getTypeBounds();
+			if (typeBounds.length > 0) {
+				typeBinding= typeBounds[0].getTypeDeclaration();
+			} else {
+				return null;
+			}
+		}
+		return (IType) typeBinding.getJavaElement();
+	}
+
+	/**
+	 * Checks whether or not a method can be overridden.
+	 *
+	 * @param method the method
+	 * @return <code>true</code> if the method cannot be overridden, <code>false</code> otherwise
+	 * @throws JavaModelException if this element does not exist or if an exception occurs while
+	 *             accessing its corresponding resource
+	 * @since 3.7
+	 */
+	private static boolean cannotBeOverriddenMethod(IMethod method) throws JavaModelException {
+		return JdtFlags.isPrivate(method) || JdtFlags.isFinal(method) || JdtFlags.isStatic(method) || method.isConstructor()
+				|| JdtFlags.isFinal((IMember)method.getParent());
+	}
+
+	/**
+	 * Checks whether a full type hierarchy is needed to search for implementors.
+	 *
+	 * @param monitor the progress monitor
+	 * @param method the method
+	 * @param receiverType the receiver type
+	 * @return <code>true</code> if a full type hierarchy is needed, <code>false</code> otherwise
+	 * @throws JavaModelException if the java element does not exist or if an exception occurs while
+	 *             accessing its corresponding resource
+	 * @since 3.6
+	 */
+	private static boolean isFullHierarchyNeeded(IProgressMonitor monitor, IMethod method, IType receiverType) throws JavaModelException {
+		ITypeHierarchy superTypeHierarchy= receiverType.newSupertypeHierarchy(monitor);
+		MethodOverrideTester methodOverrideTester= new MethodOverrideTester(receiverType, superTypeHierarchy);
+		return methodOverrideTester.findOverriddenMethodInType(receiverType, method) == null;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationToLocationMapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationToLocationMapper.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.eclipse.jdt.ls.core.internal.JDTUtils.toLocation;
+
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.handlers.ImplementationCollector.ResultMapper;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Maps {@link IJavaElement} and a position to a {@link Location} object.
+ */
+public class ImplementationToLocationMapper implements ResultMapper<Location> {
+
+	private boolean includeClassFiles;
+	private boolean useDefaultPosition;
+
+	/**
+	 * Creates a ImplementationToLocationMapper instance. If
+	 * <b>includeClassFiles</b> is <code>true</code>, will include elements from
+	 * binary files. If <b>useDefaultPosition</b> is <code>true</code>, returned
+	 * {@link Location} will always return a default {@link Range}, at
+	 * {@link Position}s [0,0].
+	 *
+	 * @param includeClassFiles,
+	 *            if <code>true</code>, will include elements from binary files
+	 * @param useDefaultPosition,
+	 *            if <code>true</code>, will always return a default
+	 *            Range([0,0],[0,0]) ( to avoid actually reading files)
+	 */
+	public ImplementationToLocationMapper(boolean includeClassFiles, boolean useDefaultPosition) {
+		this.includeClassFiles = includeClassFiles;
+		this.useDefaultPosition = useDefaultPosition;
+	}
+
+	@Override
+	public Location convert(IJavaElement element, int offset, int position) {
+		ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
+		Location location = null;
+		try {
+			if (compilationUnit != null) {
+				if (useDefaultPosition || offset > 0 && position > 0) {
+					//builds location from offset and position directly
+					location = toLocation(compilationUnit, offset, position);
+				} else {
+					// opens file to determine location
+					location = toLocation(element);
+				}
+
+			} else if (includeClassFiles) {
+				IClassFile cf = (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
+				if (cf != null) {
+					if (useDefaultPosition || offset > 0 && position > 0) {
+						//builds location from offset and position directly
+						location = toLocation(cf, offset, position);
+					} else {
+						//opens source to determine location
+						location = toLocation(element);
+						if (location == null) {//If no source was attached, return default location
+							location = toLocation(cf, 0, 0);
+						}
+					}
+				}
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException("Failed to convert " + element, e);
+		}
+		return location;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandler.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+
+/**
+ * Implementations handler
+ *
+ * @author Fred Bricon
+ */
+public class ImplementationsHandler {
+
+	private PreferenceManager preferenceManager;
+
+	public ImplementationsHandler(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
+	}
+
+	public List<? extends Location> findImplementations(TextDocumentPositionParams param, IProgressMonitor monitor) {
+		List<Location> locations = null;
+		IJavaElement elementToSearch = null;
+		try {
+			ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(param.getTextDocument().getUri());
+			if (typeRoot != null) {
+				elementToSearch = JDTUtils.findElementAtSelection(typeRoot, param.getPosition().getLine(), param.getPosition().getCharacter(), this.preferenceManager, monitor);
+			}
+			if (elementToSearch == null) {
+				return Collections.emptyList();
+			}
+			int offset = getOffset(param, typeRoot);
+			IRegion region = new Region(offset, 0);
+			IType primaryType = typeRoot.findPrimaryType();
+			//java.lang.Object is a special case. We need to minimize heavy cost of I/O,
+			// by avoiding opening all files from the Object hierarchy
+			boolean useDefaultLocation = primaryType == null ? false : "java.lang.Object".equals(primaryType.getFullyQualifiedName());
+			ImplementationToLocationMapper mapper = new ImplementationToLocationMapper(preferenceManager.isClientSupportsClassFileContent(), useDefaultLocation);
+			ImplementationCollector<Location> collector = new ImplementationCollector<>(region, elementToSearch, mapper);
+			locations = collector.findImplementations(monitor);
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logException("Find implementations failure ", e);
+		}
+
+		return locations;
+	}
+
+	private int getOffset(TextDocumentPositionParams param, ITypeRoot typeRoot) {
+		int offset = 0;
+		try {
+			IDocument document = JsonRpcHelpers.toDocument(typeRoot.getBuffer());
+			offset = document.getLineOffset(param.getPosition().getLine()) + param.getPosition().getCharacter();
+		} catch (JavaModelException | BadLocationException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+		}
+		return offset;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -184,6 +184,9 @@ final public class InitHandler {
 		if (!preferenceManager.getClientPreferences().isDocumentHighlightDynamicRegistered()) {
 			capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		}
+		if (!preferenceManager.getClientPreferences().isImplementationDynamicRegistered()) {
+			capabilities.setImplementationProvider(Boolean.TRUE);
+		}
 		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setOpenClose(Boolean.TRUE);
 		textDocumentSyncOptions.setSave(new SaveOptions(Boolean.TRUE));
@@ -258,6 +261,7 @@ final public class InitHandler {
 		return null;
 	}
 
+	@Deprecated
 	public static void removeWorkspaceDiagnosticsHandler() {
 		if (workspaceDiagnosticsHandler != null) {
 			ResourcesPlugin.getWorkspace().removeResourceChangeListener(workspaceDiagnosticsHandler);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
@@ -61,6 +61,10 @@ public class ProgressReporterManager extends ProgressProvider {
 		return new ProgressReporter();
 	}
 
+	public IProgressMonitor getProgressReporter(CancelChecker checker) {
+		return new ProgressReporter(checker);
+	}
+
 	@Override
 	public IProgressMonitor createProgressGroup() {
 		return getDefaultMonitor();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -136,6 +136,10 @@ public class ClientPreferences {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getDocumentHighlight());
 	}
 
+	public boolean isImplementationDynamicRegistered() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getImplementation());
+	}
+
 	public boolean isWillSaveRegistered() {
 		return v3supported && capabilities.getTextDocument().getSynchronization() != null && isTrue(capabilities.getTextDocument().getSynchronization().getWillSave());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -208,6 +208,7 @@ public class Preferences {
 	public static final String REFERENCES = "textDocument/references";
 	public static final String DOCUMENT_HIGHLIGHT = "textDocument/documentHighlight";
 	public static final String WORKSPACE_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
+	public static final String IMPLEMENTATION = "textDocument/implementation";
 
 	public static final String FORMATTING_ID = UUID.randomUUID().toString();
 	public static final String FORMATTING_ON_TYPE_ID = UUID.randomUUID().toString();
@@ -226,6 +227,7 @@ public class Preferences {
 	public static final String DOCUMENT_HIGHLIGHT_ID = UUID.randomUUID().toString();
 	public static final String WORKSPACE_CHANGE_FOLDERS_ID = UUID.randomUUID().toString();
 	public static final String WORKSPACE_WATCHED_FILES_ID = UUID.randomUUID().toString();
+	public static final String IMPLEMENTATION_ID = UUID.randomUUID().toString();
 
 	private Map<String, Object> configuration;
 	private Severity incompleteClasspathSeverity;

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo.java
@@ -1,0 +1,10 @@
+package org.sample;
+
+public class Foo {
+
+	public static void main(String[] args) {
+		System.out.print("Hello world!");
+	}
+	
+	public void someMethod() {}
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo2.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo2.java
@@ -1,0 +1,6 @@
+package org.sample;
+
+public class Foo2 implements IFoo {
+
+    public void someMethod() {}
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo3.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo3.java
@@ -1,0 +1,8 @@
+package org.sample;
+
+/**
+ * This is foo3
+ */
+public class Foo3 extends Foo2 {
+
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/IFoo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/IFoo.java
@@ -1,0 +1,7 @@
+package java;
+
+public interface IFoo {
+	
+	void someMethod();
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
@@ -252,7 +251,7 @@ public class CodeLensHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testResolveImplementationsCodeLense() {
+	public void testResolveImplementationsCodeLens() {
 		String source = "src/java/IFoo.java";
 		String payload = createCodeLensImplementationsRequest(source, 5, 17, 21);
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandlerTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * ImplementationsHandlerTest
+ */
+public class ImplementationsHandlerTest extends AbstractProjectsManagerBasedTest{
+
+	private ImplementationsHandler handler;
+	private IProject project;
+
+
+	@Before
+	public void setup() throws Exception{
+		importProjects("eclipse/hello");
+		project = WorkspaceHelper.getProject("hello");
+		preferenceManager = mock(PreferenceManager.class);
+		when(preferenceManager.getPreferences()).thenReturn(new Preferences());
+		handler = new ImplementationsHandler(preferenceManager);
+	}
+
+	@Test
+	public void testEmpty(){
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(1, 1));
+		param.setTextDocument(new TextDocumentIdentifier("/foo/bar"));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull(implementations);
+		assertTrue("implementations are not empty", implementations.isEmpty());
+	}
+
+	@Test
+	public void testInterfaceImplementation() {
+		URI uri = project.getFile("src/org/sample/IFoo.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(2, 20)); //Position over IFoo
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(2, implementations.size());
+		Location foo2 = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo2.getUri(), foo2.getUri().contains("org/sample/Foo2.java"));
+		assertEquals(JDTUtils.newLineRange(2, 13, 17), foo2.getRange());
+		Location foo3 = implementations.get(1);
+		assertTrue("Unexpected implementation : " + foo3.getUri(), foo3.getUri().contains("org/sample/Foo3.java"));
+		assertEquals(JDTUtils.newLineRange(5, 13, 17), foo3.getRange());
+	}
+
+	@Test
+	public void testClassImplementation() {
+		URI uri = project.getFile("src/org/sample/Foo2.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(2, 14)); //Position over Foo2
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 1, implementations.size());
+		Location foo3 = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo3.getUri(), foo3.getUri().contains("org/sample/Foo3.java"));
+		assertEquals(JDTUtils.newLineRange(5, 13, 17), foo3.getRange());
+	}
+
+	@Test
+	public void testMethodImplementation() {
+		URI uri = project.getFile("src/org/sample/IFoo.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(4, 14)); //Position over IFoo#someMethod
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 1, implementations.size());
+		Location foo2 = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo2.getUri(), foo2.getUri().contains("org/sample/Foo2.java"));
+		//check range points to someMethod() position
+		assertEquals(new Position(4, 16), foo2.getRange().getStart());
+		assertEquals(new Position(4, 26), foo2.getRange().getEnd());
+	}
+
+	@Test
+	public void testImplementationFromBinaryTypeWithoutClassContentSupport() {
+		//Only workspace implementation returned
+		List<? extends Location> implementations = getRunnableImplementations();
+		assertEquals(implementations.toString(), 1, implementations.size());
+		assertTrue("Unexpected implementation : " + implementations.get(0).getUri(), implementations.get(0).getUri().contains("org/sample/RunnableTest.java"));
+		assertEquals(JDTUtils.newLineRange(2, 13, 25), implementations.get(0).getRange());
+	}
+
+	@Test
+	public void testImplementationFromBinaryTypeWithClassContentSupport() {
+		when(preferenceManager.isClientSupportsClassFileContent()).thenReturn(true);
+		//workspace + binary implementations returned
+		List<? extends Location> implementations = getRunnableImplementations();
+		// only jdk classes are expected to implement Runnable
+		assertEquals(implementations.toString(), 8, implementations.size());
+		Range defaultRange = JDTUtils.newRange();
+		assertTrue("Unexpected implementation : " + implementations.get(0).getUri(), implementations.get(0).getUri().contains("org/sample/RunnableTest.java"));
+		for (int i = 1; i < implementations.size(); i++) {
+			Location implem = implementations.get(i);
+			assertTrue("Unexpected implementation : " + implem.getUri(), implem.getUri().contains("rtstubs.jar"));
+			assertEquals("Expected default location ", defaultRange, implem.getRange());//no jdk sources available
+		}
+	}
+
+	private List<? extends Location> getRunnableImplementations() {
+		URI uri = project.getFile("src/org/sample/RunnableTest.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(2, 42));//implementations of java.lang.Runnable
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		return implementations;
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -91,8 +91,8 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		String query = "Baz";
 		List<SymbolInformation> results = handler.search(query, monitor);
 		assertNotNull(results);
-		assertEquals("Unexpected results", 2, results.size());
 		Range defaultRange = JDTUtils.newRange();
+		assertEquals("Unexpected results", 2, results.size());
 		for (SymbolInformation symbol : results) {
 			assertNotNull("Kind is missing", symbol.getKind());
 			assertNotNull("ContainerName is missing", symbol.getContainerName());
@@ -108,7 +108,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		String query = "IFoo";
 		List<SymbolInformation> results = handler.search(query, monitor);
 		assertNotNull(results);
-		assertEquals("Found "+ results.size() + " results", 1, results.size());
+		assertEquals("Found " + results.size() + " results", 2, results.size());
 		SymbolInformation symbol = results.get(0);
 		assertEquals(SymbolKind.Interface, symbol.getKind());
 		assertEquals("java", symbol.getContainerName());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
@@ -65,7 +65,7 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 			assertIsJavaProject(project);
 			assertNoErrors(project);
 			//1 message sent to the platform logger
-			assertEquals(1, logListener.getErrors().size());
+			assertEquals(logListener.getErrors().toString(), 1, logListener.getErrors().size());
 			String error = logListener.getErrors().get(0);
 			assertTrue("Unexpected error: " + error, error.startsWith("Missing resource filter type: 'org.eclipse.ui.ide.missingFilter'"));
 			//but no message sent to the client


### PR DESCRIPTION
java.lang.Object is treated as a special case. Because of its large type
hierarchy, implementation location is not computed from reading all
files. Instead a default location at 0,0 will always be returned.

Fixes #556

Signed-off-by: Fred Bricon <fbricon@gmail.com>