### PR TITLE
GH-28: Added support for the super- and subtype hierarchies.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -11,6 +11,9 @@
 package org.eclipse.jdt.ls.core.internal;
 
 import static org.eclipse.core.resources.IResource.DEPTH_ONE;
+import static org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels.ALL_DEFAULT;
+import static org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels.M_APP_RETURNTYPE;
+import static org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels.ROOT_VARIABLE;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +33,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -37,6 +41,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IAnnotatable;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IBuffer;
@@ -51,6 +56,7 @@ import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
@@ -72,6 +78,7 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
+import org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -81,6 +88,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
@@ -273,14 +281,99 @@ public final class JDTUtils {
 		return (pkg == null || pkg.getName() == null)?"":pkg.getName().getFullyQualifiedName();
 	}
 
+	/**
+	 * Returns with the human readable name of the element. For types with type
+	 * arguments, it is {@code Comparable<T>} instead of {@code Comparable}. First,
+	 * this method tries to retrieve the
+	 * {@link JavaElementLabels#getElementLabel(IJavaElement, long) label} of the
+	 * element, then falls back to {@link IJavaElement#getElementName() element
+	 * name}. Returns {@code null} if the argument does not have a name.
+	 */
+	public static String getName(IJavaElement element) {
+		Assert.isNotNull(element, "element");
+		String name = JavaElementLabels.getElementLabel(element, ALL_DEFAULT);
+		return name == null ? element.getElementName() : name;
+	}
 
 	/**
-	 * Given the uri returns a {@link IClassFile}.
-	 * May return null if it can not resolve the uri to a
-	 * library.
+	 * Returns with the details of the document symbol. This is usually the type
+	 * information of a member. For methods, this is the type information of the
+	 * return type. Can return with an empty string, but never {@code null}.
+	 *
+	 * @see JDTUtils#getName(IJavaElement)
+	 */
+	public static String getDetail(IJavaElement element) {
+		Assert.isNotNull(element, "element");
+		String name = getName(element);
+		String nameWithDetails = JavaElementLabels.getElementLabel(element, ALL_DEFAULT | M_APP_RETURNTYPE | ROOT_VARIABLE);
+		if (nameWithDetails != null && nameWithDetails.startsWith(name)) {
+			return nameWithDetails.substring(name.length());
+		}
+		return "";
+	}
+
+	/**
+	 * Returns with the document symbol {@code SymbolKind kind} for the Java
+	 * element.
+	 */
+	public static SymbolKind getSymbolKind(IJavaElement element) {
+		switch (element.getElementType()) {
+			case IJavaElement.ANNOTATION:
+				return SymbolKind.Property; // TODO: find a better mapping
+			case IJavaElement.CLASS_FILE:
+			case IJavaElement.COMPILATION_UNIT:
+				return SymbolKind.File;
+			case IJavaElement.FIELD:
+				return SymbolKind.Field;
+			case IJavaElement.IMPORT_CONTAINER:
+			case IJavaElement.IMPORT_DECLARATION:
+				return SymbolKind.Module;
+			case IJavaElement.INITIALIZER:
+				return SymbolKind.Constructor;
+			case IJavaElement.LOCAL_VARIABLE:
+			case IJavaElement.TYPE_PARAMETER:
+				return SymbolKind.Variable;
+			case IJavaElement.METHOD:
+				return SymbolKind.Method;
+			case IJavaElement.PACKAGE_DECLARATION:
+				return SymbolKind.Package;
+			case IJavaElement.TYPE:
+				try {
+					IType type = (IType) element;
+					if (type.isEnum()) {
+						return SymbolKind.Enum;
+					} else if (type.isInterface()) {
+						return SymbolKind.Interface;
+					} else {
+						return SymbolKind.Class;
+					}
+				} catch (JavaModelException e) {
+					return SymbolKind.Class;
+				}
+		}
+		return SymbolKind.String;
+	}
+
+	/**
+	 * {@code true} if the element is deprecated. Otherwise, {@code false}.
+	 */
+	public static boolean isDeprecated(IJavaElement element) throws JavaModelException {
+		Assert.isNotNull(element, "element");
+		if (element instanceof ITypeRoot) {
+			return Flags.isDeprecated(((ITypeRoot) element).findPrimaryType().getFlags());
+		} else if (element instanceof IMember) {
+			return Flags.isDeprecated(((IMember) element).getFlags());
+		}
+		return false;
+	}
+
+	/**
+	 * Given the uri returns a {@link IClassFile}. May return null if it can not
+	 * resolve the uri to a library.
 	 *
 	 * @see #toLocation(IClassFile, int, int)
-	 * @param uri with 'jdt' scheme
+	 * @param uri
+	 *            with 'jdt' scheme
 	 * @return class file
 	 */
 	public static IClassFile resolveClassFile(String uriString){
@@ -355,6 +448,13 @@ public final class JDTUtils {
 		};
 
 		/* default */ abstract ISourceRange getRange(IJavaElement element) throws JavaModelException;
+
+		/**
+		 * Sugar for {@link JDTUtils#toLocation(IJavaElement, LocationType)}.
+		 */
+		public Location toLocation(IJavaElement element) throws JavaModelException {
+			return JDTUtils.toLocation(element, this);
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -226,6 +226,10 @@ final public class InitHandler {
 		wsCapabilities.setWorkspaceFolders(wsFoldersOptions);
 		capabilities.setWorkspace(wsCapabilities);
 
+		if (!preferenceManager.getClientPreferences().isTypeHierarchyDynamicRegistered()) {
+			capabilities.setTypeHierarchyProvider(Boolean.TRUE);
+		}
+
 		result.setCapabilities(capabilities);
 		return result;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyHandler.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.jdt.core.ICompilationUnit.NO_AST;
+import static org.eclipse.jdt.core.IJavaElement.CLASS_FILE;
+import static org.eclipse.jdt.core.IJavaElement.COMPILATION_UNIT;
+import static org.eclipse.jdt.core.IJavaElement.METHOD;
+import static org.eclipse.jdt.core.IJavaElement.TYPE;
+import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logException;
+import static org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels.ALL_DEFAULT;
+import static org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels.DEFAULT_QUALIFIED;
+import static org.eclipse.lsp4j.TypeHierarchyDirection.Both;
+import static org.eclipse.lsp4j.TypeHierarchyDirection.Children;
+import static org.eclipse.lsp4j.TypeHierarchyDirection.Parents;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IOrdinaryClassFile;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JDTUtils.LocationType;
+import org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TypeHierarchyDirection;
+import org.eclipse.lsp4j.TypeHierarchyItem;
+import org.eclipse.lsp4j.TypeHierarchyParams;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Handler for serving the {@code textDocument/typeHierarchy} method. Retrieves
+ * type hierarchy items based on the cursor location in the text document. On
+ * demand, can resolve sub- and supertypes.
+ *
+ */
+public class TypeHierarchyHandler {
+
+	//@formatter:off
+	protected static Map<Integer, Function<IJavaElement, IType>> SUPPORTED_TYPES = ImmutableMap.<Integer, Function<IJavaElement, IType>>of(
+			TYPE, type -> (IType) type,
+			METHOD, method -> ((IMethod) method).getDeclaringType()
+	);
+	//@formatter:on
+
+	protected PreferenceManager preferenceManager;
+
+	public TypeHierarchyHandler(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
+	}
+
+	public TypeHierarchyItem typeHierarchy(TypeHierarchyParams params, IProgressMonitor monitor) {
+		Assert.isNotNull(params, "params");
+		Assert.isNotNull(params.getPosition(), "params.position");
+		Assert.isNotNull(params.getTextDocument(), "params.textDocument");
+
+		String uri = params.getTextDocument().getUri();
+		Position position = params.getPosition();
+		TypeHierarchyDirection direction = params.getDirection() == null ? Children : params.getDirection();
+		int resolve = params.getResolve();
+		return getTypeHierarchy(uri, position, direction, resolve, monitor);
+	}
+
+	protected TypeHierarchyItem getTypeHierarchy(String uri, Position position, TypeHierarchyDirection direction, int resolve, IProgressMonitor monitor) {
+		Assert.isNotNull(uri, "uri");
+		Assert.isNotNull(position, "position");
+		Assert.isLegal(resolve >= 0, "'resolve' must be a non-negative integer. Was: " + resolve);
+
+		try {
+			final Pair<TypeHierarchyItem, IType> toResolve = getTypeHierarchyItem(uri, position, monitor);
+			if (toResolve == null || toResolve.getLeft() == null) {
+				return null;
+			}
+
+			if (monitor.isCanceled()) {
+				return toResolve.getKey();
+			}
+
+			TypeHierarchyItem copy = shallowCopy(toResolve.getKey());
+			try {
+				if (direction == Children || direction == Both) {
+					int depth = resolve;
+					resolveChildren(Collections.singletonList(toResolve), depth, monitor);
+				}
+				if (direction == Parents || direction == Both) {
+					int depth = resolve;
+					resolveParents(Collections.singletonList(toResolve), depth, monitor);
+				}
+			} catch (OperationCanceledException e) {
+				return copy;
+			}
+
+			return toResolve.getLeft();
+		} catch (JavaModelException e) {
+			logException("Error when retrieving the type hierarchy in " + uri + " at " + position + ".", e);
+			return null;
+		}
+	}
+
+	protected void resolveChildren(Collection<Pair<TypeHierarchyItem, IType>> pairs, int depth, IProgressMonitor monitor) throws JavaModelException {
+		if (depth > 0) {
+			for (Pair<TypeHierarchyItem, IType> pair : pairs) {
+				if (monitor.isCanceled()) {
+					throw new OperationCanceledException();
+				}
+				IType type = pair.getRight();
+				ITypeHierarchy typeHierarchy = type.newTypeHierarchy(monitor);
+				List<Pair<TypeHierarchyItem, IType>> subtypes = Arrays.stream(typeHierarchy.getSubtypes(type)).map(t -> toTypeHierarchyItem(t)).collect(toList());
+				pair.getLeft().setChildren(subtypes.stream().map(p -> p.getLeft()).collect(toList()));
+				resolveChildren(subtypes, depth--, monitor);
+			}
+		}
+	}
+
+	protected void resolveParents(Collection<Pair<TypeHierarchyItem, IType>> pairs, int depth, IProgressMonitor monitor) throws JavaModelException {
+		if (depth > 0) {
+			for (Pair<TypeHierarchyItem, IType> pair : pairs) {
+				if (monitor.isCanceled()) {
+					throw new OperationCanceledException();
+				}
+				IType type = pair.getRight();
+				ITypeHierarchy typeHierarchy = type.newSupertypeHierarchy(monitor);
+				List<Pair<TypeHierarchyItem, IType>> supertypes = Arrays.stream(typeHierarchy.getSupertypes(type)).map(t -> toTypeHierarchyItem(t)).collect(toList());
+				pair.getLeft().setParents(supertypes.stream().map(p -> p.getLeft()).collect(toList()));
+				resolveParents(supertypes, depth--, monitor);
+			}
+		}
+	}
+
+	/**
+	 * Returns with a copy of the argument without the {@code parents} and
+	 * {@code children}.
+	 */
+	private TypeHierarchyItem shallowCopy(TypeHierarchyItem other) {
+		TypeHierarchyItem copy = new TypeHierarchyItem();
+		copy.setName(other.getName());
+		copy.setDetail(other.getDetail());
+		copy.setKind(other.getKind());
+		copy.setDeprecated(other.getDeprecated());
+		copy.setUri(other.getUri());
+		copy.setRange(other.getRange());
+		copy.setSelectionRange(other.getSelectionRange());
+		return copy;
+	}
+
+	private Pair<TypeHierarchyItem, IType> getTypeHierarchyItem(String uri, Position position, IProgressMonitor monitor) throws JavaModelException {
+		SubMonitor subMonitor = SubMonitor.convert(monitor, 3);
+		ITypeRoot root = JDTUtils.resolveTypeRoot(uri);
+		if (root == null) {
+			return null;
+		}
+		if (root instanceof ICompilationUnit) {
+			ICompilationUnit unit = (ICompilationUnit) root;
+			if (root.getResource() == null) {
+				return null;
+			}
+			reconcile(unit, subMonitor.newChild(1));
+		}
+
+		int line = position.getLine();
+		int character = position.getCharacter();
+		IJavaElement selectedElement = JDTUtils.findElementAtSelection(root, line, character, preferenceManager, subMonitor.newChild(1));
+		if (!isSupportedType(selectedElement)) {
+			selectedElement = getFallbackElement(root, selectedElement);
+			if (!isSupportedType(selectedElement)) {
+				return null;
+			}
+		}
+
+		IType selectedType = getType(selectedElement);
+		if (selectedType != null) {
+			return toTypeHierarchyItem(selectedType);
+		}
+		return null;
+	}
+
+	/**
+	 * If the {@link IJavaElement selectedElement} argument is <b>not</b>
+	 * {@link #isSupportedType(IJavaElement) supported}, it returns with the primary
+	 * type from the {@code root} argument. Otherwise, returns the
+	 * {@code selectedElement} argument.
+	 */
+	private IJavaElement getFallbackElement(ITypeRoot root, IJavaElement selectedElement) {
+		if (!isSupportedType(selectedElement)) {
+			int rootType = root.getElementType();
+			if (rootType == CLASS_FILE && root instanceof IOrdinaryClassFile) {
+				selectedElement = ((IOrdinaryClassFile) root).getType();
+			} else if (rootType == COMPILATION_UNIT) {
+				selectedElement = ((ICompilationUnit) root).findPrimaryType();
+			}
+		}
+		return isSupportedType(selectedElement) ? selectedElement : null;
+	}
+
+	private void reconcile(ICompilationUnit unit, IProgressMonitor monitor) throws JavaModelException {
+		unit.reconcile(NO_AST, false, null, monitor);
+	}
+
+	/**
+	 * {@code true} if the {@code element} argument is not {@code null} and its
+	 * {@link IJavaElement#getElementType() type} is covered by this handler.
+	 */
+	private boolean isSupportedType(IJavaElement element) {
+		return element != null && SUPPORTED_TYPES.keySet().contains(element.getElementType());
+	}
+
+	/**
+	 * Returns the {@link IType type} from the {@link IJavaElement element} argument
+	 * if it is supported. Otherwise, returns {@code null}.
+	 */
+	private IType getType(IJavaElement element) {
+		return SUPPORTED_TYPES.getOrDefault(element.getElementType(), type -> null).apply(element);
+	}
+
+	/**
+	 * Maps the type argument into the corresponding LSP specific type hierarchy
+	 * item. Returns with {@code null} if the type is not supported. The
+	 * {@link TypeHierarchyItem#getChildren() children} and
+	 * {@link TypeHierarchyItem#getParents() parents} will be left as {@code null}.
+	 */
+	private Pair<TypeHierarchyItem, IType> toTypeHierarchyItem(IType type) {
+		if (!isSupportedType(type)) {
+			return null;
+		}
+		try {
+			Location fullLocation = getLocation(type, LocationType.FULL_RANGE);
+			Range range = fullLocation.getRange();
+			String uri = fullLocation.getUri();
+			TypeHierarchyItem item = new TypeHierarchyItem();
+			item.setName(JDTUtils.getName(type));
+			item.setKind(JDTUtils.getSymbolKind(type));
+			item.setRange(range);
+			item.setSelectionRange(getLocation(type, LocationType.NAME_RANGE).getRange());
+			item.setUri(uri);
+			item.setDetail(getDetail(type));
+			item.setDeprecated(JDTUtils.isDeprecated(type));
+			return Pair.of(item, type);
+		} catch (JavaModelException e) {
+			logException("Error when mapping type " + type + " into a type hierarchy item symbol.", e);
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the location of the Java {@code element} based on the desired
+	 * {@code locationType}.
+	 */
+	private Location getLocation(IJavaElement element, LocationType locationType) throws JavaModelException {
+		Assert.isNotNull(element, "element");
+		Assert.isNotNull(locationType, "locationType");
+		Location location = locationType.toLocation(element);
+		if (location == null && element instanceof IType) {
+			IType type = (IType) element;
+			ICompilationUnit unit = (ICompilationUnit) type.getAncestor(COMPILATION_UNIT);
+			IClassFile classFile = (IClassFile) type.getAncestor(CLASS_FILE);
+			if (unit != null || (classFile != null && classFile.getSourceRange() != null)) {
+				return locationType.toLocation(type);
+			}
+			if (type instanceof IMember && ((IMember) type).getClassFile() != null) {
+				return JDTUtils.toLocation(((IMember) type).getClassFile());
+			}
+		}
+		return location;
+	}
+
+	/**
+	 * The FQN of the container package of the {@code type} argument.
+	 */
+	private String getDetail(IType type) {
+		IPackageFragment packageFragment = type.getPackageFragment();
+		if (packageFragment != null) {
+			String name = JavaElementLabels.getElementLabel(packageFragment, ALL_DEFAULT);
+			return name == null ? packageFragment.getElementName() : name;
+		}
+		String fqnName = JavaElementLabels.getElementLabel(type, DEFAULT_QUALIFIED);
+		if (fqnName != null) {
+			String name = JDTUtils.getName(type);
+			if (name != null && fqnName.endsWith(name)) {
+				return fqnName.substring(0, fqnName.length() - (name.length() + 1));
+			}
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyResolveHandler.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.ResolveTypeHierarchyItemParams;
+import org.eclipse.lsp4j.TypeHierarchyDirection;
+import org.eclipse.lsp4j.TypeHierarchyItem;
+
+/**
+ * Handler for the {@code typeHierarchy/resolve} LS method.
+ *
+ * Resolves unresolved type hierarchy items.
+ *
+ */
+public class TypeHierarchyResolveHandler extends TypeHierarchyHandler {
+
+	public TypeHierarchyResolveHandler(PreferenceManager preferenceManager) {
+		super(preferenceManager);
+	}
+
+	public TypeHierarchyItem resolve(ResolveTypeHierarchyItemParams params, IProgressMonitor monitor) {
+		Assert.isNotNull(params, "params");
+		Assert.isNotNull(params.getDirection(), "params.direction");
+		Assert.isNotNull(params.getItem(), "params.item");
+
+		String uri = params.getItem().getUri();
+		Position position = params.getItem().getSelectionRange().getStart();
+		TypeHierarchyDirection direction = params.getDirection();
+		int resolve = params.getResolve();
+		return getTypeHierarchy(uri, position, direction, resolve, monitor);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -230,4 +230,9 @@ public class ClientPreferences {
 				.stream().filter(k -> kind.startsWith(k)).findAny().isPresent();
 		//@formatter:on
 	}
+
+	public boolean isTypeHierarchyDynamicRegistered() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getTypeHierarchyCapabilities());
+	}
+
 }

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -34,8 +34,13 @@
             <repository location="http://download.eclipse.org/releases/2019-03/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.6.0.v20181130-0905"/>
-           <repository location="http://download.eclipse.org/lsp4j/updates/releases/0.6.0"/>
+           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.7.0.v20190228-1519"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.7.0/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/milestones"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/TypeHierarchyHandlerTest.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.eclipse.lsp4j.SymbolKind.Class;
+import static org.eclipse.lsp4j.SymbolKind.Enum;
+import static org.eclipse.lsp4j.SymbolKind.Interface;
+import static org.eclipse.lsp4j.TypeHierarchyDirection.Children;
+import static org.eclipse.lsp4j.TypeHierarchyDirection.Parents;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TypeHierarchyDirection;
+import org.eclipse.lsp4j.TypeHierarchyItem;
+import org.eclipse.lsp4j.TypeHierarchyParams;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Iterables;
+
+public class TypeHierarchyHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	private IProject jarProject;
+	private IProject srcProject;
+
+	@Before
+	public void setup() throws Exception {
+		importProjects(Arrays.asList("eclipse/hello", "maven/salut"));
+		jarProject = WorkspaceHelper.getProject("salut");
+		srcProject = WorkspaceHelper.getProject("hello");
+	}
+
+	@Test
+	public void subTypeInJar_type() throws Exception {
+		// Line 99 from `WordUtils`
+		//     public static String wrap(final String str, final int wrapLength) {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.text.WordUtils");
+		doAssert(getSubTypes(uri, 98, 19), "String", Class);
+	}
+
+	@Test
+	public void subTypeInJar_variable() throws Exception {
+		// Line 284 from `WordUtils`.
+		//         final StringBuilder wrappedLine = new StringBuilder(inputLineLength + 32);
+		String uri = getUriFromJarProject("org.apache.commons.lang3.text.WordUtils");
+		doAssert(getSubTypes(uri, 283, 29), "WordUtils", Class);
+	}
+
+	@Test
+	public void subTypeInJar_method() throws Exception {
+		// Line 99 from `WordUtils`
+		//     public static String wrap(final String str, final int wrapLength) {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.text.WordUtils");
+		doAssert(getSubTypes(uri, 98, 26), "WordUtils", Class);
+	}
+
+	@Test
+	public void subTypeInJar_typeArgument() throws Exception {
+		// Line 324 from `TypeUtils`
+		//            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.reflect.TypeUtils");
+		doAssert(getSubTypes(uri, 323, 22), "TypeVariable<D extends GenericDeclaration>", Interface);
+	}
+
+	@Test
+	public void subTypeInJar_noSelectedJavaElement() throws Exception {
+		// Line 324 from `TypeUtils`
+		//            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.reflect.TypeUtils");
+		doAssert(getSubTypes(uri, 0, 0), "TypeUtils", Class);
+	}
+
+	@Test
+	public void superTypeInJar_typeArgument() throws Exception {
+		// Line 324 from `TypeUtils`
+		//            final Map<TypeVariable<?>, Type> typeVarAssigns) {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.reflect.TypeUtils");
+		TypeHierarchyItem typeVariableNode = doAssert(getSuperTypes(uri, 323, 22), "TypeVariable<D extends GenericDeclaration>", Interface);
+		List<TypeHierarchyItem> superTypes = getSuperTypes(typeVariableNode).getParents();
+		assertEquals(2, superTypes.size());
+		doAssertContains(superTypes, "AnnotatedElement", Interface);
+		doAssertContains(superTypes, "Type", Interface);
+	}
+
+	@Test
+	public void superTypeInJar_ctor() throws Exception {
+		// Line 109 from `CompareToBuilder`
+		//    public CompareToBuilder() {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.builder.CompareToBuilder");
+		TypeHierarchyItem typeVariableNode = doAssert(getSuperTypes(uri, 108, 11), "CompareToBuilder", Class);
+		List<TypeHierarchyItem> superTypes = getSuperTypes(typeVariableNode).getParents();
+		assertEquals(2, superTypes.size());
+		doAssertContains(superTypes, "Object", Class);
+		doAssertContains(superTypes, "Builder<T>", Interface);
+	}
+
+	@Test
+	public void superTypeInJar_interfaceDoesNotExtendObject() throws Exception {
+		// Line 79 from `Builder`
+		//public interface Builder<T> {
+		String uri = getUriFromJarProject("org.apache.commons.lang3.builder.Builder");
+		TypeHierarchyItem typeVariableNode = doAssert(getSuperTypes(uri, 78, 17), "Builder<T>", Interface);
+		List<TypeHierarchyItem> superTypes = getSuperTypes(typeVariableNode).getParents();
+		assertEquals(0, superTypes.size());
+	}
+
+	@Test
+	public void superTypeInJar_enum() throws Exception {
+		// Line 303 from `JavaVersion`
+		//    JAVA_1_8(1.8f, "1.8"),
+		String uri = getUriFromJarProject("org.apache.commons.lang3.JavaVersion");
+		TypeHierarchyItem enumNode = doAssert(getSuperTypes(uri, 302, 4), "JavaVersion", Enum);
+		List<TypeHierarchyItem> superTypes = getSuperTypes(enumNode).getParents();
+		assertEquals(1, superTypes.size());
+		doAssertContains(superTypes, "Enum<E extends Enum<E>>", Class);
+		List<TypeHierarchyItem> superSuperTypes = getSuperTypes(superTypes.iterator().next()).getParents();
+		assertEquals(3, superSuperTypes.size());
+		doAssertContains(superSuperTypes, "Object", Class);
+		doAssertContains(superSuperTypes, "Comparable<T>", Interface);
+		doAssertContains(superSuperTypes, "Serializable", Interface);
+	}
+
+	@Test
+	public void subTypeInSrc_typeInMethodSignature() throws Exception {
+		// Line 8 from `Baz`
+		//	protected File getParent(File file, int depth) {
+		String uri = getUriFromSrcProject("org.sample.Baz");
+		doAssert(getSubTypes(uri, 7, 28), "File", Class).getChildren();
+
+		List<TypeHierarchyItem> superTypes = doAssert(getSuperTypes(uri, 7, 28), "File", Class).getParents();
+		doAssertContains(superTypes, "Object", Class);
+		doAssertContains(superTypes, "Comparable<T>", Interface);
+		doAssertContains(superTypes, "Serializable", Interface);
+	}
+
+	@Test
+	public void subTypeInSrc_paramInMethodSignature() throws Exception {
+		// Line 8 from `Baz`
+		//	protected File getParent(File file, int depth) {
+		String uri = getUriFromSrcProject("org.sample.Baz");
+		List<TypeHierarchyItem> subTypes = doAssert(getSubTypes(uri, 7, 33), "Baz", Class).getChildren();
+		assertEquals(0, subTypes.size());
+
+		List<TypeHierarchyItem> superTypes = doAssert(getSuperTypes(uri, 7, 33), "Baz", Class).getParents();
+		doAssertContains(superTypes, "Object", Class);
+	}
+
+	@Test
+	public void subTypeInSrc_variableType() throws Exception {
+		// Line 6 from `Highlight`
+		//		String string = "";
+		String uri = getUriFromSrcProject("org.sample.Highlight");
+		List<TypeHierarchyItem> subTypes = doAssert(getSubTypes(uri, 5, 2), "String", Class).getChildren();
+		assertEquals(0, subTypes.size());
+
+		List<TypeHierarchyItem> superTypes = doAssert(getSuperTypes(uri, 5, 2), "String", Class).getParents();
+		doAssertContains(superTypes, "Object", Class);
+		doAssertContains(superTypes, "Comparable<T>", Interface);
+		doAssertContains(superTypes, "CharSequence", Interface);
+		doAssertContains(superTypes, "Serializable", Interface);
+	}
+
+	@Test
+	public void subTypeInSrc_variableName() throws Exception {
+		// Line 6 from `Highlight`
+		//		String string = "";
+		String uri = getUriFromSrcProject("org.sample.Highlight");
+		doAssert(getSubTypes(uri, 5, 9), "Highlight", Class).getChildren();
+	}
+
+	/**
+	 * Asserts the node and returns with the argument if valid. Otherwise, throws an
+	 * exception.
+	 */
+	private TypeHierarchyItem doAssert(TypeHierarchyItem node, String expectedName, SymbolKind expectedKind) {
+		assertNotNull(node);
+		assertEquals("Unexpected name in: " + node.toString(), expectedName, node.getName());
+		assertEquals("Unexpected symbol kind in: " + node.toString(), expectedKind, node.getKind());
+		return node;
+	}
+
+	private TypeHierarchyItem doAssertContains(Iterable<? extends TypeHierarchyItem> nodes, String expectedName, SymbolKind expectedKind) {
+		assertNotNull(nodes);
+		//@formatter:off
+		return StreamSupport.stream(nodes.spliterator(), false)
+			.filter(node -> node.getName().equals(expectedName))
+			.filter(node -> node.getKind().equals(expectedKind))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError(
+					new StringBuilder("Cannot find node with name: '")
+						.append(expectedName)
+						.append("' and kind: '")
+						.append(expectedKind)
+						.append("' in ")
+						.append(Iterables.toString(nodes))
+						.append(".")
+						.toString()));
+		//@formatter:on
+
+	}
+
+	private String getUriFromSrcProject(String className) throws JavaModelException {
+		return ClassFileUtil.getURI(srcProject, className);
+	}
+
+	private String getUriFromJarProject(String className) throws JavaModelException {
+		return ClassFileUtil.getURI(jarProject, className);
+	}
+
+	private TypeHierarchyItem getSubTypes(String uri, int line, int character) {
+		return new TypeHierarchyHandler(preferenceManager).typeHierarchy(newParams(uri, line, character, Children, 1), new NullProgressMonitor());
+	}
+
+	private TypeHierarchyItem getSuperTypes(TypeHierarchyItem node) {
+		String uri = node.getUri();
+		Position position = node.getSelectionRange().getStart();
+		int line = position.getLine();
+		int character = position.getCharacter();
+		return new TypeHierarchyHandler(preferenceManager).typeHierarchy(newParams(uri, line, character, Parents, 1), new NullProgressMonitor());
+	}
+
+	private TypeHierarchyItem getSuperTypes(String uri, int line, int character) {
+		return new TypeHierarchyHandler(preferenceManager).typeHierarchy(newParams(uri, line, character, Parents, 1), new NullProgressMonitor());
+	}
+
+	private TypeHierarchyParams newParams(String uri, int line, int character, TypeHierarchyDirection direction, int resolve) {
+		TypeHierarchyParams params = new TypeHierarchyParams();
+		params.setDirection(direction);
+		params.setPosition(new Position(line, character));
+		params.setTextDocument(new TextDocumentIdentifier(uri));
+		params.setResolve(resolve);
+		return params;
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
@@ -144,4 +144,5 @@ public class ClientPreferencesTest {
 		when(text.getDocumentSymbol()).thenReturn(capabilities);
 		assertTrue(prefs.isHierarchicalDocumentSymbolSupported());
 	}
+
 }


### PR DESCRIPTION
~**Note:** This item depends on https://github.com/eclipse/lsp4j/issues/272 due to required API changes. Still, this PR is ready for review/preview.~ Done.

Closes: #28.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

![screencast 2018-10-11 15-18-32](https://user-images.githubusercontent.com/1405703/46811007-26757d80-cd72-11e8-981d-4e0606d5e600.gif)

<img width="482" alt="46809098-15c30880-cd6e-11e8-8146-fcdc90f6721b" src="https://user-images.githubusercontent.com/1405703/46811029-368d5d00-cd72-11e8-99fa-9b9069b18aee.png">

For reviewers:
 - ~I start working on a client implementation, once it is available, I will update this PR.~ A client implementation with Eclipse Theia is available [here](https://github.com/theia-ide/theia/pull/3148).
 - ~Why did I add `org.eclipse.wst.xml_ui.feature.feature.group` to the [TP](https://github.com/eclipse/eclipse.jdt.ls/pull/823/files#diff-876b543348991468f6ac3f66768a2973R40)~? The TP related change is not required anymore. See https://github.com/eclipse/eclipse.jdt.ls/pull/823#pullrequestreview-176602548.
   - LSP4J depends on Xtext/Xtend 2.15.
   - Xtext/Xtend 2.15 is not available from the `http://download.eclipse.org/releases/photon/` p2 site.
   - But `org.jboss.tools.maven.apt.feature.feature.group` depends on `org.eclipse.wst.xml.ui` that we used to pull from `http://download.eclipse.org/releases/photon/` under the hood.
   - I had to explicitly declare the `org.eclipse.wst.xml_ui.feature.feature.group` feature dependency to fulfill the missing `o.e.wst.xml.ui` plug-in.

Edit: Updated the section for the TP.