### PR TITLE
[WIP] Add resource operation support

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
@@ -39,6 +39,12 @@ import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.DynamicValida
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenameCompilationUnitChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenamePackageChange;
 import org.eclipse.jdt.ls.core.internal.corext.util.JavaElementUtil;
+import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.CreateFileOptions;
+import org.eclipse.lsp4j.DeleteFile;
+import org.eclipse.lsp4j.DeleteFileOptions;
+import org.eclipse.lsp4j.RenameFile;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -55,6 +61,8 @@ import org.eclipse.text.edits.TextEdit;
  *
  */
 public class ChangeUtil {
+
+	private static final String TEMP_FILE_NAME = ".temp";
 
 	/**
 	 * Converts changes to resource changes if resource changes are supported by the
@@ -101,7 +109,7 @@ public class ChangeUtil {
 	}
 
 	private static void convertResourceChange(WorkspaceEdit edit, ResourceChange resourceChange) throws CoreException {
-		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isWorkspaceEditResourceChangesSupported()) {
+		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isResourceOperationSupported()) {
 			return;
 		}
 
@@ -134,35 +142,47 @@ public class ChangeUtil {
 			convertTextEdit(edit, cu, textEdit);
 		}
 
-		org.eclipse.lsp4j.ResourceChange rc = new org.eclipse.lsp4j.ResourceChange();
 		IPath newPackageFragment = new Path(packageChange.getNewName().replace('.', IPath.SEPARATOR));
 		IPath oldPackageFragment = new Path(packageChange.getOldName().replace('.', IPath.SEPARATOR));
 		IPath newPackagePath = pack.getResource().getLocation().removeLastSegments(oldPackageFragment.segmentCount()).append(newPackageFragment);
-		rc.setNewUri(ResourceUtils.fixURI(newPackagePath.toFile().toURI()));
+
 		if (packageChange.getRenameSubpackages()) {
-			rc.setCurrent(ResourceUtils.fixURI(pack.getResource().getRawLocationURI()));
-			edit.getResourceChanges().add(Either.forLeft(rc));
+			RenameFile renameFile = new RenameFile();
+			renameFile.setNewUri(ResourceUtils.fixURI(newPackagePath.toFile().toURI()));
+			renameFile.setOldUri(ResourceUtils.fixURI(pack.getResource().getRawLocationURI()));
+			edit.getDocumentChanges().add(Either.forRight(renameFile));
 		} else {
-			edit.getResourceChanges().add(Either.forLeft(rc));
+			CreateFile createFile = new CreateFile();
+			createFile.setUri(ResourceUtils.fixURI(newPackagePath.toFile().toURI()) + "/" + TEMP_FILE_NAME);
+			createFile.setOptions(new CreateFileOptions(false, true));
+			edit.getDocumentChanges().add(Either.forRight(createFile));
+
 			for (ICompilationUnit unit : units) {
-				org.eclipse.lsp4j.ResourceChange cuResourceChange = new org.eclipse.lsp4j.ResourceChange();
-				cuResourceChange.setCurrent(ResourceUtils.fixURI(unit.getResource().getLocationURI()));
+				RenameFile cuResourceChange = new RenameFile();
+				cuResourceChange.setOldUri(ResourceUtils.fixURI(unit.getResource().getLocationURI()));
 				IPath newCUPath = newPackagePath.append(unit.getPath().lastSegment());
 				cuResourceChange.setNewUri(ResourceUtils.fixURI(newCUPath.toFile().toURI()));
-				edit.getResourceChanges().add(Either.forLeft(cuResourceChange));
+				edit.getDocumentChanges().add(Either.forRight(cuResourceChange));
 			}
+
+			// Workaround: https://github.com/Microsoft/language-server-protocol/issues/272
+			DeleteFile deleteFile = new DeleteFile();
+			deleteFile.setUri(ResourceUtils.fixURI(newPackagePath.toFile().toURI()) + "/" + TEMP_FILE_NAME);
+			deleteFile.setOptions(new DeleteFileOptions(false, true));
+			edit.getDocumentChanges().add(Either.forRight(deleteFile));
+
 		}
 	}
 
 	private static void convertCUResourceChange(WorkspaceEdit edit, RenameCompilationUnitChange cuChange) {
 		ICompilationUnit modifiedCU = (ICompilationUnit) cuChange.getModifiedElement();
-		org.eclipse.lsp4j.ResourceChange rc = new org.eclipse.lsp4j.ResourceChange();
+		RenameFile rf = new RenameFile();
 		String newCUName = cuChange.getNewName();
 		IPath currentPath = modifiedCU.getResource().getLocation();
-		rc.setCurrent(ResourceUtils.fixURI(modifiedCU.getResource().getRawLocationURI()));
+		rf.setOldUri(ResourceUtils.fixURI(modifiedCU.getResource().getRawLocationURI()));
 		IPath newPath = currentPath.removeLastSegments(1).append(newCUName);
-		rc.setNewUri(ResourceUtils.fixURI(newPath.toFile().toURI()));
-		edit.getResourceChanges().add(Either.forLeft(rc));
+		rf.setNewUri(ResourceUtils.fixURI(newPath.toFile().toURI()));
+		edit.getDocumentChanges().add(Either.forRight(rf));
 	}
 
 	private static void convertTextChange(WorkspaceEdit root, IJavaElement element, TextChange textChange) {
@@ -182,13 +202,13 @@ public class ChangeUtil {
 		for (TextEdit textEdit : children) {
 			TextEditConverter converter = new TextEditConverter(unit, textEdit);
 			String uri = JDTUtils.toURI(unit);
-			if (JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isWorkspaceEditResourceChangesSupported()) {
-				List<Either<org.eclipse.lsp4j.ResourceChange, TextDocumentEdit>> changes = root.getResourceChanges();
+			if (JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isResourceOperationSupported()) {
+				List<Either<TextDocumentEdit, ResourceOperation>> changes = root.getDocumentChanges();
 				if (changes == null) {
 					changes = new LinkedList<>();
-					root.setResourceChanges(changes);
+					root.setDocumentChanges(changes);
 				}
-				changes.add(Either.forRight(converter.convertToTextDocumentEdit(0)));
+				changes.add(Either.forLeft(converter.convertToTextDocumentEdit(0)));
 			} else {
 				Map<String, List<org.eclipse.lsp4j.TextEdit>> changes = root.getChanges();
 				if (changes.containsKey(uri)) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -154,7 +154,7 @@ final public class InitHandler {
 			capabilities.setSignatureHelpProvider(SignatureHelpHandler.createOptions());
 		}
 		if (!preferenceManager.getClientPreferences().isRenameDynamicRegistrationSupported()) {
-			capabilities.setRenameProvider(Boolean.TRUE);
+			capabilities.setRenameProvider(RenameHandler.createOptions());
 		}
 		if (!preferenceManager.getClientPreferences().isCodeActionDynamicRegistered()) {
 			capabilities.setCodeActionProvider(Boolean.TRUE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -89,6 +89,8 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.PrepareRenameResult;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
@@ -250,7 +252,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 			toggleCapability(preferenceManager.getPreferences().isSignatureHelpEnabled(), Preferences.SIGNATURE_HELP_ID, Preferences.TEXT_DOCUMENT_SIGNATURE_HELP, SignatureHelpHandler.createOptions());
 		}
 		if (preferenceManager.getClientPreferences().isRenameDynamicRegistrationSupported()) {
-			toggleCapability(preferenceManager.getPreferences().isRenameEnabled(), Preferences.RENAME_ID, Preferences.TEXT_DOCUMENT_RENAME, null);
+			toggleCapability(preferenceManager.getPreferences().isRenameEnabled(), Preferences.RENAME_ID, Preferences.TEXT_DOCUMENT_RENAME, RenameHandler.createOptions());
 		}
 		if (preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isExecuteCommandEnabled(), Preferences.EXECUTE_COMMAND_ID, Preferences.WORKSPACE_EXECUTE_COMMAND,
@@ -625,6 +627,17 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		logInfo(">> document/onTypeFormatting");
 		FormatterHandler handler = new FormatterHandler(preferenceManager);
 		return computeAsync((monitor) -> handler.onTypeFormatting(params, monitor));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.lsp4j.services.TextDocumentService#prepareRename(org.eclipse.lsp4j.TextDocumentPositionParams)
+	 */
+	@Override
+	public CompletableFuture<Either<Range, PrepareRenameResult>> prepareRename(TextDocumentPositionParams params) {
+		logInfo(">> document/prepareRename");
+
+		PrepareRenameHandler handler = new PrepareRenameHandler();
+		return computeAsync((monitor) -> handler.prepareRename(params, monitor));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PrepareRenameHandler.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.internal.core.manipulation.search.IOccurrencesFinder.OccurrenceLocation;
+import org.eclipse.jdt.internal.core.manipulation.search.OccurrencesFinder;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.lsp4j.PrepareRenameResult;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+public class PrepareRenameHandler {
+
+	public PrepareRenameHandler() {
+	}
+
+	public Either<Range, PrepareRenameResult> prepareRename(TextDocumentPositionParams params, IProgressMonitor monitor) {
+
+		final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
+		if (unit != null) {
+			try {
+				OccurrencesFinder finder = new OccurrencesFinder();
+				CompilationUnit ast = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
+
+				if (ast != null) {
+					int offset = JsonRpcHelpers.toOffset(unit.getBuffer(), params.getPosition().getLine(), params.getPosition().getCharacter());
+					String error = finder.initialize(ast, offset, 0);
+					if (error == null) {
+						OccurrenceLocation[] occurrences = finder.getOccurrences();
+						if (occurrences != null) {
+							for (OccurrenceLocation loc : occurrences) {
+								if (monitor.isCanceled()) {
+									return Either.forLeft(new Range());
+								}
+								if (loc.getOffset() <= offset && loc.getOffset() + loc.getLength() >= offset) {
+									return Either.forLeft(JDTUtils.toRange(unit, loc.getOffset(), loc.getLength()));
+								}
+							}
+						}
+					}
+				}
+
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("Problem with compute occurrences for" + unit.getElementName() + " in prepareRename", e);
+			}
+		}
+		return Either.forLeft(new Range());
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.util.ArrayList;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.CoreException;
@@ -24,8 +25,12 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.rename.RenameSupport;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
 import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
@@ -33,6 +38,12 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
 
 public class RenameHandler {
+
+	public static RenameOptions createOptions() {
+		RenameOptions renameOptions = new RenameOptions();
+		renameOptions.setPrepareProvider(true);
+		return renameOptions;
+	}
 
 	private PreferenceManager preferenceManager;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.ResourceOperationKind;
 
 /**
  * A wrapper around {@link ClientCapabilities}
@@ -175,6 +176,16 @@ public class ClientPreferences {
 
 	public boolean isWorkspaceEditResourceChangesSupported() {
 		return capabilities.getWorkspace() != null && capabilities.getWorkspace().getWorkspaceEdit() != null && isTrue(capabilities.getWorkspace().getWorkspaceEdit().getResourceChanges());
+	}
+
+	@Deprecated
+	public boolean isResourceOperationSupported() {
+		//@formatter:off
+		return capabilities.getWorkspace() != null && capabilities.getWorkspace().getWorkspaceEdit() != null
+				&& capabilities.getWorkspace().getWorkspaceEdit().getResourceOperations().contains(ResourceOperationKind.Create)
+				&& capabilities.getWorkspace().getWorkspaceEdit().getResourceOperations().contains(ResourceOperationKind.Rename)
+				&& capabilities.getWorkspace().getWorkspaceEdit().getResourceOperations().contains(ResourceOperationKind.Delete);
+		//@formatter:on
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -33,12 +33,13 @@
             <repository location="http://download.eclipse.org/eclipse/updates/4.10-I-builds/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.5.0.v20180903-1212"/>
-            <repository location="http://download.eclipse.org/lsp4j/updates/releases/0.5.0/"/>
+            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+            <repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.xtend.sdk.feature.group" version="2.14.0.v20180523-0937"/>
-            <repository location="http://download.eclipse.org/releases/photon/"/>
+            <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
+            <repository location="http://download.eclipse.org/releases/2018-12/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.5.0.201805160042"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -13,7 +13,6 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,9 +34,11 @@ import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.RenameFile;
 import org.eclipse.lsp4j.RenameParams;
-import org.eclipse.lsp4j.ResourceChange;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
@@ -213,7 +214,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testRenameTypeWhithResourceChanges() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isWorkspaceEditResourceChangesSupported()).thenReturn(true);
+		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 
@@ -234,18 +235,18 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 		WorkspaceEdit edit = getRenameEdit(cu, pos, "Newname");
 		assertNotNull(edit);
-		List<Either<ResourceChange, TextDocumentEdit>> resourceChanges = edit.getResourceChanges();
+		List<Either<TextDocumentEdit, ResourceOperation>> resourceChanges = edit.getDocumentChanges();
 
 		assertEquals(resourceChanges.size(), 3);
 
-		Either<ResourceChange, TextDocumentEdit> change = resourceChanges.get(2);
-		ResourceChange resourceChange = change.getLeft();
-		assertEquals(JDTUtils.toURI(cu), resourceChange.getCurrent());
+		Either<TextDocumentEdit, ResourceOperation> change = resourceChanges.get(2);
+		RenameFile resourceChange = (RenameFile) change.getRight();
+		assertEquals(JDTUtils.toURI(cu), resourceChange.getOldUri());
 		assertEquals(JDTUtils.toURI(cu).replace("E", "Newname"), resourceChange.getNewUri());
 
 		List<TextEdit> testChanges = new LinkedList<>();
-		testChanges.addAll(resourceChanges.get(0).getRight().getEdits());
-		testChanges.addAll(resourceChanges.get(1).getRight().getEdits());
+		testChanges.addAll(resourceChanges.get(0).getLeft().getEdits());
+		testChanges.addAll(resourceChanges.get(1).getLeft().getEdits());
 
 		String expected = "package test1;\n" +
 						  "public class Newname {\n" +
@@ -725,7 +726,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testRenamePackage() throws JavaModelException, BadLocationException {
-		when(clientPreferences.isWorkspaceEditResourceChangesSupported()).thenReturn(true);
+		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
 
 		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
 		IPackageFragment pack2 = sourceFolder.createPackageFragment("parent.test2", false, null);
@@ -759,16 +760,16 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 		WorkspaceEdit edit = getRenameEdit(cuB, pos, "parent.newpackage");
 		assertNotNull(edit);
 
-		List<Either<ResourceChange, TextDocumentEdit>> resourceChanges = edit.getResourceChanges();
+		List<Either<TextDocumentEdit, ResourceOperation>> resourceChanges = edit.getDocumentChanges();
 
-		assertEquals(5, resourceChanges.size());
+		assertEquals(6, resourceChanges.size());
 
 		List<TextEdit> testChangesA = new LinkedList<>();
-		testChangesA.addAll(resourceChanges.get(0).getRight().getEdits());
+		testChangesA.addAll(resourceChanges.get(0).getLeft().getEdits());
 
 		List<TextEdit> testChangesB = new LinkedList<>();
-		testChangesB.addAll(resourceChanges.get(1).getRight().getEdits());
-		testChangesB.addAll(resourceChanges.get(2).getRight().getEdits());
+		testChangesB.addAll(resourceChanges.get(1).getLeft().getEdits());
+		testChangesB.addAll(resourceChanges.get(2).getLeft().getEdits());
 
 		String expectedA =
 				"package test1;\n" +
@@ -790,13 +791,12 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(expectedB, TextEditUtil.apply(builderB.toString(), testChangesB));
 
 		//moved package
-		ResourceChange resourceChange = resourceChanges.get(3).getLeft();
-		assertNull(resourceChange.getCurrent());
-		assertEquals(ResourceUtils.fixURI(pack2.getResource().getRawLocationURI()).replace("test2", "newpackage"), resourceChange.getNewUri());
+		CreateFile resourceChange = (CreateFile) resourceChanges.get(3).getRight();
+		assertEquals(ResourceUtils.fixURI(pack2.getResource().getRawLocationURI()).replace("test2/", "newpackage/.temp"), resourceChange.getUri());
 
 		//moved class B
-		ResourceChange resourceChange2 = resourceChanges.get(4).getLeft();
-		assertEquals(ResourceUtils.fixURI(cuB.getResource().getRawLocationURI()), resourceChange2.getCurrent());
+		RenameFile resourceChange2 = (RenameFile) resourceChanges.get(4).getRight();
+		assertEquals(ResourceUtils.fixURI(cuB.getResource().getRawLocationURI()), resourceChange2.getOldUri());
 		assertEquals(ResourceUtils.fixURI(cuB.getResource().getRawLocationURI()).replace("test2", "newpackage"), resourceChange2.getNewUri());
 	}
 


### PR DESCRIPTION
Adopt the lsp4j resource operation. 

Still, there are two issues here: 
- https://github.com/eclipse/eclipse.jdt.ls/issues/834
The rename and resource change will trigger the auto build, which will publish diagnostic yet the file is not saved on the client side. At least, the behavior of VSCode jave. Not sure about other client. 

- https://github.com/Microsoft/language-server-protocol/issues/272
The language server protocol doesn't have the fully support for creation folder.  The code has a workaround for this issue, but it appears not work very well on vscode client, not sure on other client. 

@fbricon , @snjeza Any suggestion on these two issues. 