### PR TITLE
For jdk classes, ensure the project name is not the default ones sinc…

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
@@ -13,15 +13,19 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -50,18 +54,41 @@ public class NavigateToDefinitionHandler {
 			if (element == null) {
 				return null;
 			}
+
+
 			ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
 			IClassFile cf = (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
 			if (compilationUnit != null || (cf != null && cf.getSourceRange() != null)  ) {
-				return JDTUtils.toLocation(element);
+				return fixLocation(element, JDTUtils.toLocation(element), unit.getJavaProject());
 			}
 			if (element instanceof IMember && ((IMember) element).getClassFile() != null) {
-				return JDTUtils.toLocation(((IMember) element).getClassFile());
+				return fixLocation(element, JDTUtils.toLocation(((IMember) element).getClassFile()), unit.getJavaProject());
 			}
 		} catch (JavaModelException e) {
 			JavaLanguageServerPlugin.logException("Problem computing definition for" +  unit.getElementName(), e);
 		}
 		return null;
+	}
+
+	private static Location fixLocation(IJavaElement element, Location location, IJavaProject javaProject) {
+		if (!javaProject.equals(element.getJavaProject()) && element.getJavaProject().getProject().getName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
+			// see issue at: https://github.com/eclipse/eclipse.jdt.ls/issues/842 and https://bugs.eclipse.org/bugs/show_bug.cgi?id=541573
+			// for jdk classes, jdt will reuse the java model by altering project to share the model between projects
+			// so that sometimes the project for `element` is default project and the project is different from the project for `unit`
+			// this fix is to replace the project name with non-default ones since default project should be transparent to users.
+			if (location.getUri().contains(ProjectsManager.DEFAULT_PROJECT_NAME)) {
+				String patched = StringUtils.replaceOnce(location.getUri(), ProjectsManager.DEFAULT_PROJECT_NAME, javaProject.getProject().getName());
+				try {
+					IClassFile cf = (IClassFile) JavaCore.create(JDTUtils.toURI(patched).getQuery());
+					if (cf != null && cf.exists()) {
+						location.setUri(patched);
+					}
+				} catch (Exception ex) {
+
+				}
+			}
+		}
+		return location;
 	}
 
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -38,12 +38,14 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 
 	private NavigateToDefinitionHandler handler;
 	private IProject project;
+	private IProject defaultProject;
 
 	@Before
 	public void setUp() throws Exception {
 		handler = new NavigateToDefinitionHandler(preferenceManager);
 		importProjects("maven/salut");
 		project = WorkspaceHelper.getProject("salut");
+		defaultProject = linkFilesToDefaultProject("singlefile/Single.java").getProject();
 	}
 
 	@Test
@@ -70,6 +72,16 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 	@Test
 	public void testDisassembledSource() throws Exception {
 		testClass("javax.tools.Tool", 6, 44);
+	}
+
+	@Test
+	public void testJdkClasses() throws Exception {
+		// because for test, we are using fake rt.jar(rtstubs.jar), the issue of issue https://bugs.eclipse.org/bugs/show_bug.cgi?id=541573 will
+		// never occur in test cases
+		String uri = ClassFileUtil.getURI(defaultProject, "Single");
+		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
+		handler.definition(new TextDocumentPositionParams(identifier, new Position(1, 31)), monitor);
+		testClass("org.apache.commons.lang3.stringutils", 6579, 20);
 	}
 
 	private void testClass(String className, int line, int column) throws JavaModelException {


### PR DESCRIPTION
…e default project should be transparent to users

Signed-off-by: andxu <andxu@microsoft.com>