### PR TITLE
Add commands to add/remove/list the project's source path

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -60,6 +60,15 @@
             <command
                   id="java.project.resolveSourceAttachment">
             </command>
+            <command
+                  id="java.project.addToSourcePath">
+            </command>
+            <command
+                  id="java.project.removeFromSourcePath">
+            </command>
+            <command
+                  id="java.project.listSourcePaths">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -45,6 +46,14 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return SourceAttachmentCommand.resolveSourceAttachment(arguments, monitor);
 				case "java.project.updateSourceAttachment":
 					return SourceAttachmentCommand.updateSourceAttachment(arguments, monitor);
+				case "java.project.addToSourcePath":
+					String sourceFolder = (String) arguments.get(0);
+					return BuildPathCommand.addToSourcePath(sourceFolder);
+				case "java.project.removeFromSourcePath":
+					String sourceFolder1 = (String) arguments.get(0);
+					return BuildPathCommand.removeFromSourcePath(sourceFolder1);
+				case "java.project.listSourcePaths":
+					return BuildPathCommand.listSourcePaths();
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/BuildPathCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/BuildPathCommand.java
@@ -1,0 +1,249 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.Messages;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+
+public class BuildPathCommand {
+	public static final String UNSUPPORTED_ON_MAVEN = "Unsupported operation. Please use pom.xml file to manage the source directories of maven project.";
+	public static final String UNSUPPORTED_ON_GRADLE = "Unsupported operation. Please use build.gradle file to manage the source directories of gradle project.";
+
+	public static Result addToSourcePath(String sourceFolderUri) {
+		IPath sourceFolderPath = ResourceUtils.filePathFromURI(sourceFolderUri);
+		IProject targetProject = findBelongedProject(sourceFolderPath);
+		if (targetProject != null && !ProjectUtils.isGeneralJavaProject(targetProject)) {
+			String message = ProjectUtils.isGradleProject(targetProject) ? UNSUPPORTED_ON_GRADLE : UNSUPPORTED_ON_MAVEN;
+			return new Result(false, message);
+		}
+
+		IPath projectLocation = null;
+		IContainer projectRootResource = null;
+		IPath[] exclusionPath = new IPath[0];
+		if (targetProject == null) {
+			try {
+				IPath workspaceRoot = ProjectUtils.findBelongedWorkspaceRoot(sourceFolderPath);
+				if (workspaceRoot == null) {
+					return new Result(false, Messages.format("The folder ''{0}'' doesn''t belong to any workspace.", getWorkspacePath(sourceFolderPath).toOSString()));
+				}
+
+				targetProject = ProjectUtils.createInvisibleProjectIfNotExist(workspaceRoot);
+				final IFolder workspaceLink = targetProject.getFolder(ProjectUtils.WORKSPACE_LINK);
+				projectLocation = workspaceRoot;
+				projectRootResource = workspaceLink;
+				List<IProject> subProjects = ProjectUtils.getVisibleProjects(workspaceRoot);
+				exclusionPath = subProjects.stream().map(project -> {
+					IPath relativePath = project.getLocation().makeRelativeTo(workspaceRoot);
+					return workspaceLink.getFolder(relativePath).getFullPath();
+				}).toArray(IPath[]::new);
+			} catch (OperationCanceledException | CoreException e) {
+				JavaLanguageServerPlugin.logException("Failed to create the invisible project.", e);
+				return new Result(false, "Failed to add the folder to the workspace invisible project's source path. Reason: " + e.getMessage());
+			}
+		} else {
+			projectLocation = targetProject.getLocation();
+			projectRootResource = targetProject;
+		}
+
+		IPath relativeSourcePath = sourceFolderPath.makeRelativeTo(projectLocation);
+		IPath sourcePath = relativeSourcePath.isEmpty() ? projectRootResource.getFullPath() : projectRootResource.getFolder(relativeSourcePath).getFullPath();
+		IJavaProject javaProject = JavaCore.create(targetProject);
+		try {
+			if (ProjectUtils.addSourcePath(sourcePath, exclusionPath, javaProject)) {
+				return new Result(true, Messages.format("Successfully added ''{0}'' to the project {1}''s source path.", new String[] { getWorkspacePath(sourceFolderPath).toOSString(), targetProject.getName() }));
+			} else {
+				return new Result(true, Messages.format("No need to add it to source path again, because the folder ''{0}'' is already in the project {1}''s source path.",
+						new String[] { getWorkspacePath(sourceFolderPath).toOSString(), targetProject.getName() }));
+			}
+		} catch (CoreException e) {
+			return new Result(false, e.getMessage());
+		}
+
+	}
+
+	public static Result removeFromSourcePath(String sourceFolderUri) {
+		IPath sourceFolderPath = ResourceUtils.filePathFromURI(sourceFolderUri);
+		IProject targetProject = findBelongedProject(sourceFolderPath);
+		if (targetProject != null && !ProjectUtils.isGeneralJavaProject(targetProject)) {
+			String message = ProjectUtils.isGradleProject(targetProject) ? UNSUPPORTED_ON_GRADLE : UNSUPPORTED_ON_MAVEN;
+			return new Result(false, message);
+		}
+
+		IPath projectLocation = null;
+		IContainer projectRootResource = null;
+		if (targetProject == null) {
+			IPath workspaceRoot = ProjectUtils.findBelongedWorkspaceRoot(sourceFolderPath);
+			if (workspaceRoot == null) {
+				return new Result(false, Messages.format("The folder ''{0}'' doesn''t belong to any workspace.", getWorkspacePath(sourceFolderPath).toOSString()));
+			}
+
+			String invisibleProjectName = ProjectUtils.getWorkspaceInvisibleProjectName(workspaceRoot);
+			targetProject = ResourcesPlugin.getWorkspace().getRoot().getProject(invisibleProjectName);
+			if (!targetProject.exists()) {
+				return new Result(true, Messages.format("No need to remove it from source path, because the folder ''{0}'' isn''t on any project''s source path.", getWorkspacePath(sourceFolderPath).toOSString()));
+			}
+
+			projectLocation = workspaceRoot;
+			projectRootResource = targetProject.getFolder(ProjectUtils.WORKSPACE_LINK);
+		} else {
+			projectLocation = targetProject.getLocation();
+			projectRootResource = targetProject;
+		}
+
+		IPath relativeSourcePath = sourceFolderPath.makeRelativeTo(projectLocation);
+		IPath sourcePath = relativeSourcePath.isEmpty() ? projectRootResource.getFullPath() : projectRootResource.getFolder(relativeSourcePath).getFullPath();
+		IJavaProject javaProject = JavaCore.create(targetProject);
+		try {
+			if (ProjectUtils.removeSourcePath(sourcePath, javaProject)) {
+				return new Result(true, Messages.format("Successfully removed ''{0}'' from the project {1}''s source path.", new String[] { getWorkspacePath(sourceFolderPath).toOSString(), targetProject.getName() }));
+			} else {
+				return new Result(true, Messages.format("No need to remove it from source path, because the folder ''{0}'' isn''t on any project''s source path.", getWorkspacePath(sourceFolderPath).toOSString()));
+			}
+		} catch (CoreException e) {
+			return new Result(false, e.getMessage());
+		}
+	}
+
+	public static Result listSourcePaths() {
+		List<SourcePath> sourcePathList = new ArrayList<>();
+		IProject[] projects = ProjectUtils.getAllProjects();
+		for (IProject project : projects) {
+			if (!ProjectsManager.DEFAULT_PROJECT_NAME.equals(project.getName()) && ProjectUtils.isJavaProject(project)) {
+				try {
+					IPath[] paths = ProjectUtils.listSourcePaths(JavaCore.create(project));
+					for (IPath path : paths) {
+						IPath entryPath = path;
+						String projectName = project.getName();
+						String projectType = "General";
+						if (ProjectUtils.isMavenProject(project)) {
+							projectType = "Maven";
+						}
+
+						if (ProjectUtils.isGradleProject(project)) {
+							projectType = "Gradle";
+						}
+
+						IContainer projectRoot = project;
+						if (!ProjectUtils.isVisibleProject(project)) {
+							projectType = "Workspace";
+							IFolder workspaceLinkFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK);
+							if (!workspaceLinkFolder.isLinked()) {
+								continue;
+							}
+
+							projectRoot = workspaceLinkFolder;
+						}
+
+						IPath relativePath = entryPath.makeRelativeTo(projectRoot.getFullPath());
+						IPath location = projectRoot.getRawLocation().append(relativePath);
+						IPath displayPath = getWorkspacePath(location);
+						sourcePathList.add(new SourcePath(location != null ? location.toOSString() : "", displayPath != null ? displayPath.toOSString() : entryPath.toOSString(), projectName, projectType));
+					}
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.logException("Failed to resolve the existing source paths in current workspace.", e);
+					return new ListCommandResult(false, e.getMessage());
+				}
+			}
+		}
+
+		return new ListCommandResult(true, null, sourcePathList.toArray(new SourcePath[0]));
+	}
+
+	private static IProject findBelongedProject(IPath sourceFolder) {
+		List<IProject> projects = Stream.of(ProjectUtils.getAllProjects()).filter(ProjectUtils::isJavaProject).sorted(new Comparator<IProject>() {
+			@Override
+			public int compare(IProject p1, IProject p2) {
+				return p2.getLocation().toOSString().length() - p1.getLocation().toOSString().length();
+			}
+		}).collect(Collectors.toList());
+
+		for (IProject project : projects) {
+			if (project.getLocation().isPrefixOf(sourceFolder)) {
+				return project;
+			}
+		}
+
+		return null;
+	}
+
+	private static IPath getWorkspacePath(IPath path) {
+		PreferenceManager manager = JavaLanguageServerPlugin.getPreferencesManager();
+		Collection<IPath> rootPaths = manager.getPreferences().getRootPaths();
+		if (rootPaths != null) {
+			for (IPath rootPath : rootPaths) {
+				if (rootPath.isPrefixOf(path)) {
+					return path.makeRelativeTo(rootPath.append(".."));
+				}
+			}
+		}
+
+		return path;
+	}
+
+	public static class Result {
+		public boolean status;
+		public String message;
+
+		Result(boolean status, String message) {
+			this.status = status;
+			this.message = message;
+		}
+	}
+
+	public static class ListCommandResult extends Result {
+		public SourcePath[] data;
+
+		ListCommandResult(boolean status, String message) {
+			super(status, message);
+			data = new SourcePath[0];
+		}
+
+		ListCommandResult(boolean status, String message, SourcePath[] data) {
+			super(status, message);
+			this.data = data;
+		}
+	}
+
+	public static class SourcePath {
+		public String path;
+		public String displayPath;
+		public String projectName;
+		public String projectType;
+
+		SourcePath(String path, String displayPath, String projectName, String projectType) {
+			this.path = path;
+			this.displayPath = displayPath;
+			this.projectName = projectName;
+			this.projectType = projectType;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -13,6 +13,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -127,14 +128,18 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 		// Check if it is a Java ...
 		if (JavaCore.isJavaLikeFileName(file.getName())) {
 			ICompilationUnit cu = (ICompilationUnit) JavaCore.create(file);
-			//ignoring working copies, they're handled in the DocumentLifecycleHandler
-			if (!cu.isWorkingCopy()) {
-				IMarker[] javaMarkers = resource.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_ONE);
-				IMarker[] taskMarkers = resource.findMarkers(IJavaModelMarker.TASK_MARKER, false, IResource.DEPTH_ONE);
-				markers = Arrays.copyOf(javaMarkers, javaMarkers.length + taskMarkers.length);
-				System.arraycopy(taskMarkers, 0, markers, javaMarkers.length, taskMarkers.length);
-				document = JsonRpcHelpers.toDocument(cu.getBuffer());
+			// Clear the diagnostics for the resource not on the classpath
+			if (cu.getJavaProject() == null || !cu.getJavaProject().isOnClasspath(cu)) {
+				String uri = JDTUtils.getFileURI(resource);
+				this.connection.publishDiagnostics(new PublishDiagnosticsParams(ResourceUtils.toClientUri(uri), Collections.emptyList()));
+				return false;
 			}
+
+			IMarker[] javaMarkers = resource.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_ONE);
+			IMarker[] taskMarkers = resource.findMarkers(IJavaModelMarker.TASK_MARKER, false, IResource.DEPTH_ONE);
+			markers = Arrays.copyOf(javaMarkers, javaMarkers.length + taskMarkers.length);
+			System.arraycopy(taskMarkers, 0, markers, javaMarkers.length, taskMarkers.length);
+			document = JsonRpcHelpers.toDocument(cu.getBuffer());
 		} // or a build file
 		else if (projectsManager.isBuildFile(file)) {
 			//all errors on that build file should be relevant

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/BuildPathCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/BuildPathCommandTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand.ListCommandResult;
+import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand.Result;
+import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand.SourcePath;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.junit.Test;
+
+public class BuildPathCommandTest extends AbstractProjectsManagerBasedTest {
+
+	@Test
+	public void testBuildPathOperationInWorkspaceProject() throws IOException {
+		String path = "singlefile/lesson1";
+		File file = copyFiles(path, true);
+		IPath workspaceRoot = Path.fromOSString(file.getAbsolutePath());
+		PreferenceManager manager = JavaLanguageServerPlugin.getPreferencesManager();
+		manager.getPreferences().setRootPaths(Arrays.asList(workspaceRoot));
+
+		IPath srcPath = workspaceRoot.append("src");
+		Result addSrcResult = BuildPathCommand.addToSourcePath(srcPath.toFile().toURI().toString());
+		assertTrue(addSrcResult.status);
+		String invisibleProjectName = ProjectUtils.getWorkspaceInvisibleProjectName(workspaceRoot);
+		IProject invisibleProject = ResourcesPlugin.getWorkspace().getRoot().getProject(invisibleProjectName);
+		assertTrue(invisibleProject.exists());
+		assertTrue(ProjectUtils.isJavaProject(invisibleProject));
+
+		IPath mainJavaPath = workspaceRoot.append("src/main/java");
+		Result addMainJavaResult = BuildPathCommand.addToSourcePath(mainJavaPath.toFile().toURI().toString());
+		assertFalse(addMainJavaResult.status);
+
+		IPath samplesPath = workspaceRoot.append("samples");
+		Result addSamplesResult = BuildPathCommand.addToSourcePath(samplesPath.toFile().toURI().toString());
+		assertTrue(addSamplesResult.status);
+
+		ListCommandResult listResult = (ListCommandResult) BuildPathCommand.listSourcePaths();
+		assertTrue(listResult.status);
+		SourcePath[] sourcePaths = listResult.data;
+		assertNotNull(sourcePaths);
+		assertEquals(sourcePaths.length, 2);
+		assertEquals(sourcePaths[0].displayPath, new Path("lesson1").append("src").toOSString());
+		assertEquals(sourcePaths[1].displayPath, new Path("lesson1").append("samples").toOSString());
+	}
+
+	@Test
+	public void testBuildPathOperationInEclipseProject() throws Exception {
+		importProjects("eclipse/hello");
+		IProject project = WorkspaceHelper.getProject("hello");
+		PreferenceManager manager = JavaLanguageServerPlugin.getPreferencesManager();
+		manager.getPreferences().setRootPaths(Arrays.asList(project.getLocation()));
+
+		ListCommandResult listResult = (ListCommandResult) BuildPathCommand.listSourcePaths();
+		assertTrue(listResult.status);
+		SourcePath[] sourcePaths = listResult.data;
+		assertNotNull(sourcePaths);
+		assertEquals(sourcePaths.length, 2);
+		assertEquals(sourcePaths[0].displayPath, new Path("hello").append("src").toOSString());
+		assertEquals(sourcePaths[1].displayPath, new Path("hello").append("test").toOSString());
+
+		IResource srcJavaResource = project.findMember("src/java");
+		Result addSrcJavaResult = BuildPathCommand.addToSourcePath(JDTUtils.getFileURI(srcJavaResource));
+		assertFalse(addSrcJavaResult.status);
+
+		IJavaProject javaProject = JavaCore.create(project);
+		IResource nopackageResource = project.findMember("nopackage");
+		Result addNopackageResult = BuildPathCommand.addToSourcePath(JDTUtils.getFileURI(nopackageResource));
+		assertTrue(addNopackageResult.status);
+		assertEquals(ProjectUtils.listSourcePaths(javaProject).length, 3);
+
+		Result removeNopackageResult = BuildPathCommand.removeFromSourcePath(JDTUtils.getFileURI(nopackageResource));
+		assertTrue(removeNopackageResult.status);
+		assertEquals(ProjectUtils.listSourcePaths(javaProject).length, 2);
+	}
+
+	@Test
+	public void testBuildPathOperationInMavenProject() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		PreferenceManager manager = JavaLanguageServerPlugin.getPreferencesManager();
+		manager.getPreferences().setRootPaths(Arrays.asList(project.getLocation()));
+
+		ListCommandResult listResult = (ListCommandResult) BuildPathCommand.listSourcePaths();
+		assertTrue(listResult.status);
+		SourcePath[] sourcePaths = listResult.data;
+		assertNotNull(sourcePaths);
+		assertEquals(sourcePaths.length, 5);
+
+		IResource srcResource = project.findMember("src");
+		Result addSrcResult = BuildPathCommand.addToSourcePath(JDTUtils.getFileURI(srcResource));
+		assertFalse(addSrcResult.status);
+		assertEquals(addSrcResult.message, BuildPathCommand.UNSUPPORTED_ON_MAVEN);
+
+		IResource mainJavaResource = project.findMember("src/main/java");
+		Result addMainJavaResult = BuildPathCommand.removeFromSourcePath(JDTUtils.getFileURI(mainJavaResource));
+		assertFalse(addMainJavaResult.status);
+		assertEquals(addMainJavaResult.message, BuildPathCommand.UNSUPPORTED_ON_MAVEN);
+	}
+
+	@Test
+	public void testBuildPathOperationInGradleProject() throws Exception {
+		importProjects("gradle/simple-gradle");
+		IProject project = WorkspaceHelper.getProject("simple-gradle");
+		PreferenceManager manager = JavaLanguageServerPlugin.getPreferencesManager();
+		manager.getPreferences().setRootPaths(Arrays.asList(project.getLocation()));
+
+		ListCommandResult listResult = (ListCommandResult) BuildPathCommand.listSourcePaths();
+		assertTrue(listResult.status);
+		SourcePath[] sourcePaths = listResult.data;
+		assertNotNull(sourcePaths);
+		assertEquals(sourcePaths.length, 2);
+
+		IResource srcResource = project.findMember("src");
+		Result addSrcResult = BuildPathCommand.addToSourcePath(JDTUtils.getFileURI(srcResource));
+		assertFalse(addSrcResult.status);
+		assertEquals(addSrcResult.message, BuildPathCommand.UNSUPPORTED_ON_GRADLE);
+
+		IResource mainJavaResource = project.findMember("src/main/java");
+		Result addMainJavaResult = BuildPathCommand.removeFromSourcePath(JDTUtils.getFileURI(mainJavaResource));
+		assertFalse(addMainJavaResult.status);
+		assertEquals(addMainJavaResult.message, BuildPathCommand.UNSUPPORTED_ON_GRADLE);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

This is for feature https://github.com/redhat-developer/vscode-java/issues/619, marking a folder as source root is helpful for the standalone java file support and simple eclipse project. Currently i disabled the operation on maven/gradle project because the user could manage this kind of source path through pom.xml and build.gradle.

Below is the basic feature:
- Add Folder to Java Source Path (context menu)
- Remove Folder from Java Source Path (context menu)
- List all Java source paths (command palette)

See the peer PR https://github.com/redhat-developer/vscode-java/pull/724