### PR TITLE
Add enable/disable completion option

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -11,6 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,10 +30,13 @@ import org.eclipse.jdt.ls.core.internal.contentassist.SnippetCompletionProposal;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class CompletionHandler{
+
+	public final static CompletionOptions DEFAULT_COMPLETION_OPTIONS = new CompletionOptions(Boolean.TRUE, Arrays.asList(".", "@", "#", "*"));
 
 	Either<List<CompletionItem>, CompletionList> completion(CompletionParams position,
 			IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -41,7 +41,6 @@ import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeLensOptions;
-import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
@@ -134,7 +133,9 @@ final public class InitHandler {
 		}
 		InitializeResult result = new InitializeResult();
 		ServerCapabilities capabilities = new ServerCapabilities();
-		capabilities.setCompletionProvider(new CompletionOptions(Boolean.TRUE, Arrays.asList(".", "@", "#", "*")));
+		if (!preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
+			capabilities.setCompletionProvider(CompletionHandler.DEFAULT_COMPLETION_OPTIONS);
+		}
 		if (!preferenceManager.getClientPreferences().isFormattingDynamicRegistrationSupported()) {
 			capabilities.setDocumentFormattingProvider(Boolean.TRUE);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -173,6 +173,9 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	public void initialized(InitializedParams params) {
 		logInfo(">> initialized");
 		JobHelpers.waitForInitializeJobs();
+		if (preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
+			registerCapability(Preferences.COMPLETION_ID, Preferences.COMPLETION, CompletionHandler.DEFAULT_COMPLETION_OPTIONS);
+		}
 		if (preferenceManager.getClientPreferences().isWorkspaceSymbolDynamicRegistered()) {
 			registerCapability(Preferences.WORKSPACE_SYMBOL_ID, Preferences.WORKSPACE_SYMBOL);
 		}
@@ -209,7 +212,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 
 		workspaceDiagnosticsHandler = new WorkspaceDiagnosticsHandler(this.client, pm);
 		workspaceDiagnosticsHandler.addResourceChangeListener();
-		
+
 		computeAsync((monitor) -> {
 			try {
 				workspaceDiagnosticsHandler.publishDiagnostics(monitor);
@@ -224,6 +227,9 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	 * Toggles the server capabilities according to user preferences.
 	 */
 	private void syncCapabilitiesToSettings() {
+		if (preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
+			toggleCapability(preferenceManager.getPreferences().isCompletionEnabled(), Preferences.COMPLETION_ID, Preferences.COMPLETION, CompletionHandler.DEFAULT_COMPLETION_OPTIONS);
+		}
 		if (preferenceManager.getClientPreferences().isFormattingDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isJavaFormatEnabled(), Preferences.FORMATTING_ID, Preferences.TEXT_DOCUMENT_FORMATTING, null);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -56,6 +56,10 @@ public class ClientPreferences {
 		return capabilities.getWorkspace() != null && isTrue(capabilities.getWorkspace().getWorkspaceFolders());
 	}
 
+	public boolean isCompletionDynamicRegistered() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getCompletion());
+	}
+
 	public boolean isCompletionSnippetsSupported() {
 		//@formatter:off
 		return v3supported && capabilities.getTextDocument().getCompletion() != null

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -129,6 +129,11 @@ public class Preferences {
 	public static final String MAVEN_USER_SETTINGS_KEY = "java.configuration.maven.userSettings";
 
 	/**
+	 * Preference key to enable/disable the 'completion'.
+	 */
+	public static final String COMPLETION_ENABLED_KEY = "java.completion.enabled";
+
+	/**
 	 * A named preference that holds the favorite static members.
 	 * <p>
 	 * Value is of type <code>String</code>: list of favorites.
@@ -201,6 +206,7 @@ public class Preferences {
 	public static final String WORKSPACE_SYMBOL = "workspace/symbol";
 	public static final String WORKSPACE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
 	public static final String DOCUMENT_SYMBOL = "textDocument/documentSymbol";
+	public static final String COMPLETION = "textDocument/completion";
 	public static final String CODE_ACTION = "textDocument/codeAction";
 	public static final String DEFINITION = "textDocument/definition";
 	public static final String TYPEDEFINITION = "textDocument/typeDefinition";
@@ -219,6 +225,7 @@ public class Preferences {
 	public static final String EXECUTE_COMMAND_ID = UUID.randomUUID().toString();
 	public static final String WORKSPACE_SYMBOL_ID = UUID.randomUUID().toString();
 	public static final String DOCUMENT_SYMBOL_ID = UUID.randomUUID().toString();
+	public static final String COMPLETION_ID = UUID.randomUUID().toString();
 	public static final String CODE_ACTION_ID = UUID.randomUUID().toString();
 	public static final String DEFINITION_ID = UUID.randomUUID().toString();
 	public static final String TYPEDEFINITION_ID = UUID.randomUUID().toString();
@@ -243,6 +250,7 @@ public class Preferences {
 	private boolean renameEnabled;
 	private boolean executeCommandEnabled;
 	private boolean autobuildEnabled;
+	private boolean completionEnabled;
 	private boolean completionOverwrite;
 	private boolean guessMethodArguments;
 	private boolean javaFormatComments;
@@ -336,6 +344,7 @@ public class Preferences {
 		renameEnabled = true;
 		executeCommandEnabled = true;
 		autobuildEnabled = true;
+		completionEnabled = true;
 		completionOverwrite = true;
 		guessMethodArguments = false;
 		javaFormatComments = true;
@@ -395,6 +404,8 @@ public class Preferences {
 		boolean autobuildEnable = getBoolean(configuration, AUTOBUILD_ENABLED_KEY, true);
 		prefs.setAutobuildEnabled(autobuildEnable);
 
+		boolean completionEnable = getBoolean(configuration, COMPLETION_ENABLED_KEY, true);
+		prefs.setCompletionEnabled(completionEnable);
 		boolean completionOverwrite = getBoolean(configuration, JAVA_COMPLETION_OVERWRITE_KEY, true);
 		prefs.setCompletionOverwrite(completionOverwrite);
 
@@ -520,6 +531,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setCompletionEnabled(boolean enabled) {
+		this.completionEnabled = enabled;
+		return this;
+	}
+
 	public Preferences setCompletionOverwrite(boolean completionOverwrite) {
 		this.completionOverwrite = completionOverwrite;
 		return this;
@@ -631,6 +647,10 @@ public class Preferences {
 
 	public boolean isAutobuildEnabled() {
 		return autobuildEnabled;
+	}
+
+	public boolean isCompletionEnabled() {
+		return completionEnabled;
 	}
 
 	public boolean isCompletionOverwrite() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -147,10 +147,11 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		when(mockCapabilies.isHoverDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isReferencesDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isDocumentHighlightDynamicRegistered()).thenReturn(Boolean.TRUE);
+		when(mockCapabilies.isCompletionDynamicRegistered()).thenReturn(Boolean.TRUE);
 		InitializeResult result = initialize(true);
 		assertNull(result.getCapabilities().getDocumentSymbolProvider());
 		server.initialized(new InitializedParams());
-		verify(client, times(7)).registerCapability(any());
+		verify(client, times(8)).registerCapability(any());
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Yaohai Zheng <yaozheng@microsoft.com>

Provide dynamic registration for completion. 

With this change, we can avoid introduce this interface: https://github.com/eclipse/eclipse.jdt.ls/issues/613 and also make https://github.com/eclipse/eclipse.jdt.ls/issues/60 possible without conflict in an extensible way. 