### PR TITLE
Fix bug: fail to import project containing file tree with a circular link

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetector.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetector.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.FileSystemLoopException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -151,6 +152,16 @@ public class BasicFileDetector {
 					return includeNested?CONTINUE:SKIP_SUBTREE;
 				}
 				return CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+				Objects.requireNonNull(file);
+    			if (exc instanceof FileSystemLoopException) {
+        			return CONTINUE;
+    			} else {
+        			throw exc;
+    			}
 			}
 
 		};

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
@@ -103,24 +103,28 @@ public class BasicFileDetectorTest {
 	}
 
 	@Test
-	public void testScanCircleSymbolicLinks() throws Exception {
-		File targetLinkFolder = new File(Paths.get("projects/buildfiles").toString(), "circle_symbolic_link-"
+	public void testScanCircularSymbolicLinks() throws Exception {
+		File originDirectory = new File("projects/buildfiles");
+		File tempDirectory = new File(System.getProperty("java.io.tmpdir"), "/circular_symbolic_link_ws-"+
 			+ new Random().nextInt(10000));
+		File circularSymbolicLink = new File(tempDirectory, "circular_symbolic_link");
 		try {
-			Path targetLinkPath = Paths.get(targetLinkFolder.getPath());
-			Files.createSymbolicLink(targetLinkPath, Paths.get("projects/buildfiles").toAbsolutePath());
-			BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles"), "buildfile");
+			FileUtils.copyDirectory(originDirectory, tempDirectory);
+			Path targetLinkPath = Paths.get(circularSymbolicLink.getPath());
+			Files.createSymbolicLink(targetLinkPath, Paths.get(tempDirectory.getAbsolutePath()));
+			BasicFileDetector detector = new BasicFileDetector(Paths.get(tempDirectory.getPath()), "buildfile");
 
 			Collection<Path> dirs = detector.scan(null);
 			assertEquals("Found " + dirs, 6, dirs.size());
 
-			List<String> missingDirs = separatorsToSystem(list("projects/buildfiles", "projects/buildfiles/parent/1_0/0_2_0",
-					"projects/buildfiles/parent/1_0/0_2_1", "projects/buildfiles/parent/1_1",
-					"projects/buildfiles/parent/1_1/1_2_0", "projects/buildfiles/parent/1_1/1_2_1"));
-			dirs.stream().map(Path::toString).forEach(missingDirs::remove);
+			List<String> missingDirs = separatorsToSystem(list("", "parent/1_0/0_2_0",
+					"parent/1_0/0_2_1", "parent/1_1",
+					"parent/1_1/1_2_0", "parent/1_1/1_2_1"));
+			dirs.stream().map(dir -> tempDirectory.toPath().relativize(dir).toString()).forEach(missingDirs::remove);
 			assertEquals("Directories were not detected" + missingDirs, 0, missingDirs.size());
 		} finally {
-			targetLinkFolder.delete();
+			circularSymbolicLink.delete();
+			FileUtils.deleteDirectory(tempDirectory);
 		}
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
@@ -102,6 +102,28 @@ public class BasicFileDetectorTest {
 		}
 	}
 
+	@Test
+	public void testScanCircleSymbolicLinks() throws Exception {
+		File targetLinkFolder = new File(Paths.get("projects/buildfiles").toString(), "circle_symbolic_link-"
+			+ new Random().nextInt(10000));
+		try {
+			Path targetLinkPath = Paths.get(targetLinkFolder.getPath());
+			Files.createSymbolicLink(targetLinkPath, Paths.get("projects/buildfiles").toAbsolutePath());
+			BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles"), "buildfile");
+
+			Collection<Path> dirs = detector.scan(null);
+			assertEquals("Found " + dirs, 6, dirs.size());
+
+			List<String> missingDirs = separatorsToSystem(list("projects/buildfiles", "projects/buildfiles/parent/1_0/0_2_0",
+					"projects/buildfiles/parent/1_0/0_2_1", "projects/buildfiles/parent/1_1",
+					"projects/buildfiles/parent/1_1/1_2_0", "projects/buildfiles/parent/1_1/1_2_1"));
+			dirs.stream().map(Path::toString).forEach(missingDirs::remove);
+			assertEquals("Directories were not detected" + missingDirs, 0, missingDirs.size());
+		} finally {
+			targetLinkFolder.delete();
+		}
+	}
+
 	@SafeVarargs
 	private final <E> List<E> list(E... elements) {
 		return new ArrayList<>(Arrays.asList(elements));


### PR DESCRIPTION
Signed-off-by: Poytr1 <pengcheng.xu@elastic.co>

This PR is related to https://github.com/eclipse/eclipse.jdt.ls/pull/836

When I was trying to import a project which has a circular link to parent dir or current dir, the whole project failed to be initialized with an Exception threw by language server. Here is the log snippet:
```
!ENTRY org.eclipse.jdt.ls.core 4 0 2018-12-26 19:11:45.517
!MESSAGE Initialization failed 
!STACK 1
Java Model Exception: Core Exception [code 0] Failed to scan /Volumes/android/WORKING_DIRECTORY
....
!MESSAGE Failed to scan /Volumes/android/WORKING_DIRECTORY
!STACK 0
java.nio.file.FileSystemLoopException: /Volumes/android/WORKING_DIRECTORY/external/autotest/venv/autotest_lib
	at java.base/java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:294)
	at java.base/java.nio.file.FileTreeWalker.next(FileTreeWalker.java:373)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2760)
	at org.eclipse.jdt.ls.core.internal.managers.BasicFileDetector.scanDir(BasicFileDetector.java:157)
	at org.eclipse.jdt.ls.core.internal.managers.BasicFileDetector.scan(BasicFileDetector.java:131)
	at org.eclipse.jdt.ls.core.internal.managers.EclipseProjectImporter.applies(EclipseProjectImporter.java:41)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.getImporter(ProjectsManager.java:331)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.importProjects(ProjectsManager.java:134)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.access$1(ProjectsManager.java:130)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager$2.run(ProjectsManager.java:124)
	at org.eclipse.jdt.internal.core.BatchOperation.executeOperation(BatchOperation.java:41)
	at org.eclipse.jdt.internal.core.JavaModelOperation.run(JavaModelOperation.java:736)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2295)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2322)
	at org.eclipse.jdt.core.JavaCore.run(JavaCore.java:5810)
	at org.eclipse.jdt.core.JavaCore.run(JavaCore.java:5767)
	at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.initializeProjects(ProjectsManager.java:116)
	at org.eclipse.jdt.ls.core.internal.handlers.InitHandler$1.runInWorkspace(InitHandler.java:242)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:42)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```
and the `autotest_lib` is refer to its parent dir:
![image](https://user-images.githubusercontent.com/20534718/50470600-1cb3fb80-09ec-11e9-85e8-13123a4da20e.png)

The is due to that eclipse.jdt.ls has specified the FOLLOW_LINKS option and the file tree has a circular link to a parent directory, the looping directory is reported in the visitFileFailed method with the FileSystemLoopException.
(according to the java.nio doc https://docs.oracle.com/javase/tutorial/essential/io/walk.html)

So I make the change and the walker of file tree will not terminate while meeting the `FileSystemLoopException`, it skips and continue to walk the rest of tree. 