### PR TITLE
Add source CodeAction support for organize imports.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -22,7 +22,9 @@ package org.eclipse.jdt.ls.core.internal.corrections;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IBuffer;
@@ -60,10 +62,10 @@ public class QuickFixProcessor {
 		return start;
 	}
 
-	public ArrayList<CUCorrectionProposal> getCorrections(IInvocationContext context, IProblemLocationCore[] locations)
+	public List<CUCorrectionProposal> getCorrections(IInvocationContext context, IProblemLocationCore[] locations)
 			throws CoreException {
 		if (locations == null || locations.length == 0) {
-			return new ArrayList<>();
+			return Collections.emptyList();
 		}
 
 		HashSet<Integer> handledProblems = new HashSet<>(locations.length);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -60,10 +60,10 @@ public class QuickFixProcessor {
 		return start;
 	}
 
-	public CUCorrectionProposal[] getCorrections(IInvocationContext context, IProblemLocationCore[] locations)
+	public ArrayList<CUCorrectionProposal> getCorrections(IInvocationContext context, IProblemLocationCore[] locations)
 			throws CoreException {
 		if (locations == null || locations.length == 0) {
-			return new CUCorrectionProposal[0];
+			return new ArrayList<>();
 		}
 
 		HashSet<Integer> handledProblems = new HashSet<>(locations.length);
@@ -75,7 +75,7 @@ public class QuickFixProcessor {
 				process(context, curr, resultingCollections);
 			}
 		}
-		return resultingCollections.toArray(new CUCorrectionProposal[resultingCollections.size()]);
+		return resultingCollections;
 	}
 
 	private void process(IInvocationContext context, IProblemLocationCore problem,

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CUCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CUCorrectionProposal.java
@@ -68,44 +68,6 @@ public class CUCorrectionProposal extends ChangeCorrectionProposal  {
 	}
 
 	/**
-	 * Constructs a correction proposal working on a compilation unit with a given
-	 * text change.
-	 *
-	 * @param name
-	 *            the name that is displayed in the proposal selection dialog
-	 * @param cu
-	 *            the compilation unit to which the change can be applied
-	 * @param change
-	 *            the change that is executed when the proposal is applied or
-	 *            <code>null</code> if implementors override
-	 *            {@link #addEdits(IDocument, TextEdit)} to provide the text edits
-	 *            or {@link #createTextChange()} to provide a text change
-	 * @param relevance
-	 *            the relevance of this proposal
-	 */
-	public CUCorrectionProposal(String name, ICompilationUnit cu, Change change, int relevance) {
-		this(name, null, cu, null, relevance);
-	}
-
-	/**
-	 * Constructs a correction proposal working on a compilation unit.
-	 * <p>
-	 * Users have to override {@link #addEdits(IDocument, TextEdit)} to provide the
-	 * text edits or {@link #createTextChange()} to provide a text change.
-	 * </p>
-	 *
-	 * @param name
-	 *            the name that is displayed in the proposal selection dialog
-	 * @param cu
-	 *            the compilation unit on that the change works
-	 * @param relevance
-	 *            the relevance of this proposal
-	 */
-	protected CUCorrectionProposal(String name, ICompilationUnit cu, int relevance) {
-		this(name, cu, null, relevance);
-	}
-
-	/**
 	 * Called when the {@link CompilationUnitChange} is initialized. Subclasses can override to add
 	 * text edits to the root edit of the change. Implementors must not access the proposal, e.g.
 	 * not call {@link #getChange()}.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/JavadocTagsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/JavadocTagsSubProcessor.java
@@ -83,7 +83,7 @@ public class JavadocTagsSubProcessor {
 		private final String fComment;
 
 		private AddJavadocCommentProposal(String name, ICompilationUnit cu, int relevance, int insertPosition, String comment) {
-			super(name, CodeActionKind.Source, cu, null, relevance);
+			super(name, CodeActionKind.QuickFix, cu, null, relevance);
 			fInsertPosition= insertPosition;
 			fComment= comment;
 		}
@@ -116,7 +116,7 @@ public class JavadocTagsSubProcessor {
 		private final ASTNode fMissingNode;
 
 		public AddMissingJavadocTagProposal(String label, ICompilationUnit cu, BodyDeclaration bodyDecl, ASTNode missingNode, int relevance) {
-			super(label, CodeActionKind.Source, cu, null, relevance);
+			super(label, CodeActionKind.QuickFix, cu, null, relevance);
 			fBodyDecl= bodyDecl;
 			fMissingNode= missingNode;
 		}
@@ -211,7 +211,7 @@ public class JavadocTagsSubProcessor {
 		private final BodyDeclaration fBodyDecl;
 
 		public AddAllMissingJavadocTagsProposal(String label, ICompilationUnit cu, BodyDeclaration bodyDecl, int relevance) {
-			super(label, CodeActionKind.Source, cu, null, relevance);
+			super(label, CodeActionKind.QuickFix, cu, null, relevance);
 			fBodyDecl= bodyDecl;
 		}
 
@@ -669,7 +669,7 @@ public class JavadocTagsSubProcessor {
 		rewrite.remove(node, null);
 
 		String label= CorrectionMessages.JavadocTagsSubProcessor_removetag_description;
-		proposals.add(new ASTRewriteCorrectionProposal(label, CodeActionKind.Source, context.getCompilationUnit(), rewrite,
+		proposals.add(new ASTRewriteCorrectionProposal(label, CodeActionKind.QuickFix, context.getCompilationUnit(), rewrite,
 				IProposalRelevance.REMOVE_TAG));
 	}
 
@@ -691,7 +691,7 @@ public class JavadocTagsSubProcessor {
 		rewrite.replace(name, ast.newName(typeBinding.getQualifiedName()), null);
 
 		String label= CorrectionMessages.JavadocTagsSubProcessor_qualifylinktoinner_description;
-		ASTRewriteCorrectionProposal proposal = new ASTRewriteCorrectionProposal(label, CodeActionKind.Source, context.getCompilationUnit(),
+		ASTRewriteCorrectionProposal proposal = new ASTRewriteCorrectionProposal(label, CodeActionKind.QuickFix, context.getCompilationUnit(),
 				rewrite, IProposalRelevance.QUALIFY_INNER_TYPE_NAME);
 
 		proposals.add(proposal);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/RenameNodeCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/RenameNodeCorrectionProposal.java
@@ -32,7 +32,7 @@ public class RenameNodeCorrectionProposal extends CUCorrectionProposal {
 	private int fLength;
 
 	public RenameNodeCorrectionProposal(String name, ICompilationUnit cu, int offset, int length, String newName, int relevance) {
-		super(name, CodeActionKind.Refactor, cu, null, relevance);
+		super(name, CodeActionKind.QuickFix, cu, null, relevance);
 		fOffset= offset;
 		fLength= length;
 		fNewName= newName;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.QuickFixProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor;
+import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -54,6 +55,8 @@ public class CodeActionHandler {
 	private QuickFixProcessor quickFixProcessor = new QuickFixProcessor();
 
 	private QuickAssistProcessor quickAssistProcessor = new QuickAssistProcessor();
+
+	private SourceAssistProcessor sourceAssistProcessor = new SourceAssistProcessor();
 
 	private PreferenceManager preferenceManager;
 
@@ -77,24 +80,44 @@ public class CodeActionHandler {
 		IProblemLocationCore[] locations = this.getProblemLocationCores(unit, params.getContext().getDiagnostics());
 
 		List<Either<Command, CodeAction>> $ = new ArrayList<>();
+		List<CUCorrectionProposal> candidates = new ArrayList<>();
 		try {
-			CUCorrectionProposal[] corrections = this.quickFixProcessor.getCorrections(context, locations);
-			Arrays.sort(corrections, new CUCorrectionProposalComparator());
-			for (CUCorrectionProposal proposal : corrections) {
-				$.add(getCodeActionFromProposal(proposal, params.getContext()));
-			}
+			ArrayList<CUCorrectionProposal> corrections = this.quickFixProcessor.getCorrections(context, locations);
+			corrections.sort(new CUCorrectionProposalComparator());
+			candidates.addAll(corrections);
 		} catch (CoreException e) {
-			JavaLanguageServerPlugin.logException("Problem resolving code actions", e);
+			JavaLanguageServerPlugin.logException("Problem resolving quick fix code actions", e);
 		}
 
 		try {
-			CUCorrectionProposal[] corrections = this.quickAssistProcessor.getAssists(context, locations);
-			Arrays.sort(corrections, new CUCorrectionProposalComparator());
-			for (CUCorrectionProposal proposal : corrections) {
+			ArrayList<CUCorrectionProposal> corrections = this.quickAssistProcessor.getAssists(context, locations);
+			corrections.sort(new CUCorrectionProposalComparator());
+			candidates.addAll(corrections);
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logException("Problem resolving quick assist code actions", e);
+		}
+
+		ArrayList<CUCorrectionProposal> corrections = this.sourceAssistProcessor.getAssists(context, locations);
+		corrections.sort(new CUCorrectionProposalComparator());
+		candidates.addAll(corrections);
+
+		if (params.getContext().getOnly() != null && !params.getContext().getOnly().isEmpty()) {
+			List<CUCorrectionProposal> resultList = new ArrayList<>();
+			List<String> acceptedActionKinds = params.getContext().getOnly();
+			for (CUCorrectionProposal proposal : candidates) {
+				if (acceptedActionKinds.contains(proposal.getKind())) {
+					resultList.add(proposal);
+				}
+			}
+			candidates = resultList;
+		}
+
+		try {
+			for (CUCorrectionProposal proposal : candidates) {
 				$.add(getCodeActionFromProposal(proposal, params.getContext()));
 			}
 		} catch (CoreException e) {
-			JavaLanguageServerPlugin.logException("Problem resolving code actions", e);
+			JavaLanguageServerPlugin.logException("Problem converting proposal to code actions", e);
 		}
 
 		return $;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -82,7 +82,7 @@ public class CodeActionHandler {
 		List<Either<Command, CodeAction>> $ = new ArrayList<>();
 		List<CUCorrectionProposal> candidates = new ArrayList<>();
 		try {
-			ArrayList<CUCorrectionProposal> corrections = this.quickFixProcessor.getCorrections(context, locations);
+			List<CUCorrectionProposal> corrections = this.quickFixProcessor.getCorrections(context, locations);
 			corrections.sort(new CUCorrectionProposalComparator());
 			candidates.addAll(corrections);
 		} catch (CoreException e) {
@@ -90,14 +90,14 @@ public class CodeActionHandler {
 		}
 
 		try {
-			ArrayList<CUCorrectionProposal> corrections = this.quickAssistProcessor.getAssists(context, locations);
+			List<CUCorrectionProposal> corrections = this.quickAssistProcessor.getAssists(context, locations);
 			corrections.sort(new CUCorrectionProposalComparator());
 			candidates.addAll(corrections);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Problem resolving quick assist code actions", e);
 		}
 
-		ArrayList<CUCorrectionProposal> corrections = this.sourceAssistProcessor.getAssists(context, locations);
+		List<CUCorrectionProposal> corrections = this.sourceAssistProcessor.getAssists(context, locations);
 		corrections.sort(new CUCorrectionProposalComparator());
 		candidates.addAll(corrections);
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -83,7 +84,6 @@ public class CodeActionHandler {
 		List<CUCorrectionProposal> candidates = new ArrayList<>();
 		try {
 			List<CUCorrectionProposal> corrections = this.quickFixProcessor.getCorrections(context, locations);
-			corrections.sort(new CUCorrectionProposalComparator());
 			candidates.addAll(corrections);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Problem resolving quick fix code actions", e);
@@ -91,15 +91,15 @@ public class CodeActionHandler {
 
 		try {
 			List<CUCorrectionProposal> corrections = this.quickAssistProcessor.getAssists(context, locations);
-			corrections.sort(new CUCorrectionProposalComparator());
 			candidates.addAll(corrections);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Problem resolving quick assist code actions", e);
 		}
 
 		List<CUCorrectionProposal> corrections = this.sourceAssistProcessor.getAssists(context, locations);
-		corrections.sort(new CUCorrectionProposalComparator());
 		candidates.addAll(corrections);
+
+		candidates.sort(new CUCorrectionProposalComparator());
 
 		if (params.getContext().getOnly() != null && !params.getContext().getOnly().isEmpty()) {
 			List<CUCorrectionProposal> resultList = new ArrayList<>();
@@ -189,6 +189,12 @@ public class CodeActionHandler {
 
 		@Override
 		public int compare(CUCorrectionProposal p1, CUCorrectionProposal p2) {
+			String k1 = p1.getKind();
+			String k2 = p2.getKind();
+			if (!StringUtils.isBlank(k1) && !StringUtils.isBlank(k2) && !k1.equals(k2)) {
+				return k1.compareTo(k2);
+			}
+
 			int r1 = p1.getRelevance();
 			int r2 = p2.getRelevance();
 			int relevanceDif = r2 - r1;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -23,6 +23,7 @@ package org.eclipse.jdt.ls.core.internal.text.correction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -141,7 +142,7 @@ public class QuickAssistProcessor {
 	public QuickAssistProcessor() {
 	}
 
-	public ArrayList<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
+	public List<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
 		ASTNode coveringNode = context.getCoveringNode();
 		if (coveringNode != null) {
 			ArrayList<ASTNode> coveredNodes = getFullyCoveredNodes(context, coveringNode);
@@ -198,7 +199,7 @@ public class QuickAssistProcessor {
 			}
 			return resultingCollections;
 		}
-		return new ArrayList<>();
+		return Collections.emptyList();
 	}
 
 	private static boolean getConvertVarTypeToResolvedTypeProposal(IInvocationContext context, ASTNode node, Collection<CUCorrectionProposal> proposals) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -141,7 +141,7 @@ public class QuickAssistProcessor {
 	public QuickAssistProcessor() {
 	}
 
-	public CUCorrectionProposal[] getAssists(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
+	public ArrayList<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
 		ASTNode coveringNode = context.getCoveringNode();
 		if (coveringNode != null) {
 			ArrayList<ASTNode> coveredNodes = getFullyCoveredNodes(context, coveringNode);
@@ -196,9 +196,9 @@ public class QuickAssistProcessor {
 				getConvertVarTypeToResolvedTypeProposal(context, coveringNode, resultingCollections);
 				getConvertResolvedTypeToVarTypeProposal(context, coveringNode, resultingCollections);
 			}
-			return resultingCollections.toArray(new CUCorrectionProposal[resultingCollections.size()]);
+			return resultingCollections;
 		}
-		return new CUCorrectionProposal[0];
+		return new ArrayList<>();
 	}
 
 	private static boolean getConvertVarTypeToResolvedTypeProposal(IInvocationContext context, ASTNode node, Collection<CUCorrectionProposal> proposals) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
 * Copyright (c) 2017 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
@@ -13,6 +12,7 @@
 package org.eclipse.jdt.ls.core.internal.text.correction;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -29,10 +29,7 @@ import org.eclipse.text.edits.TextEdit;
 
 public class SourceAssistProcessor {
 
-	public SourceAssistProcessor() {
-	}
-
-	public ArrayList<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) {
+	public List<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) {
 		ArrayList<CUCorrectionProposal> resultingCollections = new ArrayList<>();
 
 		getOrganizeImportsProposal(context, resultingCollections);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -1,0 +1,61 @@
+
+/*******************************************************************************
+* Copyright (c) 2017 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.text.correction;
+
+import java.util.ArrayList;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation;
+import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
+import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.text.edits.TextEdit;
+
+public class SourceAssistProcessor {
+
+	public SourceAssistProcessor() {
+	}
+
+	public ArrayList<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) {
+		ArrayList<CUCorrectionProposal> resultingCollections = new ArrayList<>();
+
+		getOrganizeImportsProposal(context, resultingCollections);
+
+		return resultingCollections;
+	}
+
+	private static void getOrganizeImportsProposal(IInvocationContext context, ArrayList<CUCorrectionProposal> resultingCollections) {
+		ICompilationUnit unit = context.getCompilationUnit();
+
+		CUCorrectionProposal proposal = new CUCorrectionProposal(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
+				CodeActionKind.SourceOrganizeImports,
+				unit,
+				null,
+				IProposalRelevance.ORGANIZE_IMPORTS) {
+			@Override
+			protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
+				CompilationUnit astRoot = context.getASTRoot();
+				OrganizeImportsOperation op = new OrganizeImportsOperation(unit, astRoot, true, false, true, null);
+				editRoot.addChild(op.createTextEdit(null));
+			}
+		};
+
+		resultingCollections.add(proposal);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
@@ -36,8 +36,10 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
@@ -48,6 +50,8 @@ import org.junit.Assert;
 public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 
 	private List<String> ignoredCommands;
+
+	private List<String> ignoredKinds = Arrays.asList(CodeActionKind.Source + ".*");
 
 	protected void assertCodeActionExists(ICompilationUnit cu, Expected expected) throws Exception {
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu);
@@ -153,12 +157,19 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	protected Range getRange(ICompilationUnit cu, IProblem[] problems) throws JavaModelException {
+		if (problems.length == 0) {
+			return new Range(new Position(), new Position());
+		}
 		IProblem problem = problems[0];
 		return JDTUtils.toRange(cu, problem.getSourceStart(), 0);
 	}
 
 	protected void setIgnoredCommands(List<String> ignoredCommands) {
 		this.ignoredCommands = ignoredCommands;
+	}
+
+	protected void setIgnoredKind(List<String> ignoredKind) {
+		this.ignoredKinds = ignoredKind;
 	}
 
 	protected List<Either<Command, CodeAction>> evaluateCodeActions(ICompilationUnit cu) throws JavaModelException {
@@ -179,6 +190,22 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 		parms.setContext(context);
 
 		List<Either<Command, CodeAction>> codeActions = new CodeActionHandler(this.preferenceManager).getCodeActionCommands(parms, new NullProgressMonitor());
+
+		if (this.ignoredKinds != null) {
+			List<Either<Command, CodeAction>> filteredList = new ArrayList<>();
+			for (Either<Command, CodeAction> codeAction : codeActions) {
+				if (codeAction.isRight()) {
+					for (String str : this.ignoredKinds) {
+						if (codeAction.getRight().getKind().matches(str)) {
+							filteredList.add(codeAction);
+							break;
+						}
+					}
+				}
+			}
+			codeActions.removeAll(filteredList);
+		}
+
 		if (this.ignoredCommands != null) {
 			List<Either<Command, CodeAction>> filteredList = new ArrayList<>();
 			for (Either<Command, CodeAction> codeAction : codeActions) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
@@ -196,10 +196,10 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 			List<Either<Command, CodeAction>> filteredList = codeActions.stream().filter(Either::isRight).filter(codeAction -> {
 				for (String str : this.ignoredKinds) {
 					if (codeAction.getRight().getKind().matches(str)) {
-						return false;
+						return true;
 					}
 				}
-				return true;
+				return false;
 			}).collect(Collectors.toList());
 			codeActions.removeAll(filteredList);
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/JavadocQuickFixTest.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.correction;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
@@ -969,7 +968,7 @@ public class JavadocQuickFixTest extends AbstractQuickFixTest {
 	public void testMissingFieldComment() throws Exception {
 		Map<String, String> original = fJProject1.getOptions(false);
 		HashMap<String, String> newOptions = new HashMap<>(original);
-		this.setIgnoredCommands(Arrays.asList("Extract.*"));
+		this.setIgnoredCommands("Extract.*");
 		// newOptions.put(JavaCore.COMPILER_PB_MISSING_JAVADOC_COMMENTS,
 		// JavaCore.ERROR);
 		// newOptions.put(JavaCore.COMPILER_PB_MISSING_JAVADOC_COMMENTS_VISIBILITY,

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LocalCorrectionQuickFixTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.jdt.ls.core.internal.correction;
 
-import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -39,7 +38,7 @@ public class LocalCorrectionQuickFixTest extends AbstractQuickFixTest {
 		fJProject1.setOptions(options);
 
 		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
-		this.setIgnoredCommands(Arrays.asList("Extract.*"));
+		this.setIgnoredCommands("Extract.*");
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
@@ -618,6 +618,55 @@ public class ModifierCorrectionsQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("public class C {\n");
 		buf.append("    private int test;\n");
+		buf.append("}\n");
+		buf.append("public class E extends C {\n");
+		buf.append("    public void foo () {\n");
+		buf.append("         int test = 1;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e2 = new Expected("Create local variable 'test'", buf.toString());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("    private int test;\n");
+		buf.append("}\n");
+		buf.append("public class E extends C {\n");
+		buf.append("    private int test;\n");
+		buf.append("\n");
+		buf.append("    public void foo () {\n");
+		buf.append("         test = 1;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e3 = new Expected("Create field 'test'", buf.toString());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("    private int test;\n");
+		buf.append("}\n");
+		buf.append("public class E extends C {\n");
+		buf.append("    public void foo (int test) {\n");
+		buf.append("         test = 1;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e4 = new Expected("Create parameter 'test'", buf.toString());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("    private int test;\n");
+		buf.append("}\n");
+		buf.append("public class E extends C {\n");
+		buf.append("    public void foo () {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e5 = new Expected("Remove assignment", buf.toString());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class C {\n");
+		buf.append("    private int test;\n");
 		buf.append("\n");
 		buf.append("    /**\n");
 		buf.append("     * @return the test\n");
@@ -638,56 +687,7 @@ public class ModifierCorrectionsQuickFixTest extends AbstractQuickFixTest {
 		buf.append("         setTest(1);\n");
 		buf.append("    }\n");
 		buf.append("}\n");
-		Expected e2 = new Expected("Create getter and setter for 'test'...", buf.toString());
-
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("public class C {\n");
-		buf.append("    private int test;\n");
-		buf.append("}\n");
-		buf.append("public class E extends C {\n");
-		buf.append("    public void foo () {\n");
-		buf.append("         int test = 1;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e3 = new Expected("Create local variable 'test'", buf.toString());
-
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("public class C {\n");
-		buf.append("    private int test;\n");
-		buf.append("}\n");
-		buf.append("public class E extends C {\n");
-		buf.append("    private int test;\n");
-		buf.append("\n");
-		buf.append("    public void foo () {\n");
-		buf.append("         test = 1;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e4 = new Expected("Create field 'test'", buf.toString());
-
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("public class C {\n");
-		buf.append("    private int test;\n");
-		buf.append("}\n");
-		buf.append("public class E extends C {\n");
-		buf.append("    public void foo (int test) {\n");
-		buf.append("         test = 1;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e5 = new Expected("Create parameter 'test'", buf.toString());
-
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("public class C {\n");
-		buf.append("    private int test;\n");
-		buf.append("}\n");
-		buf.append("public class E extends C {\n");
-		buf.append("    public void foo () {\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e6 = new Expected("Remove assignment", buf.toString());
+		Expected e6 = new Expected("Create getter and setter for 'test'...", buf.toString());
 
 		assertCodeActions(cu, e1, e2, e3, e4, e5, e6);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/OrganizeImportsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/OrganizeImportsActionTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.jdt.ls.core.internal.correction;
 
-import java.util.Arrays;
 import java.util.Hashtable;
 
 import org.eclipse.core.resources.IProject;
@@ -37,7 +36,7 @@ public class OrganizeImportsActionTest extends AbstractQuickFixTest {
 		fJProject1.setOptions(options);
 		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
 
-		this.setIgnoredKind(Arrays.asList("quickfix.*", "refactor.*"));
+		this.setIgnoredKind("quickfix.*", "refactor.*");
 	}
 
 	public void setupJava9() throws Exception {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/OrganizeImportsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/OrganizeImportsActionTest.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2017-2018 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.Arrays;
+import java.util.Hashtable;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OrganizeImportsActionTest extends AbstractQuickFixTest {
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+
+		this.setIgnoredKind(Arrays.asList("quickfix.*", "refactor.*"));
+	}
+
+	public void setupJava9() throws Exception {
+		importExistingProjects("eclipse/java9");
+		IProject project = WorkspaceHelper.getProject("java9");
+		fJProject1 = JavaCore.create(project);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src/main/java"));
+	}
+
+	@Test
+	public void testOrganizeImportsModuleInfo() throws Exception {
+
+		setupJava9();
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("import foo.bar.MyDriverAction;\n");
+		buf.append("import java.sql.DriverAction;\n");
+		buf.append("import java.sql.SQLException;\n");
+		buf.append("\n");
+		buf.append("module mymodule.nine {\n");
+		buf.append("	requires java.sql;\n");
+		buf.append("	exports foo.bar;\n");
+		buf.append("	provides DriverAction with MyDriverAction;\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("import java.sql.DriverAction;\n");
+		buf.append("\n");
+		buf.append("import foo.bar.MyDriverAction;\n");
+		buf.append("\n");
+		buf.append("module mymodule.nine {\n");
+		buf.append("	requires java.sql;\n");
+		buf.append("	exports foo.bar;\n");
+		buf.append("	provides DriverAction with MyDriverAction;\n");
+		buf.append("}\n");
+
+		Expected e1 = new Expected("Organize imports", buf.toString());
+
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testOrganizeImportsUnused() throws Exception {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+
+		Expected e1 = new Expected("Organize imports", buf.toString());
+
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testOrganizeImportsSort() throws Exception {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected e1 = new Expected("Organize imports", buf.toString());
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testOrganizeImportsAutomaticallyResolve() throws Exception {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public E() {\n");
+		buf.append("        ArrayList list = new ArrayList();\n");
+		buf.append("        HashMap<String, String> map = new HashMap<String, String>();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected e1 = new Expected("Organize imports", buf.toString());
+
+		assertCodeActions(cu, e1);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
-import static org.mockito.Mockito.when;
-
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,7 +23,6 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.LanguageServerWorkingCopyOwner;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
-import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -56,8 +53,6 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 	@Mock
 	private JavaClientConnection connection;
 
-	@Mock
-	private ClientPreferences clientPreferences;
 
 	@Override
 	@Before
@@ -66,9 +61,6 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		project = WorkspaceHelper.getProject("hello");
 		wcOwner = new LanguageServerWorkingCopyOwner(connection);
 		server = new JDTLanguageServer(projectsManager, this.preferenceManager);
-
-		when(this.preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
-		when(clientPreferences.isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
 	}
 
 	@Test
@@ -88,8 +80,9 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnusedImport), range))));
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 		Assert.assertNotNull(codeActions);
-		Assert.assertEquals(2, codeActions.size());
+		Assert.assertEquals(3, codeActions.size());
 		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
+		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
 		Command c = codeActions.get(0).getRight().getCommand();
 		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
 	}
@@ -111,7 +104,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnterminatedString), range))));
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 		Assert.assertNotNull(codeActions);
-		Assert.assertEquals(1, codeActions.size());
+		Assert.assertEquals(2, codeActions.size());
 		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
 		Command c = codeActions.get(0).getRight().getCommand();
 		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
@@ -134,7 +127,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 			params.setContext(context);
 			List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 			Assert.assertNotNull(codeActions);
-			Assert.assertEquals(0, codeActions.size());
+			Assert.assertEquals(1, codeActions.size());
 		} finally {
 			cu.discardWorkingCopy();
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -168,6 +168,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		parms.setRange(range);
 		CodeActionContext context = new CodeActionContext();
 		context.setDiagnostics(DiagnosticsHandler.toDiagnosticsArray(cu, Arrays.asList(problems)));
+		context.setOnly(Arrays.asList(CodeActionKind.QuickFix));
 		parms.setContext(context);
 
 		return new CodeActionHandler(this.preferenceManager).getCodeActionCommands(parms, new NullProgressMonitor());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -147,6 +148,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		when(clientPreferences.isProgressReportSupported()).thenReturn(true);
 		when(clientPreferences.isSemanticHighlightingSupported()).thenReturn(true);
 		when(preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
+		when(clientPreferences.isSupportedCodeActionKind(anyString())).thenReturn(true);
 		return clientPreferences;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractVariableTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractVariableTest.java
@@ -11,7 +11,6 @@
 
 package org.eclipse.jdt.ls.core.internal.refactoring;
 
-import java.util.Arrays;
 import java.util.Hashtable;
 
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -36,7 +35,7 @@ public class ExtractVariableTest extends AbstractSelectionTest {
 
 		fJProject1.setOptions(options);
 		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
-		this.setIgnoredCommands(Arrays.asList("Extract to method"));
+		this.setIgnoredCommands("Extract to method");
 	}
 
 	@Test


### PR DESCRIPTION
@fbricon  The original organize imports delegate commands is not deleted yet since it is used by other client and provide organize in folders/workspaces functionalities. 

Fixes #845