### PR TITLE
Added a launch configuration for the JDT LS.

### DIFF
--- a/launch/jdt.ls.socket-stream.launch
+++ b/launch/jdt.ls.socket-stream.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+<setAttribute key="additional_plugins"/>
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.jdt.ls.core.id1"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="false"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/jdt.ls.socket-stream"/>
+<booleanAttribute key="default" value="false"/>
+<stringAttribute key="deselected_workspace_plugins" value="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ui"/>
+<stringAttribute key="featureDefaultLocation" value="workspace"/>
+<stringAttribute key="featurePluginResolution" value="workspace"/>
+<booleanAttribute key="includeOptional" value="false"/>
+<stringAttribute key="location" value="${workspace_loc}/../runtime-JDT-LS"/>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="CLIENT_HOST" value="127.0.0.1"/>
+<mapEntry key="CLIENT_PORT" value="5036"/>
+<mapEntry key="socket.stream.debug" value="true"/>
+</mapAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.sdk.ide"/>
+<setAttribute key="selected_features"/>
+<stringAttribute key="selected_target_plugins" value="com.google.gson@default:default,com.google.guava*15.0.0.v201403281430@default:default,com.google.guava*21.0.0.v20170206-1425@default:default,com.gradleware.tooling.client@default:default,com.gradleware.tooling.model@default:default,com.gradleware.tooling.utils@default:default,com.ibm.icu.base@default:default,javax.inject@default:default,javax.xml@default:default,org.apache.ant@default:default,org.apache.commons.io@default:default,org.apache.commons.lang3@default:default,org.apache.log4j@default:default,org.eclipse.buildship.core@default:default,org.eclipse.compare.core@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filebuffers@default:default,org.eclipse.core.filesystem.macosx@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.net@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.debug.core@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.frameworkadmin.equinox@default:default,org.eclipse.equinox.frameworkadmin@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.region@default:false,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.security.macosx@default:false,org.eclipse.equinox.security@default:default,org.eclipse.equinox.simpleconfigurator.manipulator@default:default,org.eclipse.equinox.simpleconfigurator@1:true,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.jdt.apt.core@default:default,org.eclipse.jdt.apt.pluggable.core@default:default,org.eclipse.jdt.compiler.apt@default:false,org.eclipse.jdt.compiler.tool@default:false,org.eclipse.jdt.core.manipulation@default:default,org.eclipse.jdt.core@default:default,org.eclipse.jdt.debug@default:default,org.eclipse.jdt.junit.core@default:default,org.eclipse.jdt.junit.runtime@default:default,org.eclipse.jdt.launching@default:default,org.eclipse.jface.text@default:default,org.eclipse.jface@default:default,org.eclipse.lsp4j.jsonrpc@default:default,org.eclipse.lsp4j@default:default,org.eclipse.ltk.core.refactoring@default:default,org.eclipse.m2e.archetype.common@default:default,org.eclipse.m2e.core@default:default,org.eclipse.m2e.jdt@default:default,org.eclipse.m2e.lifecyclemapping.defaults@default:default,org.eclipse.m2e.maven.indexer@default:default,org.eclipse.m2e.maven.runtime.slf4j.simple@default:default,org.eclipse.m2e.maven.runtime@default:default,org.eclipse.m2e.workspace.cli@default:default,org.eclipse.osgi.compatibility.state@default:false,org.eclipse.osgi.services@default:default,org.eclipse.osgi.util@default:default,org.eclipse.osgi@-1:true,org.eclipse.swt.cocoa.macosx.x86_64@default:false,org.eclipse.swt@default:default,org.eclipse.text@default:default,org.eclipse.xtend.lib.macro@default:default,org.eclipse.xtend.lib@default:default,org.eclipse.xtext.logging@default:false,org.eclipse.xtext.xbase.lib@default:default,org.gradle.toolingapi@default:default,org.hamcrest.core@default:default,org.jboss.tools.maven.apt.core@default:default,org.junit@default:default,org.slf4j.api@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="org.eclipse.jdt.ls.core@default:default"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="true"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ConnectionStreamFactory.java
@@ -99,10 +99,9 @@ public class ConnectionStreamFactory {
 	}
 
 	private StreamProvider createProvider() {
-		final String host = Environment.get("CLIENT_HOST", "localhost");
-		final String port = Environment.get("CLIENT_PORT");
+		Integer port = JDTEnvironmentUtils.getClientPort();
 		if (port != null) {
-			return new SocketStreamProvider(host, Integer.parseInt(port));
+			return new SocketStreamProvider(JDTEnvironmentUtils.getClientHost(), port);
 		}
 		return new StdIOStreamProvider();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTEnvironmentUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTEnvironmentUtils.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import org.eclipse.core.runtime.Platform;
+
+import com.google.common.base.Preconditions;
+
+public class JDTEnvironmentUtils {
+
+	public static final String CLIENT_PORT = "CLIENT_PORT";
+	public static final String CLIENT_HOST = "CLIENT_HOST";
+	public static final String DEFAULT_CLIENT_HOST = "localhost";
+
+	/**
+	 * Environment variable indicating that the JDT LS has to be started with a
+	 * socket stream. In this case, it is the JDT LS that starts and waits until the
+	 * client connects to it.
+	 */
+	public static final String SOCKET_STREAM_DEBUG = "socket.stream.debug";
+
+	/**
+	 * Returns with the client port if set. Otherwise, returns with {@code null}.
+	 * Throw an {@link IllegalStateException} if the port is set but it has an
+	 * invalid port number.
+	 *
+	 * When the client port environment variable is set to a valid port number, then
+	 * plain socket communication will be used between the language client and the
+	 * server instead of the standard IO stream one.
+	 */
+	public static Integer getClientPort() {
+		final String port = Environment.get(CLIENT_PORT);
+		if (port != null) {
+			int clientPort = Integer.parseInt(port);
+			Preconditions.checkState(clientPort >= 1 && clientPort <= 65535, "The port must be an integer between 1 and 65535. It was: '" + port + "'.");
+			return clientPort;
+		}
+		return null;
+	}
+
+	/**
+	 * Returns with the client host. Defaults to {@code localhost} if not set. Has
+	 * absolutely no effect, if this is set but the {@code CLIENT_PORT} is not.
+	 */
+	public static String getClientHost() {
+		return Environment.get(CLIENT_HOST);
+	}
+
+	/**
+	 * Has no effect, and always returns with {@code false} if the JDT LS has been
+	 * started from the source either in debug or development mode. If the
+	 * {@code CLIENT_HOST} and {@code CLIENT_PORT} environment variables are set and
+	 * the {@link JDTEnvironmentUtils#SOCKET_STREAM_DEBUG socket.stream.debug} is
+	 * set to {@code true}, the the server will start with plain socket connection
+	 * and will wait until the client connects.
+	 */
+	public static boolean inSocketStreamDebugMode() {
+		return Boolean.parseBoolean(Environment.get(SOCKET_STREAM_DEBUG, "false")) && (Platform.inDebugMode() || Platform.inDevelopmentMode()) && getClientHost() != null && getClientPort() != null;
+	}
+
+}


### PR DESCRIPTION
This PR includes an Eclipse launch configuration to start the JDT LS in debug mode. I found this approach useful when I had to develop JDT LS in Eclipse.

It also includes a tiny [`startConnection`](https://github.com/eclipse/eclipse.jdt.ls/compare/master...kittaakos:jdt-ls-launch-config?expand=1#diff-55f26b9037b6c92ad4701f61028ae2cdL251) modification, that is used only if the JDT LS was started from Eclipse in debug mode. Otherwise, we fall back to the well known original start logic.

Finally, a utility class to access the `CLIENT_HOST` and the `CLIENT_PORT` environment variables.


Signed-off-by: Akos Kitta <kittaakos@typefox.io>