### PR TITLE
Unblock smartness for initialization.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -222,6 +222,9 @@ public class ProjectsManager implements ISaveParticipant {
 	private void deleteInvalidProjects(Collection<IPath> rootPaths, IProgressMonitor monitor) {
 		List<String> workspaceProjects = rootPaths.stream().map((IPath rootPath) -> ProjectUtils.getWorkspaceInvisibleProjectName(rootPath)).collect(Collectors.toList());
 		for (IProject project : getWorkspaceRoot().getProjects()) {
+			if (project.equals(this.getDefaultProject())) {
+				continue;
+			}
 			if (project.exists() && (ResourceUtils.isContainedIn(project.getLocation(), rootPaths) || ProjectUtils.isGradleProject(project)) || workspaceProjects.contains(project.getName())) {
 				try {
 					project.getDescription();


### PR DESCRIPTION
https://github.com/eclipse/eclipse.jdt.ls/issues/860

@fbricon @mickaelistria @tsmaeder 

Tried a PR for unblock smart during initialization. Still, the sub sequence request will likely be blocked by the update maven configuration & auto build though parallel build is enabled in my test. Any suggestion to make JDT.LS and update maven configuration (auto build) parallel? 
