### PR TITLE
GH-780: Added support for the hierarchical document symbols.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logException;
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
 
@@ -550,8 +551,9 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(DocumentSymbolParams params) {
 		logInfo(">> document/documentSymbol");
-		DocumentSymbolHandler handler = new DocumentSymbolHandler();
-		return computeAsync((monitor) -> handler.documentSymbol(params, monitor).stream().map(symbol -> Either.<SymbolInformation, DocumentSymbol>forLeft(symbol)).collect(Collectors.toList()));
+		boolean hierarchicalDocumentSymbolSupported = preferenceManager.getClientPreferences().isHierarchicalDocumentSymbolSupported();
+		DocumentSymbolHandler handler = new DocumentSymbolHandler(hierarchicalDocumentSymbolSupported);
+		return computeAsync((monitor) -> handler.documentSymbol(params, monitor));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/hover/JavaElementLabels.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/hover/JavaElementLabels.java
@@ -311,7 +311,7 @@ public final class JavaElementLabels {
 	/**
 	 * User-readable string for separating the return type (e.g. " : ").
 	 */
-	public final static String DECL_STRING= ":";
+	public final static String DECL_STRING= " : ";
 	/**
 	 * User-readable string for concatenating categories (e.g. " ").
 	 * @since 3.5

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -176,4 +176,18 @@ public class ClientPreferences {
 	public boolean isWorkspaceEditResourceChangesSupported() {
 		return capabilities.getWorkspace() != null && capabilities.getWorkspace().getWorkspaceEdit() != null && isTrue(capabilities.getWorkspace().getWorkspaceEdit().getResourceChanges());
 	}
+
+	/**
+	 * {@code true} if the client has explicitly set the
+	 * {@code textDocument.documentSymbol.hierarchicalDocumentSymbolSupport} to
+	 * {@code true} when initializing the LS. Otherwise, {@code false}.
+	 */
+	public boolean isHierarchicalDocumentSymbolSupported() {
+		//@formatter:off
+		return v3supported
+				&& capabilities.getTextDocument().getDocumentSymbol() != null
+				&& capabilities.getTextDocument().getDocumentSymbol().getHierarchicalDocumentSymbolSupport() != null
+				&& capabilities.getTextDocument().getDocumentSymbol().getHierarchicalDocumentSymbolSupport().booleanValue();
+		//@formatter:on
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
@@ -18,6 +18,7 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeLensCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItemCapabilities;
+import org.eclipse.lsp4j.DocumentSymbolCapabilities;
 import org.eclipse.lsp4j.FormattingCapabilities;
 import org.eclipse.lsp4j.RangeFormattingCapabilities;
 import org.eclipse.lsp4j.RenameCapabilities;
@@ -128,5 +129,19 @@ public class ClientPreferencesTest {
 		assertFalse(prefs.isRenameDynamicRegistrationSupported());
 		when(text.getRename()).thenReturn(new RenameCapabilities(true));
 		assertTrue(prefs.isRenameDynamicRegistrationSupported());
+	}
+
+	@Test
+	public void testIsHierarchicalDocumentSymbolSupported() throws Exception {
+		DocumentSymbolCapabilities capabilities = new DocumentSymbolCapabilities();
+		assertFalse(prefs.isHierarchicalDocumentSymbolSupported());
+		when(text.getDocumentSymbol()).thenReturn(capabilities);
+		assertFalse(prefs.isHierarchicalDocumentSymbolSupported());
+		capabilities.setHierarchicalDocumentSymbolSupport(false);
+		when(text.getDocumentSymbol()).thenReturn(capabilities);
+		assertFalse(prefs.isHierarchicalDocumentSymbolSupported());
+		capabilities.setHierarchicalDocumentSymbolSupport(true);
+		when(text.getDocumentSymbol()).thenReturn(capabilities);
+		assertTrue(prefs.isHierarchicalDocumentSymbolSupported());
 	}
 }


### PR DESCRIPTION
Closes: #780.

![screencast 2018-09-17 17-33-18](https://user-images.githubusercontent.com/1405703/45633508-3c0fc400-baa0-11e8-9044-40d871be0791.gif)


Signed-off-by: Akos Kitta <kittaakos@typefox.io>