### PR TITLE
GH-508: Support for Call Hierarchy

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -48,6 +48,7 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.corrections.proposals;x-internal:=true,
  org.eclipse.jdt.ls.core.internal.handlers;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.highlighting;x-friends:="org.eclipse.jdt.ls.tests",
+ org.eclipse.jdt.ls.core.internal.hover;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.javadoc;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.lsp;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.managers;x-friends:="org.eclipse.jdt.ls.tests",

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -62,6 +62,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.util.tracker.ServiceTracker;
 
+import com.google.common.base.Throwables;
+
 public class JavaLanguageServerPlugin extends Plugin {
 
 	private static final String JDT_UI_PLUGIN = "org.eclipse.jdt.ui";
@@ -346,6 +348,16 @@ public class JavaLanguageServerPlugin extends Plugin {
 	public static void logInfo(String message) {
 		if (context != null) {
 			log(new Status(IStatus.INFO, context.getBundle().getSymbolicName(), message));
+		}
+	}
+
+	public static void logException(Throwable ex) {
+		if (context != null) {
+			String message = ex.getMessage();
+			if (message == null) {
+				message = Throwables.getStackTraceAsString(ex);
+			}
+			logException(message, ex);
 		}
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
@@ -34,10 +34,8 @@ import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.StringMatcher;
-import org.eclipse.jface.preference.IPreferenceStore;
 
 public class CallHierarchy {
     private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
@@ -58,15 +56,7 @@ public class CallHierarchy {
     }
 
     public boolean isSearchUsingImplementorsEnabled() {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
-        return settings.getBoolean(PREF_USE_IMPLEMENTORS);
-    }
-
-    public void setSearchUsingImplementorsEnabled(boolean enabled) {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
-        settings.setValue(PREF_USE_IMPLEMENTORS, enabled);
+		return true;
     }
 
     public Collection<IJavaElement> getImplementingMethods(IMethod method) {
@@ -196,33 +186,6 @@ public class CallHierarchy {
         return false;
     }
 
-    public boolean isFilterEnabled() {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        return settings.getBoolean(PREF_USE_FILTERS);
-    }
-
-    public void setFilterEnabled(boolean filterEnabled) {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        settings.setValue(PREF_USE_FILTERS, filterEnabled);
-    }
-
-    /**
-     * Returns the current filters as a string.
-     * @return returns the filters
-     */
-    public String getFilters() {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
-        return settings.getString(PREF_FILTERS_LIST);
-    }
-
-    public void setFilters(String filters) {
-        fFilters = null;
-
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        settings.setValue(PREF_FILTERS_LIST, filters);
-    }
-
     /**
      * Returns filters for packages which should not be included in the search results.
      *
@@ -230,21 +193,7 @@ public class CallHierarchy {
      */
     private StringMatcher[] getIgnoreFilters() {
         if (fFilters == null) {
-            String filterString = null;
-
-            if (isFilterEnabled()) {
-                filterString = getFilters();
-
-                if (filterString == null) {
-                    filterString = DEFAULT_IGNORE_FILTERS;
-                }
-            }
-
-            if (filterString != null) {
-                fFilters = parseList(filterString);
-            } else {
-                fFilters = null;
-            }
+			fFilters = parseList(DEFAULT_IGNORE_FILTERS);
         }
 
         return fFilters;
@@ -290,7 +239,7 @@ public class CallHierarchy {
 				return (CompilationUnit) parser.createAST(null);
 	    	}
         } catch (JavaModelException e) {
-            JavaPlugin.log(e);
+			JavaLanguageServerPlugin.logException(e);
         }
         return null;
     }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
@@ -42,7 +42,7 @@ public class CallHierarchy {
     private static final String PREF_USE_FILTERS = "PREF_USE_FILTERS"; //$NON-NLS-1$
     private static final String PREF_FILTERS_LIST = "PREF_FILTERS_LIST"; //$NON-NLS-1$
 
-    private static final String DEFAULT_IGNORE_FILTERS = "java.*,javax.*"; //$NON-NLS-1$
+	private static final String DEFAULT_IGNORE_FILTERS = ""; //$NON-NLS-1$
     private static CallHierarchy fgInstance;
     private IJavaSearchScope fSearchScope;
     private StringMatcher[] fFilters;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
@@ -35,6 +35,8 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.StringMatcher;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 public class CallHierarchy {
@@ -124,7 +126,7 @@ public class CallHierarchy {
 						addRoot(member, roots, callers);
 					}
 				} catch (JavaModelException e) {
-					JavaPlugin.log(e);
+					JavaLanguageServerPlugin.log(e);
 				}
 			} else {
 				addRoot(member, roots, callers);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchy.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *   Stephan Herrmann (stephan@cs.tu-berlin.de):
+ *          - bug 75800: [call hierarchy] should allow searches for fields
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.StringTokenizer;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IModuleDescription;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jface.preference.IPreferenceStore;
+
+public class CallHierarchy {
+    private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
+    private static final String PREF_USE_FILTERS = "PREF_USE_FILTERS"; //$NON-NLS-1$
+    private static final String PREF_FILTERS_LIST = "PREF_FILTERS_LIST"; //$NON-NLS-1$
+
+    private static final String DEFAULT_IGNORE_FILTERS = "java.*,javax.*"; //$NON-NLS-1$
+    private static CallHierarchy fgInstance;
+    private IJavaSearchScope fSearchScope;
+    private StringMatcher[] fFilters;
+
+    public static CallHierarchy getDefault() {
+        if (fgInstance == null) {
+            fgInstance = new CallHierarchy();
+        }
+
+        return fgInstance;
+    }
+
+    public boolean isSearchUsingImplementorsEnabled() {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+
+        return settings.getBoolean(PREF_USE_IMPLEMENTORS);
+    }
+
+    public void setSearchUsingImplementorsEnabled(boolean enabled) {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+
+        settings.setValue(PREF_USE_IMPLEMENTORS, enabled);
+    }
+
+    public Collection<IJavaElement> getImplementingMethods(IMethod method) {
+        if (isSearchUsingImplementorsEnabled()) {
+            IJavaElement[] result = Implementors.getInstance().searchForImplementors(new IJavaElement[] {
+                        method
+                    }, new NullProgressMonitor());
+
+            if ((result != null) && (result.length > 0)) {
+                return Arrays.asList(result);
+            }
+        }
+
+        return new ArrayList<>(0);
+    }
+
+    public Collection<IJavaElement> getInterfaceMethods(IMethod method) {
+        if (isSearchUsingImplementorsEnabled()) {
+            IJavaElement[] result = Implementors.getInstance().searchForInterfaces(new IJavaElement[] {
+                        method
+                    }, new NullProgressMonitor());
+
+            if ((result != null) && (result.length > 0)) {
+                return Arrays.asList(result);
+            }
+        }
+
+        return new ArrayList<>(0);
+    }
+
+    public MethodWrapper[] getCallerRoots(IMember[] members) {
+    	return getRoots(members, true);
+    }
+
+    public MethodWrapper[] getCalleeRoots(IMember[] members) {
+    	return getRoots(members, false);
+    }
+
+	private MethodWrapper[] getRoots(IMember[] members, boolean callers) {
+		ArrayList<MethodWrapper> roots= new ArrayList<>();
+    	for (int i= 0; i < members.length; i++) {
+			IMember member= members[i];
+			if (member instanceof IType) {
+				IType type= (IType) member;
+				try {
+					if (! type.isAnonymous()) {
+						IMethod[] constructors= JavaElementUtil.getAllConstructors(type);
+						if (constructors.length == 0) {
+							addRoot(member, roots, callers); // IType is a stand-in for the non-existing default constructor
+						} else {
+							for (int j= 0; j < constructors.length; j++) {
+								IMethod constructor= constructors[j];
+								addRoot(constructor, roots, callers);
+							}
+						}
+					} else {
+						addRoot(member, roots, callers);
+					}
+				} catch (JavaModelException e) {
+					JavaPlugin.log(e);
+				}
+			} else {
+				addRoot(member, roots, callers);
+			}
+		}
+    	return roots.toArray(new MethodWrapper[roots.size()]);
+	}
+
+	private void addRoot(IMember member, ArrayList<MethodWrapper> roots, boolean callers) {
+		MethodCall methodCall= new MethodCall(member);
+		MethodWrapper root;
+		if (callers) {
+			root= new CallerMethodWrapper(null, methodCall);
+		} else {
+			root= new CalleeMethodWrapper(null, methodCall);
+		}
+		roots.add(root);
+	}
+
+    public static CallLocation getCallLocation(Object element) {
+        CallLocation callLocation = null;
+
+        if (element instanceof MethodWrapper) {
+            MethodWrapper methodWrapper = (MethodWrapper) element;
+            MethodCall methodCall = methodWrapper.getMethodCall();
+
+            if (methodCall != null) {
+                callLocation = methodCall.getFirstCallLocation();
+            }
+        } else if (element instanceof CallLocation) {
+            callLocation = (CallLocation) element;
+        }
+
+        return callLocation;
+    }
+
+    public IJavaSearchScope getSearchScope() {
+        if (fSearchScope == null) {
+            fSearchScope= SearchEngine.createWorkspaceScope();
+        }
+
+        return fSearchScope;
+    }
+
+    public void setSearchScope(IJavaSearchScope searchScope) {
+        this.fSearchScope = searchScope;
+    }
+
+	/**
+	 * Checks whether the fully qualified name is ignored by the set filters.
+	 *
+	 * @param fullyQualifiedName the fully qualified name
+	 *
+	 * @return <code>true</code> if the fully qualified name is ignored
+	 */
+    public boolean isIgnored(String fullyQualifiedName) {
+        if ((getIgnoreFilters() != null) && (getIgnoreFilters().length > 0)) {
+            for (int i = 0; i < getIgnoreFilters().length; i++) {
+                String fullyQualifiedName1 = fullyQualifiedName;
+
+                if (getIgnoreFilters()[i].match(fullyQualifiedName1)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public boolean isFilterEnabled() {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        return settings.getBoolean(PREF_USE_FILTERS);
+    }
+
+    public void setFilterEnabled(boolean filterEnabled) {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        settings.setValue(PREF_USE_FILTERS, filterEnabled);
+    }
+
+    /**
+     * Returns the current filters as a string.
+     * @return returns the filters
+     */
+    public String getFilters() {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+
+        return settings.getString(PREF_FILTERS_LIST);
+    }
+
+    public void setFilters(String filters) {
+        fFilters = null;
+
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        settings.setValue(PREF_FILTERS_LIST, filters);
+    }
+
+    /**
+     * Returns filters for packages which should not be included in the search results.
+     *
+     * @return StringMatcher[]
+     */
+    private StringMatcher[] getIgnoreFilters() {
+        if (fFilters == null) {
+            String filterString = null;
+
+            if (isFilterEnabled()) {
+                filterString = getFilters();
+
+                if (filterString == null) {
+                    filterString = DEFAULT_IGNORE_FILTERS;
+                }
+            }
+
+            if (filterString != null) {
+                fFilters = parseList(filterString);
+            } else {
+                fFilters = null;
+            }
+        }
+
+        return fFilters;
+    }
+
+    public static boolean arePossibleInputElements(List<?> elements) {
+		if (elements.size() < 1) {
+			return false;
+		}
+		for (Iterator<?> iter= elements.iterator(); iter.hasNext();) {
+			if (! isPossibleInputElement(iter.next())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Parses the comma separated string into an array of {@link StringMatcher} objects.
+	 *
+	 * @param listString the string to parse
+	 * @return an array of {@link StringMatcher} objects
+	 */
+    private static StringMatcher[] parseList(String listString) {
+        List<StringMatcher> list = new ArrayList<>(10);
+        StringTokenizer tokenizer = new StringTokenizer(listString, ","); //$NON-NLS-1$
+
+        while (tokenizer.hasMoreTokens()) {
+            String textFilter = tokenizer.nextToken().trim();
+            list.add(new StringMatcher(textFilter, false, false));
+        }
+
+        return list.toArray(new StringMatcher[list.size()]);
+    }
+
+    static CompilationUnit getCompilationUnitNode(IMember member, boolean resolveBindings) {
+    	ITypeRoot typeRoot= member.getTypeRoot();
+        try {
+	    	if (typeRoot.exists() && typeRoot.getBuffer() != null) {
+				ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+				parser.setSource(typeRoot);
+				parser.setResolveBindings(resolveBindings);
+				return (CompilationUnit) parser.createAST(null);
+	    	}
+        } catch (JavaModelException e) {
+            JavaPlugin.log(e);
+        }
+        return null;
+    }
+
+    public static boolean isPossibleInputElement(Object element){
+    	if (! (element instanceof IMember)) {
+			return false;
+		}
+
+		if (element instanceof IModuleDescription) {
+			return false;
+		}
+
+    	if (element instanceof IType) {
+			IType type= (IType) element;
+			try {
+				return type.isClass() || type.isEnum();
+			} catch (JavaModelException e) {
+				return false;
+			}
+		}
+
+    	return true;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyMessages.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2005 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import org.eclipse.osgi.util.NLS;
+
+public final class CallHierarchyMessages extends NLS {
+
+	private static final String BUNDLE_NAME= "org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyMessages";//$NON-NLS-1$
+
+	private CallHierarchyMessages() {
+		// Do not instantiate
+	}
+
+	public static String CallerMethodWrapper_taskname;
+	public static String CalleeMethodWrapper_taskname;
+
+	static {
+		NLS.initializeMessages(BUNDLE_NAME, CallHierarchyMessages.class);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyMessages.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2000, 2005 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+# 			(report 36180: Callers/Callees view)
+###############################################################################
+CallerMethodWrapper_taskname=Finding callers...
+CalleeMethodWrapper_taskname=Finding callees...

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallHierarchyVisitor.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+public abstract class CallHierarchyVisitor {
+    public void preVisit(MethodWrapper methodWrapper) {
+    }
+
+    public void postVisit(MethodWrapper methodWrapper) {
+    }
+
+    public boolean visit(MethodWrapper methodWrapper) {
+        return true;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallLocation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallLocation.java
@@ -17,7 +17,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IOpenable;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 
@@ -93,7 +93,7 @@ public class CallLocation implements IAdaptable {
             try {
                 fLineNumber= document.getLineOfOffset(fStart) + 1;
             } catch (BadLocationException e) {
-                JavaPlugin.log(e);
+				JavaLanguageServerPlugin.logException(e);
             }
         }
     }
@@ -112,7 +112,7 @@ public class CallLocation implements IAdaptable {
                 buffer = openable.getBuffer();
             }
         } catch (JavaModelException e) {
-            JavaPlugin.log(e);
+			JavaLanguageServerPlugin.log(e);
         }
         return buffer;
     }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallLocation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallLocation.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+
+public class CallLocation implements IAdaptable {
+    public static final int UNKNOWN_LINE_NUMBER= -1;
+    private IMember fMember;
+    private IMember fCalledMember;
+    private int fStart;
+    private int fEnd;
+
+    private String fCallText;
+    private int fLineNumber;
+
+    public CallLocation(IMember member, IMember calledMember, int start, int end, int lineNumber) {
+        this.fMember = member;
+        this.fCalledMember = calledMember;
+        this.fStart = start;
+        this.fEnd = end;
+        this.fLineNumber= lineNumber;
+    }
+
+    /**
+     * @return IMethod
+     */
+    public IMember getCalledMember() {
+        return fCalledMember;
+    }
+
+    /**
+     *
+     */
+    public int getEnd() {
+        return fEnd;
+    }
+
+    public IMember getMember() {
+        return fMember;
+    }
+
+    /**
+     *
+     */
+    public int getStart() {
+        return fStart;
+    }
+
+    public int getLineNumber() {
+    	initCallTextAndLineNumber();
+        return fLineNumber;
+    }
+
+    public String getCallText() {
+    	initCallTextAndLineNumber();
+        return fCallText;
+    }
+
+    private void initCallTextAndLineNumber() {
+    	if (fCallText != null) {
+			return;
+		}
+
+        IBuffer buffer= getBufferForMember();
+        if (buffer == null || buffer.getLength() < fEnd) { //binary, without source attachment || buffer contents out of sync (bug 121900)
+        	fCallText= ""; //$NON-NLS-1$
+        	fLineNumber= UNKNOWN_LINE_NUMBER;
+        	return;
+        }
+
+        fCallText= buffer.getText(fStart, (fEnd - fStart));
+
+        if (fLineNumber == UNKNOWN_LINE_NUMBER) {
+            Document document= new Document(buffer.getContents());
+            try {
+                fLineNumber= document.getLineOfOffset(fStart) + 1;
+            } catch (BadLocationException e) {
+                JavaPlugin.log(e);
+            }
+        }
+    }
+
+    /**
+     * Returns the IBuffer for the IMember represented by this CallLocation.
+     *
+     * @return IBuffer for the IMember or null if the member doesn't have a buffer (for
+     *          example if it is a binary file without source attachment).
+     */
+    private IBuffer getBufferForMember() {
+        IBuffer buffer = null;
+        try {
+            IOpenable openable = fMember.getOpenable();
+            if (openable != null && fMember.exists()) {
+                buffer = openable.getBuffer();
+            }
+        } catch (JavaModelException e) {
+            JavaPlugin.log(e);
+        }
+        return buffer;
+    }
+
+    @Override
+	public String toString() {
+        return getCallText();
+    }
+
+    @Override
+	@SuppressWarnings("unchecked")
+	public <T> T getAdapter(Class<T> adapter) {
+        if (IJavaElement.class.isAssignableFrom(adapter)) {
+            return (T) getMember();
+        }
+
+        return null;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallSearchResultCollector.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallSearchResultCollector.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IType;
+
+class CallSearchResultCollector {
+    /**
+     * A map from handle identifier ({@link String}) to {@link MethodCall}.
+     */
+    private Map<String, MethodCall> fCalledMembers;
+
+    public CallSearchResultCollector() {
+        this.fCalledMembers = createCalledMethodsData();
+    }
+
+    /**
+     * @return a map from handle identifier ({@link String}) to {@link MethodCall}
+     */
+    public Map<String, MethodCall> getCallers() {
+        return fCalledMembers;
+    }
+
+    protected void addMember(IMember member, IMember calledMember, int start, int end) {
+        addMember(member, calledMember, start, end, CallLocation.UNKNOWN_LINE_NUMBER);
+    }
+
+    protected void addMember(IMember member, IMember calledMember, int start, int end, int lineNumber) {
+        if ((member != null) && (calledMember != null)) {
+            if (!isIgnored(calledMember)) {
+                MethodCall methodCall = fCalledMembers.get(calledMember.getHandleIdentifier());
+
+                if (methodCall == null) {
+                    methodCall = new MethodCall(calledMember);
+                    fCalledMembers.put(calledMember.getHandleIdentifier(), methodCall);
+                }
+
+                methodCall.addCallLocation(new CallLocation(member, calledMember, start,
+                        end, lineNumber));
+            }
+        }
+    }
+
+    protected Map<String, MethodCall> createCalledMethodsData() {
+        return new HashMap<>();
+    }
+
+    /**
+     * Method isIgnored.
+     * @param enclosingElement
+     * @return boolean
+     */
+    private boolean isIgnored(IMember enclosingElement) {
+        String fullyQualifiedName = getTypeOfElement(enclosingElement)
+                                        .getFullyQualifiedName();
+
+        return CallHierarchy.getDefault().isIgnored(fullyQualifiedName);
+    }
+
+    private IType getTypeOfElement(IMember element) {
+        if (element.getElementType() == IJavaElement.TYPE) {
+            return (IType) element;
+        }
+
+        return element.getDeclaringType();
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
@@ -41,7 +41,7 @@ import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.HierarchicalASTVisitor;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 class CalleeAnalyzerVisitor extends HierarchicalASTVisitor {
     private final CallSearchResultCollector fSearchResults;
@@ -62,7 +62,7 @@ class CalleeAnalyzerVisitor extends HierarchicalASTVisitor {
             this.fMethodStartPosition = sourceRange.getOffset();
             this.fMethodEndPosition = fMethodStartPosition + sourceRange.getLength();
         } catch (JavaModelException jme) {
-            JavaPlugin.log(jme);
+			JavaLanguageServerPlugin.log(jme);
         }
     }
 
@@ -268,7 +268,7 @@ class CalleeAnalyzerVisitor extends HierarchicalASTVisitor {
 				fSearchResults.addMember(fMember, referencedMember, position, position + node.getLength(), number < 1 ? 1 : number);
             }
         } catch (JavaModelException jme) {
-            JavaPlugin.log(jme);
+			JavaLanguageServerPlugin.log(jme);
         }
     }
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
@@ -1,0 +1,351 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ConstructorInvocation;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.dom.HierarchicalASTVisitor;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+class CalleeAnalyzerVisitor extends HierarchicalASTVisitor {
+    private final CallSearchResultCollector fSearchResults;
+    private final IMember fMember;
+    private final CompilationUnit fCompilationUnit;
+    private final IProgressMonitor fProgressMonitor;
+    private int fMethodEndPosition;
+    private int fMethodStartPosition;
+
+    CalleeAnalyzerVisitor(IMember member, CompilationUnit compilationUnit, IProgressMonitor progressMonitor) {
+        fSearchResults = new CallSearchResultCollector();
+        this.fMember = member;
+        this.fCompilationUnit= compilationUnit;
+        this.fProgressMonitor = progressMonitor;
+
+        try {
+            ISourceRange sourceRange = member.getSourceRange();
+            this.fMethodStartPosition = sourceRange.getOffset();
+            this.fMethodEndPosition = fMethodStartPosition + sourceRange.getLength();
+        } catch (JavaModelException jme) {
+            JavaPlugin.log(jme);
+        }
+    }
+
+    /**
+     * @return a map from handle identifier ({@link String}) to {@link MethodCall}
+     */
+    public Map<String, MethodCall> getCallees() {
+        return fSearchResults.getCallers();
+    }
+
+    @Override
+	public boolean visit(ClassInstanceCreation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveConstructorBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * Find all constructor invocations (<code>this(...)</code>) from the called method.
+     * Since we only traverse into the AST on the wanted method declaration, this method
+     * should not hit on more constructor invocations than those in the wanted method.
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.ConstructorInvocation)
+     */
+    @Override
+	public boolean visit(ConstructorInvocation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveConstructorBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * @see HierarchicalASTVisitor#visit(org.eclipse.jdt.core.dom.AbstractTypeDeclaration)
+     */
+    @Override
+	public boolean visit(AbstractTypeDeclaration node) {
+    	progressMonitorWorked(1);
+    	if (!isFurtherTraversalNecessary(node)) {
+    		return false;
+    	}
+
+    	if (isNodeWithinMethod(node)) {
+    		List<BodyDeclaration> bodyDeclarations= node.bodyDeclarations();
+    		for (Iterator<BodyDeclaration> iter= bodyDeclarations.iterator(); iter.hasNext(); ) {
+				BodyDeclaration bodyDeclaration= iter.next();
+				if (bodyDeclaration instanceof MethodDeclaration) {
+					MethodDeclaration child= (MethodDeclaration) bodyDeclaration;
+					if (child.isConstructor()) {
+						addMethodCall(child.resolveBinding(), child.getName());
+					}
+				}
+			}
+    		return false;
+    	}
+
+    	return true;
+    }
+
+    /**
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.MethodDeclaration)
+     */
+    @Override
+	public boolean visit(MethodDeclaration node) {
+        progressMonitorWorked(1);
+        return isFurtherTraversalNecessary(node);
+    }
+
+    /**
+     * Find all method invocations from the called method. Since we only traverse into
+     * the AST on the wanted method declaration, this method should not hit on more
+     * method invocations than those in the wanted method.
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.MethodInvocation)
+     */
+    @Override
+	public boolean visit(MethodInvocation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveMethodBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * Find invocations of the supertype's constructor from the called method
+     * (=constructor). Since we only traverse into the AST on the wanted method
+     * declaration, this method should not hit on more method invocations than those in
+     * the wanted method.
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.SuperConstructorInvocation)
+     */
+    @Override
+	public boolean visit(SuperConstructorInvocation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveConstructorBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * Find all method invocations from the called method. Since we only traverse into
+     * the AST on the wanted method declaration, this method should not hit on more
+     * method invocations than those in the wanted method.
+     * @param node node to visit
+	 * @return whether children should be visited
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.MethodInvocation)
+     */
+    @Override
+	public boolean visit(SuperMethodInvocation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveMethodBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * When an anonymous class declaration is reached, the traversal should not go further since it's not
+     * supposed to consider calls inside the anonymous inner class as calls from the outer method.
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.AnonymousClassDeclaration)
+     */
+    @Override
+	public boolean visit(AnonymousClassDeclaration node) {
+        return isNodeEnclosingMethod(node);
+    }
+
+
+    /**
+	 * Adds the specified method binding to the search results.
+	 *
+	 * @param calledMethodBinding the called method binding
+	 * @param node the AST node
+	 */
+    protected void addMethodCall(IMethodBinding calledMethodBinding, ASTNode node) {
+        try {
+            if (calledMethodBinding != null) {
+                fProgressMonitor.worked(1);
+
+                ITypeBinding calledTypeBinding = calledMethodBinding.getDeclaringClass();
+                IType calledType = null;
+
+                if (!calledTypeBinding.isAnonymous()) {
+                    calledType = (IType) calledTypeBinding.getJavaElement();
+                } else {
+                    if (!"java.lang.Object".equals(calledTypeBinding.getSuperclass().getQualifiedName())) { //$NON-NLS-1$
+                        calledType= (IType) calledTypeBinding.getSuperclass().getJavaElement();
+                    } else {
+                        calledType = (IType) calledTypeBinding.getInterfaces()[0].getJavaElement();
+                    }
+                }
+
+                IMethod calledMethod = findIncludingSupertypes(calledMethodBinding,
+                        calledType, fProgressMonitor);
+
+                IMember referencedMember= null;
+                if (calledMethod == null) {
+                    if (calledMethodBinding.isConstructor() && calledMethodBinding.getParameterTypes().length == 0) {
+                        referencedMember= calledType;
+                    }
+                } else {
+                    if (calledType.isInterface()) {
+                        calledMethod = findImplementingMethods(calledMethod);
+                    }
+
+                    if (!isIgnoredBySearchScope(calledMethod)) {
+                        referencedMember= calledMethod;
+                    }
+                }
+                final int position= node.getStartPosition();
+				final int number= fCompilationUnit.getLineNumber(position);
+				fSearchResults.addMember(fMember, referencedMember, position, position + node.getLength(), number < 1 ? 1 : number);
+            }
+        } catch (JavaModelException jme) {
+            JavaPlugin.log(jme);
+        }
+    }
+
+    private static IMethod findIncludingSupertypes(IMethodBinding method, IType type, IProgressMonitor pm) throws JavaModelException {
+		IMethod inThisType= Bindings.findMethod(method, type);
+		if (inThisType != null) {
+			return inThisType;
+		}
+		IType[] superTypes= JavaModelUtil.getAllSuperTypes(type, pm);
+		for (int i= 0; i < superTypes.length; i++) {
+			IMethod m= Bindings.findMethod(method, superTypes[i]);
+			if (m != null) {
+				return m;
+			}
+		}
+		return null;
+	}
+
+    private boolean isIgnoredBySearchScope(IMethod enclosingElement) {
+        if (enclosingElement != null) {
+            return !getSearchScope().encloses(enclosingElement);
+        } else {
+            return false;
+        }
+    }
+
+    private IJavaSearchScope getSearchScope() {
+        return CallHierarchy.getDefault().getSearchScope();
+    }
+
+    private boolean isNodeWithinMethod(ASTNode node) {
+        int nodeStartPosition = node.getStartPosition();
+        int nodeEndPosition = nodeStartPosition + node.getLength();
+
+        if (nodeStartPosition < fMethodStartPosition) {
+            return false;
+        }
+
+        if (nodeEndPosition > fMethodEndPosition) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isNodeEnclosingMethod(ASTNode node) {
+        int nodeStartPosition = node.getStartPosition();
+        int nodeEndPosition = nodeStartPosition + node.getLength();
+
+        if (nodeStartPosition < fMethodStartPosition && nodeEndPosition > fMethodEndPosition) {
+            // Is the method completely enclosed by the node?
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isFurtherTraversalNecessary(ASTNode node) {
+        return isNodeWithinMethod(node) || isNodeEnclosingMethod(node);
+    }
+
+    private IMethod findImplementingMethods(IMethod calledMethod) {
+        Collection<IJavaElement> implementingMethods = CallHierarchy.getDefault()
+                                                        .getImplementingMethods(calledMethod);
+
+        if ((implementingMethods.size() == 0) || (implementingMethods.size() > 1)) {
+            return calledMethod;
+        } else {
+            return (IMethod) implementingMethods.iterator().next();
+        }
+    }
+
+    private void progressMonitorWorked(int work) {
+        if (fProgressMonitor != null) {
+            fProgressMonitor.worked(work);
+            if (fProgressMonitor.isCanceled()) {
+                throw new OperationCanceledException();
+            }
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeMethodWrapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CalleeMethodWrapper.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+class CalleeMethodWrapper extends MethodWrapper {
+    private Comparator<MethodWrapper> fMethodWrapperComparator = new MethodWrapperComparator();
+
+    private static class MethodWrapperComparator implements Comparator<MethodWrapper> {
+        @Override
+		public int compare(MethodWrapper m1, MethodWrapper m2) {
+            CallLocation callLocation1 = m1.getMethodCall().getFirstCallLocation();
+            CallLocation callLocation2 = m2.getMethodCall().getFirstCallLocation();
+
+            if ((callLocation1 != null) && (callLocation2 != null)) {
+                if (callLocation1.getStart() == callLocation2.getStart()) {
+                    return callLocation1.getEnd() - callLocation2.getEnd();
+                }
+
+                return callLocation1.getStart() - callLocation2.getStart();
+            }
+
+            return 0;
+        }
+    }
+
+    public CalleeMethodWrapper(MethodWrapper parent, MethodCall methodCall) {
+        super(parent, methodCall);
+    }
+
+	/* Returns the calls sorted after the call location
+	 * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#getCalls()
+     */
+    @Override
+	public MethodWrapper[] getCalls(IProgressMonitor progressMonitor) {
+        MethodWrapper[] result = super.getCalls(progressMonitor);
+        Arrays.sort(result, fMethodWrapperComparator);
+
+        return result;
+    }
+
+    @Override
+	protected String getTaskName() {
+        return CallHierarchyMessages.CalleeMethodWrapper_taskname;
+    }
+
+	/*
+	 * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#createMethodWrapper(org.eclipse.jdt.internal.corext.callhierarchy.MethodCall)
+     */
+    @Override
+	protected MethodWrapper createMethodWrapper(MethodCall methodCall) {
+        return new CalleeMethodWrapper(this, methodCall);
+    }
+
+    /*
+     * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#canHaveChildren()
+     */
+    @Override
+	public boolean canHaveChildren() {
+    	return true;
+    }
+
+	/**
+     * Find callees called from the current method.
+	 * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#findChildren(org.eclipse.core.runtime.IProgressMonitor)
+     */
+    @Override
+	protected Map<String, MethodCall> findChildren(IProgressMonitor progressMonitor) {
+    	IMember member= getMember();
+		if (member.exists()) {
+			CompilationUnit cu= CallHierarchy.getCompilationUnitNode(member, true);
+		    if (progressMonitor != null) {
+		        progressMonitor.worked(5);
+		    }
+
+			if (cu != null) {
+				CalleeAnalyzerVisitor visitor = new CalleeAnalyzerVisitor(member, cu, progressMonitor);
+
+				cu.accept(visitor);
+				return visitor.getCallees();
+			}
+		}
+        return new HashMap<>(0);
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallerMethodWrapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallerMethodWrapper.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *   Stephan Herrmann (stephan@cs.tu-berlin.de):
+ *          - bug 206949: [call hierarchy] filter field accesses (only write or only read)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IInitializer;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.internal.corext.util.JdtFlags;
+import org.eclipse.jdt.internal.corext.util.SearchUtils;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class CallerMethodWrapper extends MethodWrapper {
+	/**
+	 * Value of the expand with constructors mode.
+	 *
+	 * @since 3.5
+	 */
+	private boolean fExpandWithConstructors;
+
+	/**
+	 * Tells whether the expand with constructors mode has been set.
+	 *
+	 * @see #setExpandWithConstructors(boolean)
+	 * @since 3.5
+	 */
+	private boolean fIsExpandWithConstructorsSet;
+
+	public CallerMethodWrapper(MethodWrapper parent, MethodCall methodCall) {
+		super(parent, methodCall);
+	}
+
+    protected IJavaSearchScope getSearchScope() {
+        return CallHierarchy.getDefault().getSearchScope();
+    }
+
+    @Override
+	protected String getTaskName() {
+        return CallHierarchyMessages.CallerMethodWrapper_taskname;
+    }
+
+	@Override
+	public MethodWrapper createMethodWrapper(MethodCall methodCall) {
+        return new CallerMethodWrapper(this, methodCall);
+    }
+
+	/*
+	 * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#canHaveChildren()
+	 */
+	@Override
+	public boolean canHaveChildren() {
+		IMember member= getMember();
+		if (member instanceof IField) {
+			if (getLevel() == 1) {
+				return true;
+			}
+			int mode= getFieldSearchMode();
+			return mode == IJavaSearchConstants.REFERENCES || mode == IJavaSearchConstants.READ_ACCESSES;
+		}
+		return member instanceof IMethod || member instanceof IType;
+	}
+
+	/**
+	 * @return The result of the search for children
+	 * @see org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper#findChildren(org.eclipse.core.runtime.IProgressMonitor)
+	 */
+	@Override
+	protected Map<String, MethodCall> findChildren(IProgressMonitor progressMonitor) {
+		try {
+
+			IProgressMonitor monitor= new SubProgressMonitor(progressMonitor, 95, SubProgressMonitor.SUPPRESS_SUBTASK_LABEL);
+
+			checkCanceled(progressMonitor);
+
+			IMember member= getMember();
+			SearchPattern pattern= null;
+			IType type= null;
+			if (member instanceof IType) {
+				type= (IType) member;
+			} else if (member instanceof IInitializer && ! Flags.isStatic(member.getFlags())) {
+				type= (IType) member.getParent();
+			}
+			if (type != null) {
+				if (type.isAnonymous()) {
+					// search engine does not find reference to anonymous, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=207774
+					CallSearchResultCollector resultCollector= new CallSearchResultCollector();
+					IJavaElement parent= type.getParent();
+					if (parent instanceof IMember) {
+						IMember parentMember= (IMember) parent;
+						ISourceRange nameRange= type.getNameRange();
+						int start= nameRange != null ? nameRange.getOffset() : -1;
+						int len= nameRange != null ? nameRange.getLength() : 0;
+						resultCollector.addMember(type, parentMember, start, start + len);
+						return resultCollector.getCallers();
+					}
+				} else if (type.getParent() instanceof IMethod) {
+					// good enough for local types (does not find super(..) references in subtype constructors):
+					pattern= SearchPattern.createPattern(type,
+							IJavaSearchConstants.CLASS_INSTANCE_CREATION_TYPE_REFERENCE,
+							SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+				} else {
+					pattern= SearchPattern.createPattern(type.getFullyQualifiedName('.'),
+							IJavaSearchConstants.CONSTRUCTOR,
+							IJavaSearchConstants.REFERENCES,
+							SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+				}
+			}
+			if (pattern == null) {
+				int limitTo= IJavaSearchConstants.REFERENCES;
+				if (member.getElementType() == IJavaElement.FIELD) {
+					limitTo= getFieldSearchMode();
+				}
+				pattern= SearchPattern.createPattern(member, limitTo, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			}
+			if (pattern == null) { // e.g. for initializers
+				return new HashMap<>(0);
+			}
+
+			SearchEngine searchEngine= new SearchEngine();
+			MethodReferencesSearchRequestor searchRequestor= new MethodReferencesSearchRequestor();
+			IJavaSearchScope defaultSearchScope= getSearchScope();
+			boolean isWorkspaceScope= SearchEngine.createWorkspaceScope().equals(defaultSearchScope);
+			IJavaSearchScope searchScope= isWorkspaceScope ? getAccurateSearchScope(defaultSearchScope, member) : defaultSearchScope;
+			searchEngine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() }, searchScope, searchRequestor,
+					monitor);
+			return searchRequestor.getCallers();
+
+		} catch (CoreException e) {
+			JavaPlugin.log(e);
+			return new HashMap<>(0);
+		}
+	}
+
+	private IJavaSearchScope getAccurateSearchScope(IJavaSearchScope defaultSearchScope, IMember member) throws JavaModelException {
+		if (! JdtFlags.isPrivate(member)) {
+			return defaultSearchScope;
+		}
+
+		if (member.getCompilationUnit() != null) {
+			return SearchEngine.createJavaSearchScope(new IJavaElement[] { member.getCompilationUnit() });
+		} else if (member.getClassFile() != null) {
+			// member could be called from an inner class-> search
+			// package fragment (see also bug 109053):
+			return SearchEngine.createJavaSearchScope(new IJavaElement[] { member.getAncestor(IJavaElement.PACKAGE_FRAGMENT) });
+		} else {
+			return defaultSearchScope;
+		}
+	}
+
+	/**
+	 * Returns the value of expand with constructors mode.
+	 *
+	 * @return <code>true</code> if in expand with constructors mode, <code>false</code> otherwise or if not yet set
+	 * @see #isExpandWithConstructorsSet()
+	 *
+	 * @since 3.5
+	 */
+	public boolean getExpandWithConstructors() {
+		return fIsExpandWithConstructorsSet && fExpandWithConstructors;
+	}
+
+	/**
+	 * Sets the expand with constructors mode.
+	 *
+	 * @param value <code>true</code> if in expand with constructors mode, <code>false</code>
+	 *            otherwise
+	 * @since 3.5
+	 */
+	public void setExpandWithConstructors(boolean value) {
+		fExpandWithConstructors= value;
+		fIsExpandWithConstructorsSet= true;
+
+	}
+
+	/**
+	 * Tells whether the expand with constructors mode has been set.
+	 *
+	 * @return <code>true</code> if expand with constructors mode has been set explicitly, <code>false</code> otherwise
+	 * @see #setExpandWithConstructors(boolean)
+	 * @since 3.5
+	 */
+	public boolean isExpandWithConstructorsSet() {
+		return fIsExpandWithConstructorsSet;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallerMethodWrapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/CallerMethodWrapper.java
@@ -35,7 +35,7 @@ import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 public class CallerMethodWrapper extends MethodWrapper {
 	/**
@@ -153,7 +153,7 @@ public class CallerMethodWrapper extends MethodWrapper {
 			return searchRequestor.getCallers();
 
 		} catch (CoreException e) {
-			JavaPlugin.log(e);
+			JavaLanguageServerPlugin.log(e);
 			return new HashMap<>(0);
 		}
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/IImplementorFinder.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/IImplementorFinder.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ * 			(report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.Collection;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IType;
+
+public interface IImplementorFinder {
+
+    /**
+     * Find implementors of the specified IType instance.
+     */
+    public abstract Collection<IType> findImplementingTypes(IType type,
+        IProgressMonitor progressMonitor);
+
+    /**
+     * Find interfaces which are implemented by the specified IType instance.
+     */
+    public abstract Collection<IType> findInterfaces(IType type, IProgressMonitor progressMonitor);
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/Implementors.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/Implementors.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 /**
  * The main plugin class to be used in the desktop.
@@ -73,7 +73,7 @@ public class Implementors {
                     }
                 }
             } catch (JavaModelException e) {
-                JavaPlugin.log(e);
+				JavaLanguageServerPlugin.log(e);
             }
         }
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/Implementors.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/Implementors.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ * 			(report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+/**
+ * The main plugin class to be used in the desktop.
+ */
+public class Implementors {
+    private static IImplementorFinder[] IMPLEMENTOR_FINDERS= new IImplementorFinder[] { new JavaImplementorFinder() };
+    private static Implementors fgInstance;
+
+    /**
+     * Returns the shared instance.
+     */
+    public static Implementors getInstance() {
+        if (fgInstance == null) {
+            fgInstance = new Implementors();
+        }
+
+        return fgInstance;
+    }
+
+    /**
+     * Searches for implementors of the specified Java elements. Currently, only IMethod
+     * instances are searched for. Also, only the first element of the elements
+     * parameter is taken into consideration.
+     *
+     * @param elements
+     *
+     * @return An array of found implementing Java elements (currently only IMethod
+     *         instances)
+     */
+    public IJavaElement[] searchForImplementors(IJavaElement[] elements,
+        IProgressMonitor progressMonitor) {
+        if ((elements != null) && (elements.length > 0)) {
+            IJavaElement element = elements[0];
+
+            try {
+                if (element instanceof IMember) {
+                    IMember member = (IMember) element;
+                    IType type = member.getDeclaringType();
+
+                    if (type.isInterface()) {
+                        IType[] implementingTypes = findImplementingTypes(type,
+                                progressMonitor);
+
+                        if (member.getElementType() == IJavaElement.METHOD) {
+                            return findMethods((IMethod)member, implementingTypes, progressMonitor);
+                        } else {
+                            return implementingTypes;
+                        }
+                    }
+                }
+            } catch (JavaModelException e) {
+                JavaPlugin.log(e);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Searches for interfaces which are implemented by the declaring classes of the
+     * specified Java elements. Currently, only IMethod instances are searched for.
+     * Also, only the first element of the elements parameter is taken into
+     * consideration.
+     *
+     * @param elements
+     *
+     * @return An array of found interfaces implemented by the declaring classes of the
+     *         specified Java elements (currently only IMethod instances)
+     */
+    public IJavaElement[] searchForInterfaces(IJavaElement[] elements,
+        IProgressMonitor progressMonitor) {
+        if ((elements != null) && (elements.length > 0)) {
+            IJavaElement element = elements[0];
+
+            if (element instanceof IMember) {
+                IMember member = (IMember) element;
+                IType type = member.getDeclaringType();
+
+                IType[] implementingTypes = findInterfaces(type, progressMonitor);
+
+                if (!progressMonitor.isCanceled()) {
+                    if (member.getElementType() == IJavaElement.METHOD) {
+                        return findMethods((IMethod)member, implementingTypes, progressMonitor);
+                    } else {
+                        return implementingTypes;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private IImplementorFinder[] getImplementorFinders() {
+        return IMPLEMENTOR_FINDERS;
+    }
+
+    private IType[] findImplementingTypes(IType type, IProgressMonitor progressMonitor) {
+        Collection<IType> implementingTypes = new ArrayList<>();
+
+        IImplementorFinder[] finders = getImplementorFinders();
+
+        for (int i = 0; (i < finders.length) && !progressMonitor.isCanceled(); i++) {
+            Collection<IType> types = finders[i].findImplementingTypes(type,
+                    new SubProgressMonitor(progressMonitor, 10,
+                        SubProgressMonitor.SUPPRESS_SUBTASK_LABEL));
+
+            if (types != null) {
+                implementingTypes.addAll(types);
+            }
+        }
+
+        return implementingTypes.toArray(new IType[implementingTypes.size()]);
+    }
+
+    private IType[] findInterfaces(IType type, IProgressMonitor progressMonitor) {
+        Collection<IType> interfaces = new ArrayList<>();
+
+        IImplementorFinder[] finders = getImplementorFinders();
+
+        for (int i = 0; (i < finders.length) && !progressMonitor.isCanceled(); i++) {
+            Collection<IType> types = finders[i].findInterfaces(type,
+                    new SubProgressMonitor(progressMonitor, 10,
+                        SubProgressMonitor.SUPPRESS_SUBTASK_LABEL));
+
+            if (types != null) {
+                interfaces.addAll(types);
+            }
+        }
+
+        return interfaces.toArray(new IType[interfaces.size()]);
+    }
+
+    /**
+     * Finds IMethod instances on the specified IType instances with identical signatures
+     * as the specified IMethod parameter.
+     *
+     * @param method The method to find "equals" of.
+     * @param types The types in which the search is performed.
+     *
+     * @return An array of methods which match the method parameter.
+     */
+    private IJavaElement[] findMethods(IMethod method, IType[] types,
+        IProgressMonitor progressMonitor) {
+        Collection<IMethod> foundMethods = new ArrayList<>();
+
+        SubProgressMonitor subProgressMonitor = new SubProgressMonitor(progressMonitor,
+                10, SubProgressMonitor.SUPPRESS_SUBTASK_LABEL);
+        subProgressMonitor.beginTask("", types.length); //$NON-NLS-1$
+
+        try {
+            for (int i = 0; i < types.length; i++) {
+                IType type = types[i];
+                IMethod[] methods = type.findMethods(method);
+
+                if (methods != null) {
+                    for (int j = 0; j < methods.length; j++) {
+                        foundMethods.add(methods[j]);
+                    }
+                }
+
+                subProgressMonitor.worked(1);
+            }
+        } finally {
+            subProgressMonitor.done();
+        }
+
+        return foundMethods.toArray(new IJavaElement[foundMethods.size()]);
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/JavaImplementorFinder.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/JavaImplementorFinder.java
@@ -19,7 +19,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 public class JavaImplementorFinder implements IImplementorFinder {
 	@Override
@@ -34,7 +34,7 @@ public class JavaImplementorFinder implements IImplementorFinder {
 
             return result;
         } catch (JavaModelException e) {
-            JavaPlugin.log(e);
+			JavaLanguageServerPlugin.log(e);
         }
 
         return null;
@@ -52,7 +52,7 @@ public class JavaImplementorFinder implements IImplementorFinder {
 
             return result;
         } catch (JavaModelException e) {
-            JavaPlugin.log(e);
+			JavaLanguageServerPlugin.log(e);
         }
 
         return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/JavaImplementorFinder.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/JavaImplementorFinder.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ * 			(report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class JavaImplementorFinder implements IImplementorFinder {
+	@Override
+	public Collection<IType> findImplementingTypes(IType type, IProgressMonitor progressMonitor) {
+        ITypeHierarchy typeHierarchy;
+
+        try {
+            typeHierarchy = type.newTypeHierarchy(progressMonitor);
+
+            IType[] implementingTypes = typeHierarchy.getAllClasses();
+            HashSet<IType> result = new HashSet<>(Arrays.asList(implementingTypes));
+
+            return result;
+        } catch (JavaModelException e) {
+            JavaPlugin.log(e);
+        }
+
+        return null;
+    }
+
+    @Override
+	public Collection<IType> findInterfaces(IType type, IProgressMonitor progressMonitor) {
+        ITypeHierarchy typeHierarchy;
+
+        try {
+            typeHierarchy = type.newSupertypeHierarchy(progressMonitor);
+
+            IType[] interfaces = typeHierarchy.getAllSuperInterfaces(type);
+            HashSet<IType> result = new HashSet<>(Arrays.asList(interfaces));
+
+            return result;
+        } catch (JavaModelException e) {
+            JavaPlugin.log(e);
+        }
+
+        return null;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodCall.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodCall.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.core.IMember;
+
+public class MethodCall {
+    private IMember fMember;
+    private List<CallLocation> fCallLocations;
+
+    /**
+     * @param enclosingElement
+     */
+    public MethodCall(IMember enclosingElement) {
+        this.fMember = enclosingElement;
+    }
+
+    /**
+     *
+     */
+    public Collection<CallLocation> getCallLocations() {
+        return fCallLocations;
+    }
+
+    public CallLocation getFirstCallLocation() {
+        if ((fCallLocations != null) && !fCallLocations.isEmpty()) {
+            return fCallLocations.get(0);
+        } else {
+            return null;
+        }
+    }
+
+    public boolean hasCallLocations() {
+        return fCallLocations != null && fCallLocations.size() > 0;
+    }
+
+    /**
+     * @return Object
+     */
+    public String getKey() {
+        return getMember().getHandleIdentifier();
+    }
+
+    /**
+     *
+     */
+    public IMember getMember() {
+        return fMember;
+    }
+
+    /**
+     * @param location
+     */
+    public void addCallLocation(CallLocation location) {
+        if (fCallLocations == null) {
+            fCallLocations = new ArrayList<>();
+        }
+
+        fCallLocations.add(location);
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodReferencesSearchRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodReferencesSearchRequestor.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.Map;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchRequestor;
+
+class MethodReferencesSearchRequestor extends SearchRequestor {
+    private CallSearchResultCollector fSearchResults;
+    private boolean fRequireExactMatch = true;
+
+    MethodReferencesSearchRequestor() {
+        fSearchResults = new CallSearchResultCollector();
+    }
+
+    public Map<String, MethodCall> getCallers() {
+        return fSearchResults.getCallers();
+    }
+
+    @Override
+	public void acceptSearchMatch(SearchMatch match) {
+        if (fRequireExactMatch && (match.getAccuracy() != SearchMatch.A_ACCURATE)) {
+            return;
+        }
+
+        if (match.isInsideDocComment()) {
+            return;
+        }
+
+        if (match.getElement() != null && match.getElement() instanceof IMember) {
+            IMember member= (IMember) match.getElement();
+            switch (member.getElementType()) {
+                case IJavaElement.METHOD:
+                case IJavaElement.TYPE:
+                case IJavaElement.FIELD:
+                case IJavaElement.INITIALIZER:
+                    fSearchResults.addMember(member, member, match.getOffset(), match.getOffset()+match.getLength());
+                    break;
+            }
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodWrapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodWrapper.java
@@ -1,0 +1,372 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Jesper Kamstrup Linnet (eclipse@kamstrup-linnet.dk) - initial API and implementation
+ *          (report 36180: Callers/Callees view)
+ *   Stephan Herrmann (stephan@cs.tu-berlin.de):
+ *          - bug 206949: [call hierarchy] filter field accesses (only write or only read)
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.PlatformObject;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.internal.ui.callhierarchy.MethodWrapperWorkbenchAdapter;
+import org.eclipse.ui.model.IWorkbenchAdapter;
+
+/**
+ * This class represents the general parts of a method call (either to or from a
+ * method).
+ *
+ */
+public abstract class MethodWrapper extends PlatformObject {
+    private Map<String, MethodCall> fElements = null;
+
+    /*
+     * A cache of previously found methods. This cache should be searched
+     * before adding a "new" method object reference to the list of elements.
+     * This way previously found methods won't be searched again.
+     */
+    private Map<String, Map<String, MethodCall>> fMethodCache;
+    private final MethodCall fMethodCall;
+    private final MethodWrapper fParent;
+    private int fLevel;
+	/**
+	 * One of {@link IJavaSearchConstants#REFERENCES}, {@link IJavaSearchConstants#READ_ACCESSES},
+	 * or {@link IJavaSearchConstants#WRITE_ACCESSES}, or 0 if not set. Only used for root wrappers.
+	 */
+    private int fFieldSearchMode;
+
+    public MethodWrapper(MethodWrapper parent, MethodCall methodCall) {
+        Assert.isNotNull(methodCall);
+
+        if (parent == null) {
+            setMethodCache(new HashMap<String, Map<String, MethodCall>>());
+            fLevel = 1;
+        } else {
+            setMethodCache(parent.getMethodCache());
+            fLevel = parent.getLevel() + 1;
+        }
+
+        this.fMethodCall = methodCall;
+        this.fParent = parent;
+    }
+
+    @SuppressWarnings("unchecked")
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == IJavaElement.class) {
+	        return (T) getMember();
+	    } else if (adapter == IWorkbenchAdapter.class){
+	    	return (T) new MethodWrapperWorkbenchAdapter(this);
+	    } else {
+	    	return null;
+	    }
+	}
+
+    public MethodWrapper[] getCalls(IProgressMonitor progressMonitor) {
+        if (fElements == null) {
+            doFindChildren(progressMonitor);
+        }
+
+        MethodWrapper[] result = new MethodWrapper[fElements.size()];
+        int i = 0;
+
+        for (Iterator<String> iter = fElements.keySet().iterator(); iter.hasNext();) {
+            MethodCall methodCall = getMethodCallFromMap(fElements, iter.next());
+            result[i++] = createMethodWrapper(methodCall);
+        }
+
+        return result;
+    }
+
+    public int getLevel() {
+        return fLevel;
+    }
+
+    public IMember getMember() {
+        return getMethodCall().getMember();
+    }
+
+    public MethodCall getMethodCall() {
+        return fMethodCall;
+    }
+
+    public String getName() {
+        if (getMethodCall() != null) {
+            return getMethodCall().getMember().getElementName();
+        } else {
+            return ""; //$NON-NLS-1$
+        }
+    }
+
+    public MethodWrapper getParent() {
+        return fParent;
+    }
+
+    public int getFieldSearchMode() {
+    	if (fFieldSearchMode != 0) {
+			return fFieldSearchMode;
+		}
+    	MethodWrapper parent= getParent();
+    	while (parent != null) {
+			if (parent.fFieldSearchMode != 0) {
+				return parent.fFieldSearchMode;
+			} else {
+				parent= parent.getParent();
+			}
+		}
+    	return IJavaSearchConstants.REFERENCES;
+	}
+
+    public void setFieldSearchMode(int fieldSearchMode) {
+		fFieldSearchMode= fieldSearchMode;
+	}
+
+    @Override
+	public boolean equals(Object oth) {
+        if (this == oth) {
+            return true;
+        }
+
+        if (oth == null) {
+            return false;
+        }
+
+        if (oth instanceof MethodWrapperWorkbenchAdapter) {
+            //Note: A MethodWrapper is equal to a referring MethodWrapperWorkbenchAdapter and vice versa (bug 101677).
+        	oth= ((MethodWrapperWorkbenchAdapter) oth).getMethodWrapper();
+        }
+
+        if (oth.getClass() != getClass()) {
+            return false;
+        }
+
+        MethodWrapper other = (MethodWrapper) oth;
+
+        if (this.fParent == null) {
+            if (other.fParent != null) {
+                return false;
+            }
+        } else {
+            if (!this.fParent.equals(other.fParent)) {
+                return false;
+            }
+        }
+
+        if (this.getMethodCall() == null) {
+            if (other.getMethodCall() != null) {
+                return false;
+            }
+        } else {
+            if (!this.getMethodCall().equals(other.getMethodCall())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+	public int hashCode() {
+        final int PRIME = 1000003;
+        int result = 0;
+
+        if (fParent != null) {
+            result = (PRIME * result) + fParent.hashCode();
+        }
+
+        if (getMethodCall() != null) {
+            result = (PRIME * result) + getMethodCall().getMember().hashCode();
+        }
+
+        return result;
+    }
+
+    private void setMethodCache(Map<String, Map<String, MethodCall>> methodCache) {
+        fMethodCache = methodCache;
+    }
+
+    protected abstract String getTaskName();
+
+    private void addCallToCache(MethodCall methodCall) {
+        Map<String, MethodCall> cachedCalls = lookupMethod(this.getMethodCall());
+        cachedCalls.put(methodCall.getKey(), methodCall);
+    }
+
+	/**
+	 * Creates a method wrapper for the child of the receiver.
+	 *
+	 * @param methodCall the method call
+	 * @return the method wrapper
+	 */
+    protected abstract MethodWrapper createMethodWrapper(MethodCall methodCall);
+
+    private void doFindChildren(IProgressMonitor progressMonitor) {
+        Map<String, MethodCall> existingResults = lookupMethod(getMethodCall());
+
+        if (existingResults != null && !existingResults.isEmpty()) {
+            fElements = new HashMap<>();
+            fElements.putAll(existingResults);
+        } else {
+            initCalls();
+
+            if (progressMonitor != null) {
+                progressMonitor.beginTask(getTaskName(), 100);
+            }
+
+            try {
+                performSearch(progressMonitor);
+            } catch (OperationCanceledException e){
+            	fElements= null;
+            	throw e;
+            } finally {
+                if (progressMonitor != null) {
+                    progressMonitor.done();
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines if the method represents a recursion call (i.e. whether the
+     * method call is already in the cache.)
+     *
+     * @return True if the call is part of a recursion
+     */
+    public boolean isRecursive() {
+		if (fParent instanceof RealCallers) {
+			return false;
+		}
+        MethodWrapper current = getParent();
+
+        while (current != null) {
+            if (getMember().getHandleIdentifier().equals(current.getMember()
+                                                                        .getHandleIdentifier())) {
+                return true;
+            }
+
+            current = current.getParent();
+        }
+
+        return false;
+    }
+
+	/**
+	 * @return whether this member can have children
+	 */
+	public abstract boolean canHaveChildren();
+
+    /**
+     * This method finds the children of the current IMember (either callers or
+     * callees, depending on the concrete subclass).
+     * @param progressMonitor a progress monitor
+     *
+     * @return a map from handle identifier ({@link String}) to {@link MethodCall}
+     */
+    protected abstract Map<String, MethodCall> findChildren(IProgressMonitor progressMonitor);
+
+    private Map<String, Map<String, MethodCall>> getMethodCache() {
+        return fMethodCache;
+    }
+
+    private void initCalls() {
+        this.fElements = new HashMap<>();
+
+        initCacheForMethod();
+    }
+
+    /**
+     * Looks up a previously created search result in the "global" cache.
+     * @param methodCall the method call
+     * @return the List of previously found search results
+     */
+    private Map<String, MethodCall> lookupMethod(MethodCall methodCall) {
+        return getMethodCache().get(methodCall.getKey());
+    }
+
+    private void performSearch(IProgressMonitor progressMonitor) {
+        fElements = findChildren(progressMonitor);
+
+        for (Iterator<String> iter = fElements.keySet().iterator(); iter.hasNext();) {
+            checkCanceled(progressMonitor);
+
+            MethodCall methodCall = getMethodCallFromMap(fElements, iter.next());
+            addCallToCache(methodCall);
+        }
+    }
+
+    private MethodCall getMethodCallFromMap(Map<String, MethodCall> elements, String key) {
+        return elements.get(key);
+    }
+
+    private void initCacheForMethod() {
+        Map<String, MethodCall> cachedCalls = new HashMap<>();
+        getMethodCache().put(this.getMethodCall().getKey(), cachedCalls);
+    }
+
+    /**
+     * Checks with the progress monitor to see whether the creation of the type hierarchy
+     * should be canceled. Should be regularly called
+     * so that the user can cancel.
+     *
+     * @param progressMonitor the progress monitor
+     * @exception OperationCanceledException if cancelling the operation has been requested
+     * @see IProgressMonitor#isCanceled
+     */
+    protected void checkCanceled(IProgressMonitor progressMonitor) {
+        if (progressMonitor != null && progressMonitor.isCanceled()) {
+            throw new OperationCanceledException();
+        }
+    }
+
+    /**
+     * Allows a visitor to traverse the call hierarchy. The visiting is stopped when
+     * a recursive node is reached.
+     *
+     * @param visitor the visitor
+     * @param progressMonitor the progress monitor
+     */
+    public void accept(CallHierarchyVisitor visitor, IProgressMonitor progressMonitor) {
+        if (getParent() != null && getParent().isRecursive()) {
+            return;
+        }
+        checkCanceled(progressMonitor);
+
+        visitor.preVisit(this);
+        if (visitor.visit(this)) {
+            MethodWrapper[] methodWrappers= getCalls(progressMonitor);
+            for (int i= 0; i < methodWrappers.length; i++) {
+                methodWrappers[i].accept(visitor, progressMonitor);
+            }
+        }
+        visitor.postVisit(this);
+
+        if (progressMonitor != null) {
+            progressMonitor.worked(1);
+        }
+    }
+
+	/**
+	 * Removes the given method call from the cache.
+	 *
+	 * @since 3.6
+	 */
+	public void removeFromCache() {
+		fElements= null;
+		fMethodCache.remove(getMethodCall().getKey());
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodWrapper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/MethodWrapper.java
@@ -24,8 +24,6 @@ import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
-import org.eclipse.jdt.internal.ui.callhierarchy.MethodWrapperWorkbenchAdapter;
-import org.eclipse.ui.model.IWorkbenchAdapter;
 
 /**
  * This class represents the general parts of a method call (either to or from a
@@ -70,8 +68,6 @@ public abstract class MethodWrapper extends PlatformObject {
 	public <T> T getAdapter(Class<T> adapter) {
 		if (adapter == IJavaElement.class) {
 	        return (T) getMember();
-	    } else if (adapter == IWorkbenchAdapter.class){
-	    	return (T) new MethodWrapperWorkbenchAdapter(this);
 	    } else {
 	    	return null;
 	    }
@@ -144,11 +140,6 @@ public abstract class MethodWrapper extends PlatformObject {
 
         if (oth == null) {
             return false;
-        }
-
-        if (oth instanceof MethodWrapperWorkbenchAdapter) {
-            //Note: A MethodWrapper is equal to a referring MethodWrapperWorkbenchAdapter and vice versa (bug 101677).
-        	oth= ((MethodWrapperWorkbenchAdapter) oth).getMethodWrapper();
         }
 
         if (oth.getClass() != getClass()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/RealCallers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/callhierarchy/RealCallers.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2011 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.callhierarchy;
+
+/**
+ * Class for the real callers.
+ *
+ * @since 3.5
+ */
+	public class RealCallers extends CallerMethodWrapper {
+
+		/**
+		 * Sets the parent method wrapper.
+		 *
+		 * @param methodWrapper the method wrapper
+		 * @param methodCall the method call
+		 */
+		public RealCallers(MethodWrapper methodWrapper, MethodCall methodCall) {
+			super(methodWrapper, methodCall);
+	}
+
+		@Override
+		public boolean canHaveChildren() {
+			return true;
+	}
+
+		@Override
+		public boolean isRecursive() {
+			return false;
+		}
+	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandler.java
@@ -1,0 +1,279 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.jdt.core.ICompilationUnit.NO_AST;
+import static org.eclipse.jdt.core.IJavaElement.CLASS_FILE;
+import static org.eclipse.jdt.core.IJavaElement.COMPILATION_UNIT;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICodeAssist;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IInitializer;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JDTUtils.LocationType;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.corext.callhierarchy.CallHierarchy;
+import org.eclipse.jdt.ls.core.internal.corext.callhierarchy.CallLocation;
+import org.eclipse.jdt.ls.core.internal.corext.callhierarchy.MethodWrapper;
+import org.eclipse.lsp4j.CallHierarchyDirection;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.CallHierarchyParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+/**
+ * Handler for the {@link TextDocumentService#callHierarchy(CallHierarchyParams)
+ * <code>textDocument/callHierarchy</code>} language server method.
+ */
+public class CallHierarchyHandler {
+
+	protected static ThreadLocal<CallHierarchyItem> THREAD_LOCAL = new ThreadLocal<>();
+
+	public CallHierarchyItem callHierarchy(CallHierarchyParams params, IProgressMonitor monitor) {
+		Assert.isNotNull(params, "params");
+		Assert.isLegal(params.getResolve() >= 0, "'resolve' must a non-negative integer. Was: " + params.getResolve());
+
+		CallHierarchyDirection direction = params.getDirection() == null ? CallHierarchyDirection.Incoming : params.getDirection();
+		String uri = params.getTextDocument().getUri();
+		int line = params.getPosition().getLine();
+		int character = params.getPosition().getCharacter();
+		int resolve = params.getResolve();
+
+		try {
+			return getCallHierarchyItemAt(uri, line, character, resolve, direction, monitor);
+		} catch (OperationCanceledException e) {
+			return THREAD_LOCAL.get();
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.log(e);
+		} finally {
+			if (THREAD_LOCAL.get() != null) {
+				THREAD_LOCAL.set(null);
+			}
+		}
+		return null;
+	}
+
+	private CallHierarchyItem getCallHierarchyItemAt(String uri, int line, int character, int resolve, CallHierarchyDirection direction, IProgressMonitor monitor) throws JavaModelException {
+		Assert.isNotNull(uri, "uri");
+		Assert.isLegal(resolve >= 0, "Expected a non negative integer for 'resolve'. Was: " + resolve);
+		Assert.isNotNull(direction, "direction");
+
+		ITypeRoot root = JDTUtils.resolveTypeRoot(uri);
+		if (root == null) {
+			return null;
+		}
+
+		if (root instanceof ICompilationUnit) {
+			ICompilationUnit unit = (ICompilationUnit) root;
+			if (root.getResource() == null) {
+				return null;
+			}
+			reconcile(unit, monitor);
+		}
+
+		checkMonitor(monitor);
+
+		// Try to locate the member at the given position.
+		IMember candidate = null;
+		int offset = JsonRpcHelpers.toOffset(root, line, character);
+		List<IJavaElement> selectedElements = codeResolve(root, offset);
+		Stream<IJavaElement> possibleElements = selectedElements.stream().filter(CallHierarchy::isPossibleInputElement);
+		Optional<IJavaElement> firstElement = possibleElements.findFirst();
+		if (firstElement.isPresent() && firstElement.get() instanceof IMember) {
+			candidate = (IMember) firstElement.get();
+		}
+
+		// If the member cannot be resolved, retrieve the enclosing method.
+		if (candidate == null) {
+			candidate = getEnclosingMember(root, offset);
+			if (candidate == null) {
+				return null;
+			}
+		}
+
+		checkMonitor(monitor);
+
+		MethodWrapper wrapper = toMethodWrapper(candidate, direction);
+		if (wrapper == null) {
+			return null;
+		}
+
+		return toCallHierarchyItem(wrapper, resolve, monitor);
+	}
+
+	private List<IJavaElement> codeResolve(IJavaElement input, int offset) throws JavaModelException {
+		if (input instanceof ICodeAssist) {
+			return Arrays.asList(((ICodeAssist) input).codeSelect(offset, 0));
+		}
+		return emptyList();
+	}
+
+	private MethodWrapper toMethodWrapper(IMember member, CallHierarchyDirection direction) {
+		Assert.isNotNull(member, "member");
+
+		IMember[] members = { member };
+		CallHierarchy callHierarchy = CallHierarchy.getDefault();
+		final MethodWrapper[] result;
+		if (direction == CallHierarchyDirection.Incoming) {
+			result = callHierarchy.getCallerRoots(members);
+		} else {
+			result = callHierarchy.getCalleeRoots(members);
+		}
+		if (result == null || result.length < 1) {
+			return null;
+		}
+		return result[0];
+	}
+
+	private CallHierarchyItem toCallHierarchyItem(MethodWrapper wrapper, int resolve, IProgressMonitor monitor) {
+		checkMonitor(monitor);
+
+		if (wrapper == null || wrapper.getMember() == null) {
+			return null;
+		}
+
+		try {
+			IMember member = wrapper.getMember();
+			Location fullLocation = getLocation(member, LocationType.FULL_RANGE);
+			Range range = fullLocation.getRange();
+			String uri = fullLocation.getUri();
+			CallHierarchyItem item = new CallHierarchyItem();
+			item.setName(JDTUtils.getName(member));
+			item.setKind(JDTUtils.getSymbolKind(member));
+			item.setRange(range);
+			item.setSelectionRange(getLocation(member, LocationType.NAME_RANGE).getRange());
+			item.setUri(uri);
+			item.setDetail(JDTUtils.getDetail(member));
+			item.setDeprecated(JDTUtils.isDeprecated(member));
+
+			Collection<CallLocation> callLocations = wrapper.getMethodCall().getCallLocations();
+			// The `callLocations` should be `null` for the root item.
+			if (callLocations != null) {
+				item.setCallLocations(callLocations.stream().map(location -> {
+					IOpenable openable = location.getMember().getCompilationUnit();
+					if (openable == null) {
+						openable = location.getMember().getTypeRoot();
+					}
+					int[] start = JsonRpcHelpers.toLine(openable, location.getStart());
+					int[] end = JsonRpcHelpers.toLine(openable, location.getEnd());
+					Assert.isNotNull(start, "start");
+					Assert.isNotNull(end, "end");
+					Assert.isLegal(start[0] == end[0], "Expected equal start and end lines. Start was: " + Arrays.toString(start) + " End was:" + Arrays.toString(end));
+					Range callRange = new Range(new Position(start[0], start[1]), new Position(end[0], end[1]));
+					return new Location(uri, callRange);
+				}).collect(toList()));
+			}
+
+			// Set the copy of the unresolved item to the thread local, so that we can return with it in case of user abort. (`monitor#cancel()`)
+			if (THREAD_LOCAL.get() == null) {
+				THREAD_LOCAL.set(shallowCopy(item));
+			}
+
+			if (resolve > 0) {
+				item.setCalls(Arrays.stream(wrapper.getCalls(monitor)).map(w -> toCallHierarchyItem(w, resolve - 1, monitor)).collect(toList()));
+			}
+			return item;
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException("Error when converting to a call hierarchy item.", e);
+		}
+		return null;
+	}
+
+	/**
+	 * Throws an {@link OperationCanceledException} if the argument is canceled.
+	 */
+	private void checkMonitor(IProgressMonitor monitor) {
+		if (monitor != null && monitor.isCanceled()) {
+			throw new OperationCanceledException();
+		}
+	}
+
+	/**
+	 * Returns with a copy of the argument without the
+	 * {@link CallHierarchyItem#getCalls() calls} set.
+	 */
+	private CallHierarchyItem shallowCopy(CallHierarchyItem other) {
+		CallHierarchyItem copy = new CallHierarchyItem();
+		copy.setName(other.getName());
+		copy.setDetail(other.getDetail());
+		copy.setKind(other.getKind());
+		copy.setDeprecated(other.getDeprecated());
+		copy.setUri(other.getUri());
+		copy.setRange(other.getRange());
+		copy.setSelectionRange(other.getSelectionRange());
+		copy.setCallLocations(other.getCallLocations());
+		return copy;
+	}
+
+	/**
+	 * Gets the location of the Java {@code element} based on the desired
+	 * {@code locationType}.
+	 */
+	private Location getLocation(IJavaElement element, LocationType locationType) throws JavaModelException {
+		Assert.isNotNull(element, "element");
+		Assert.isNotNull(locationType, "locationType");
+
+		Location location = locationType.toLocation(element);
+		if (location == null && element instanceof IType) {
+			IType type = (IType) element;
+			ICompilationUnit unit = (ICompilationUnit) type.getAncestor(COMPILATION_UNIT);
+			IClassFile classFile = (IClassFile) type.getAncestor(CLASS_FILE);
+			if (unit != null || (classFile != null && classFile.getSourceRange() != null)) {
+				location = locationType.toLocation(type);
+			}
+		}
+		if (location == null && element instanceof IMember && ((IMember) element).getClassFile() != null) {
+			location = JDTUtils.toLocation(((IMember) element).getClassFile());
+		}
+		return location;
+	}
+
+	private IMember getEnclosingMember(ITypeRoot root, int offset) {
+		Assert.isNotNull(root, "root");
+		try {
+			IJavaElement enclosingElement = root.getElementAt(offset);
+			if (enclosingElement instanceof IMethod || enclosingElement instanceof IInitializer || enclosingElement instanceof IField) {
+				// opening on the enclosing type would be too confusing (since the type resolves to the constructors)
+				return (IMember) enclosingElement;
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.log(e);
+		}
+		return null;
+	}
+
+	private void reconcile(ICompilationUnit unit, IProgressMonitor monitor) throws JavaModelException {
+		unit.reconcile(NO_AST, false, null, monitor);
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyResolveHandler.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.CallHierarchyParams;
+import org.eclipse.lsp4j.ResolveCallHierarchyItemParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+/**
+ * Handler for the
+ * {@link TextDocumentService#resolveCallHierarchy(org.eclipse.lsp4j.ResolveCallHierarchyItemParams)
+ * <code>callHierarchy/resolve</code>} LS method.
+ */
+public class CallHierarchyResolveHandler extends CallHierarchyHandler {
+
+	public CallHierarchyItem resolve(ResolveCallHierarchyItemParams params, IProgressMonitor monitor) {
+		Assert.isNotNull(params, "params");
+
+		return callHierarchy(toCallHierarchyParams(params), monitor);
+	}
+
+	private CallHierarchyParams toCallHierarchyParams(ResolveCallHierarchyItemParams params) {
+		Assert.isNotNull(params.getItem(), "params.item");
+		Assert.isNotNull(params.getDirection(), "params.direction");
+
+		CallHierarchyParams result = new CallHierarchyParams();
+		result.setDirection(params.getDirection());
+		result.setResolve(params.getResolve());
+		CallHierarchyItem item = params.getItem();
+		result.setTextDocument(new TextDocumentIdentifier(item.getUri()));
+		result.setPosition(item.getRange().getStart());
+		return result;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeRoot;
@@ -246,7 +247,17 @@ public class DocumentSymbolHandler {
 		case IJavaElement.TYPE_PARAMETER:
 			return SymbolKind.Variable;
 		case IJavaElement.METHOD:
-			return SymbolKind.Method;
+			try {
+				// TODO handle `IInitializer`. What should be the `SymbolKind`?
+				if (element instanceof IMethod) {
+					if (((IMethod) element).isConstructor()) {
+						return SymbolKind.Constructor;
+					}
+				}
+				return SymbolKind.Method;
+			} catch (JavaModelException e) {
+				return SymbolKind.Method;
+			}
 		case IJavaElement.PACKAGE_DECLARATION:
 			return SymbolKind.Package;
 		case IJavaElement.TYPE:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -200,6 +200,9 @@ final public class InitHandler {
 		if (!preferenceManager.getClientPreferences().isImplementationDynamicRegistered()) {
 			capabilities.setImplementationProvider(Boolean.TRUE);
 		}
+		if (!preferenceManager.getClientPreferences().isCallHierarchyDynamicRegistered()) {
+			capabilities.setCallHierarchyProvider(Boolean.TRUE);
+		}
 		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setOpenClose(Boolean.TRUE);
 		textDocumentSyncOptions.setSave(new SaveOptions(Boolean.TRUE));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -58,6 +58,8 @@ import org.eclipse.jdt.ls.core.internal.managers.FormatterManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.CallHierarchyParams;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
@@ -96,6 +98,7 @@ import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.ResolveCallHierarchyItemParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -757,6 +760,24 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	public CompletableFuture<List<? extends Location>> implementation(TextDocumentPositionParams position) {
 		logInfo(">> document/implementation");
 		return computeAsyncWithClientProgress((monitor) -> new ImplementationsHandler(preferenceManager).findImplementations(position, monitor));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.lsp4j.services.TextDocumentService#callHierarchy(org.eclipse.lsp4j.CallHierarchyParams)
+	 */
+	@Override
+	public CompletableFuture<CallHierarchyItem> callHierarchy(CallHierarchyParams params) {
+		logInfo(">> textDocumentt/callHierarchy");
+		return computeAsyncWithClientProgress((monitor) -> new CallHierarchyHandler().callHierarchy(params, monitor));
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.lsp4j.services.TextDocumentService#resolveCallHierarchy(org.eclipse.lsp4j.ResolveCallHierarchyItemParams)
+	 */
+	@Override
+	public CompletableFuture<CallHierarchyItem> resolveCallHierarchy(ResolveCallHierarchyItemParams params) {
+		logInfo(">> callHierarchy/resolve");
+		return computeAsyncWithClientProgress((monitor) -> new CallHierarchyResolveHandler().resolve(params, monitor));
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
@@ -15,10 +15,13 @@ import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -31,6 +34,40 @@ final public class JsonRpcHelpers {
 
 	/**
 	 * Convert line, column to a document offset.
+	 *
+	 * @param openable
+	 * @param line
+	 * @param column
+	 * @return
+	 */
+	public static int toOffset(IOpenable openable, int line, int column) {
+		if (openable != null) {
+			boolean mustClose = false;
+			try {
+				if (!openable.isOpen()) {
+					openable.open(new NullProgressMonitor());
+					mustClose = openable.isOpen();
+				}
+				IBuffer buffer = openable.getBuffer();
+				return toOffset(toDocument(buffer), line, column);
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.log(e);
+			} finally {
+				if (mustClose) {
+					try {
+						openable.close();
+					} catch (JavaModelException e) {
+						JavaLanguageServerPlugin.logException("Error when closing openable: " + openable, e);
+					}
+				}
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Convert line, column to a document offset.
+	 *
 	 * @param buffer
 	 * @param line
 	 * @param column
@@ -45,7 +82,7 @@ final public class JsonRpcHelpers {
 
 	/**
 	 * Convert line, column to a document offset.
-	 * 
+	 *
 	 * @param document
 	 * @param line
 	 * @param column
@@ -69,6 +106,41 @@ final public class JsonRpcHelpers {
 	 */
 	public static int[] toLine(IBuffer buffer, int offset){
 		return toLine(toDocument(buffer), offset);
+	}
+
+	/**
+	 * Converts an offset to line number and column in an openable. If the
+	 * {@code openable} argument is {@link IOpenable#isOpen() <b>not</b> open}, this
+	 * method tries to
+	 * {@link IOpenable#open(org.eclipse.core.runtime.IProgressMonitor) open} it.
+	 *
+	 * @param buffer
+	 * @param line
+	 * @param column
+	 * @return
+	 */
+	public static int[] toLine(IOpenable openable, int offset) {
+		Assert.isNotNull(openable, "openable");
+		boolean mustClose = false;
+		try {
+			if (!openable.isOpen()) {
+				openable.open(new NullProgressMonitor());
+				mustClose = openable.isOpen();
+			}
+			IBuffer buffer = openable.getBuffer();
+			return toLine(toDocument(buffer), offset);
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.log(e);
+			return null;
+		} finally {
+			if (mustClose) {
+				try {
+					openable.close();
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.logException("Error when closing openable: " + openable, e);
+				}
+			}
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -201,6 +201,7 @@ public class ClientPreferences {
 				&& capabilities.getTextDocument().getDocumentSymbol() != null
 				&& capabilities.getTextDocument().getDocumentSymbol().getHierarchicalDocumentSymbolSupport() != null
 				&& capabilities.getTextDocument().getDocumentSymbol().getHierarchicalDocumentSymbolSupport().booleanValue();
+		//@formatter:on
 	}
 
 	public boolean isSemanticHighlightingSupported() {
@@ -213,8 +214,8 @@ public class ClientPreferences {
 
 	/**
 	 * {@code true} if the client has explicitly set the
-	 * {@code textDocument.documentSymbol.hierarchicalDocumentSymbolSupport} to
-	 * {@code true} when initializing the LS. Otherwise, {@code false}.
+	 * {@code textDocument.codeAction.codeActionLiteralSupport.codeActionKind.valueSet}
+	 * value. Otherwise, {@code false}.
 	 */
 	public boolean isSupportedCodeActionKind(String kind) {
 		//@formatter:off
@@ -226,4 +227,9 @@ public class ClientPreferences {
 				.stream().filter(k -> kind.startsWith(k)).findAny().isPresent();
 		//@formatter:on
 	}
+
+	public boolean isCallHierarchyDynamicRegistered() {
+		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getCallHierarchy());
+	}
+
 }

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -32,13 +32,13 @@
             <repository location="http://download.eclipse.org/releases/2018-12/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.6.0.v20181130-0905"/>
-           <repository location="http://download.eclipse.org/lsp4j/updates/releases/"/>
+           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.7.0.v20190128-1442"/>
+           <repository location="https://github.com/kittaakos/lsp4j-call-hierarchy/raw/master/p2/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="http://download.eclipse.org/releases/2018-12/"/>
+            <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/milestones"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/CallHierarchy.java
@@ -1,0 +1,60 @@
+package org.sample;
+
+public class CallHierarchy {
+
+  @Deprecated
+  public static void main(String[] args) {
+    new Base();
+    new Child().bar();
+    System.out.println(Base.STATIC_FIELD);
+  }
+
+  public static class Base {
+
+    static int STATIC_FIELD = 100;
+    protected int protectedField = 200;
+
+/*nothing*/
+
+    public Base() {
+/*should resolve to enclosing "method/constructor/initializer"*/
+    }
+
+    public void foo() {
+
+    }
+
+    public void bar() {
+      new Child();
+      new Child();
+      Thread.currentThread();
+      Thread.currentThread();
+    }
+
+    protected void method_1() {
+      foo();
+      bar();
+    }
+
+  }
+
+  public static class Child extends Base {
+
+    Child() {
+      super();
+      foo();
+      bar();
+      method_1();
+      protectedField = 300;
+      protectedField = 400;
+    }
+
+    protected void method_2() {
+      method_1();
+      method_1();
+      method_1();
+    }
+
+  }
+
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/CallHierarchy.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/CallHierarchy.java
@@ -1,0 +1,23 @@
+package org.sample;
+
+import org.apache.commons.lang3.builder.Builder;
+import org.apache.commons.lang3.text.WordUtils;
+
+public class CallHierarchy {
+
+  public static class FooBuilder implements Builder<Object> {
+
+    public FooBuilder() {
+      new CallHierarchyOther.X();
+    }
+
+    @Override
+    public Object build() {
+      WordUtils.capitalize("a");
+      WordUtils.capitalize("b");
+      return null;
+    }
+
+  }
+
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/CallHierarchyOther.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/CallHierarchyOther.java
@@ -1,0 +1,16 @@
+package org.sample;
+
+public class CallHierarchyOther {
+
+  static {
+    new CallHierarchy.FooBuilder();
+    new CallHierarchy.FooBuilder();
+    new CallHierarchy.FooBuilder();
+  }
+  
+  
+  @Deprecated public static class X {
+    
+  }
+  
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.lsp4j.CallHierarchyDirection.Incoming;
+import static org.eclipse.lsp4j.CallHierarchyDirection.Outgoing;
+import static org.eclipse.lsp4j.SymbolKind.Class;
+import static org.eclipse.lsp4j.SymbolKind.Constructor;
+import static org.eclipse.lsp4j.SymbolKind.Field;
+import static org.eclipse.lsp4j.SymbolKind.Method;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.CallHierarchyDirection;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.CallHierarchyParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @see CallHierarchyHandler
+ */
+public class CallHierarchyHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	@Before
+	public void setup() throws Exception {
+		importProjects(Arrays.asList("eclipse/hello", "maven/salut"));
+	}
+
+	@Test
+	public void incoming_src_missing() throws Exception {
+		// Line 16 from `CallHierarchy`
+		//<|>/*nothing*/
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		assertNull(getIncomings(uri, 13, 0, 1));
+	}
+
+	@Test
+	public void incoming_src_resolve_0() throws Exception {
+		// Line 15 from `CallHierarchy`
+		//    protected int <|>protectedField = 200;
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getIncomings(uri, 14, 18, 0);
+		assertItem(item, "protectedField", Field, "", null, false, null);
+	}
+
+	@Test
+	public void incoming_src_resolve_1() throws Exception {
+		// Line 26 from `CallHierarchy`
+		//    public void <|>bar() {
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getIncomings(uri, 25, 16, 1);
+		assertItem(item, "bar()", Method, "void", 3, false, null);
+
+		List<CallHierarchyItem> calls = item.getCalls();
+		assertItem(calls.get(0), "Child()", Constructor, "", null, false, asList(45));
+		assertItem(calls.get(1), "main(String[])", Method, "void", null, true, asList(7));
+		assertItem(calls.get(2), "method_1()", Method, "void", null, false, asList(35));
+	}
+
+	@Test
+	public void outgoing_src_resolve_0_enclosing() throws Exception {
+		// Line 20 from `CallHierarchy`
+		///*should resolve to enclosing "method/constructor/initializer"*/
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getIncomings(uri, 19, 0, 0);
+		assertItem(item, "Base()", Constructor, "", null, false, null);
+	}
+
+	@Test
+	public void outgoing_src_resolve_2() throws Exception {
+		// Line 34 from `CallHierarchy`
+		//    protected void <|>method_1() {
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getOutgoings(uri, 33, 19, 2);
+		assertItem(item, "method_1()", Method, "void", 2, false, null);
+
+		List<CallHierarchyItem> calls = item.getCalls();
+		assertItem(calls.get(0), "foo()", Method, "void", 0, false, asList(34));
+		assertItem(calls.get(1), "bar()", Method, "void", 2, false, asList(35));
+
+		List<CallHierarchyItem> call1Calls = calls.get(1).getCalls();
+		assertItem(call1Calls.get(0), "Child()", Constructor, "", null, false, asList(27, 28));
+		assertItem(call1Calls.get(1), "currentThread()", Method, "Thread", null, false, asList(29, 30));
+	}
+
+	@Test
+	public void incoming_jar_resolve_2() throws Exception {
+		// Line 12 from `CallHierarchyOther`
+		//  @Deprecated public static class <|>X {
+		String uri = getUriFromJarProject("org.sample.CallHierarchyOther");
+		CallHierarchyItem item = getIncomings(uri, 11, 34, 2);
+		assertItem(item, "X", Class, "", 1, true, null);
+
+		List<CallHierarchyItem> calls = item.getCalls();
+		assertItem(calls.get(0), "FooBuilder()", Constructor, "", 1, false, asList(10));
+
+		List<CallHierarchyItem> call0Calls = calls.get(0).getCalls();
+		assertItem(call0Calls.get(0), "{...}", Constructor, "", null, false, asList(5, 6, 7));
+	}
+
+	@Test
+	public void outgoing_jar_resolve_2() throws Exception {
+		// Line 15 from `CallHierarchy`
+		//    public Object <|>build() {
+		String uri = getUriFromJarProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getOutgoings(uri, 14, 18, 2);
+		assertItem(item, "build()", Method, "Object", 1, false, null);
+
+		List<CallHierarchyItem> calls = item.getCalls();
+		assertItem(calls.get(0), "capitalize(String)", Method, "String", 1, false, asList(15, 16));
+
+		List<CallHierarchyItem> call0Calls = calls.get(0).getCalls();
+		assertItem(call0Calls.get(0), "capitalize(String, char...)", Method, "String", null, false, asList(369));
+
+		String jarUri = call0Calls.get(0).getUri();
+		assertTrue(jarUri.startsWith("jdt://"));
+		assertTrue(jarUri.contains("org.apache.commons.lang3.text"));
+		assertTrue(jarUri.contains("WordUtils.class"));
+	}
+
+	/**
+	 * @param item
+	 *            to assert
+	 * @param name
+	 *            the expected name
+	 * @param kind
+	 *            the expected kind
+	 * @param detail
+	 *            the expected detail <b>without</b> the ` : ` (declaration) suffix.
+	 * @param calls
+	 *            the number of calls or {@code null} if expected non-defined calls.
+	 * @param deprecated
+	 *            expected deprecated state
+	 * @param callLocationStartLines
+	 *            {@code null}, if there are no call locations. Otherwise a list of
+	 *            expected start lines for the call locations
+	 * @return the {@code item}
+	 */
+	static CallHierarchyItem assertItem(CallHierarchyItem item, String name, SymbolKind kind, String detail, Integer calls, boolean deprecated, List<Integer> callLocationStartLines) {
+		assertNotNull(item);
+		assertEquals(name, item.getName());
+		assertEquals(kind, item.getKind());
+		if (detail.isEmpty()) {
+			assertEquals(detail, item.getDetail());
+		} else {
+			assertEquals(JavaElementLabels.DECL_STRING + detail, item.getDetail());
+		}
+		if (calls == null) {
+			assertNull(item.getCalls());
+		} else {
+			assertEquals(calls.intValue(), item.getCalls().size());
+		}
+		assertEquals(deprecated, item.getDeprecated());
+		if (callLocationStartLines == null) {
+			assertNull(item.getCallLocations());
+		} else {
+			List<Location> callLocations = item.getCallLocations();
+			assertEquals(callLocationStartLines.size(), callLocations.size());
+			List<Integer> actualStartLines = callLocations.stream().map(loc -> loc.getRange().getStart().getLine()).collect(toList());
+			assertEquals(callLocationStartLines, actualStartLines);
+		}
+		return item;
+	}
+
+	static CallHierarchyItem getIncomings(String uri, int line, int character, int resolve) {
+		CallHierarchyParams params = createParams(uri, line, character, Incoming, resolve);
+		return new CallHierarchyHandler().callHierarchy(params, new NullProgressMonitor());
+	}
+
+	static CallHierarchyItem getOutgoings(String uri, int line, int character, int resolve) {
+		CallHierarchyParams params = createParams(uri, line, character, Outgoing, resolve);
+		return new CallHierarchyHandler().callHierarchy(params, new NullProgressMonitor());
+	}
+
+	static CallHierarchyParams createParams(String uri, int line, int character, CallHierarchyDirection direction, int resolve) {
+		CallHierarchyParams params = new CallHierarchyParams();
+		params.setTextDocument(new TextDocumentIdentifier(uri));
+		params.setPosition(new Position(line, character));
+		params.setDirection(direction);
+		params.setResolve(resolve);
+		return params;
+	}
+
+	static String getUriFromJarProject(String className) throws JavaModelException {
+		return ClassFileUtil.getURI(WorkspaceHelper.getProject("salut"), className);
+	}
+
+	static String getUriFromSrcProject(String className) throws JavaModelException {
+		return ClassFileUtil.getURI(WorkspaceHelper.getProject("hello"), className);
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyResolveHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyResolveHandlerTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     TypeFox - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static java.util.Arrays.asList;
+import static org.eclipse.jdt.ls.core.internal.handlers.CallHierarchyHandlerTest.assertItem;
+import static org.eclipse.jdt.ls.core.internal.handlers.CallHierarchyHandlerTest.getIncomings;
+import static org.eclipse.jdt.ls.core.internal.handlers.CallHierarchyHandlerTest.getUriFromSrcProject;
+import static org.eclipse.lsp4j.SymbolKind.Constructor;
+import static org.eclipse.lsp4j.SymbolKind.Method;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.lsp4j.CallHierarchyDirection;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ResolveCallHierarchyItemParams;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @see CallHierarchyResolveHandler
+ */
+public class CallHierarchyResolveHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	@Before
+	public void setup() throws Exception {
+		importProjects(Arrays.asList("eclipse/hello", "maven/salut"));
+	}
+
+	@Test
+	public void cannot_resolve() {
+		CallHierarchyItem invalid = new CallHierarchyItem();
+		invalid.setUri("file:///missing/Resource.java");
+		invalid.setRange(new Range(new Position(0, 0), new Position(0, 0)));
+		CallHierarchyItem item = resolveIncoming(invalid, 1);
+		assertNull(item);
+	}
+
+	@Test
+	public void resolve_incoming() throws Exception {
+		// Line 26 from `CallHierarchy`
+		//    public void <|>bar() {
+		String uri = getUriFromSrcProject("org.sample.CallHierarchy");
+		CallHierarchyItem item = getIncomings(uri, 25, 16, 0);
+		assertItem(item, "bar()", Method, "void", null, false, null);
+
+		item = resolveIncoming(item, 1);
+		assertItem(item, "bar()", Method, "void", 3, false, null);
+
+		List<CallHierarchyItem> calls = item.getCalls();
+		assertItem(calls.get(0), "Child()", Constructor, "", null, false, asList(45));
+		assertItem(calls.get(1), "main(String[])", Method, "void", null, true, asList(7));
+		assertItem(calls.get(2), "method_1()", Method, "void", null, false, asList(35));
+	}
+
+	private static CallHierarchyItem resolveIncoming(CallHierarchyItem toResolve, int resolve) {
+		ResolveCallHierarchyItemParams params = new ResolveCallHierarchyItemParams();
+		params.setDirection(CallHierarchyDirection.Incoming);
+		params.setItem(toResolve);
+		params.setResolve(resolve);
+		return new CallHierarchyResolveHandler().resolve(params, new NullProgressMonitor());
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -152,7 +152,7 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 	public void testSyntheticMember_hierarchical_noSourceAttached() throws Exception {
 		String className = "foo.bar";
 		List<? extends DocumentSymbol> symbols = asStream(internalGetHierarchicalSymbols(noSourceProject, monitor, className)).collect(Collectors.toList());
-		assertHasHierarchicalSymbol("bar()", "bar", SymbolKind.Method, symbols);
+		assertHasHierarchicalSymbol("bar()", "bar", SymbolKind.Constructor, symbols);
 		assertHasHierarchicalSymbol("add(int...) : int", "bar", SymbolKind.Method, symbols);
 	}
 


### PR DESCRIPTION
Issue: #508.

This PR contains
 - the migration of the `o.e.j.i.coreext.callhierarchy` package to the the JDT LS.
   - _Copied o.e.j.i.corext.callhierarchy source from JDT UI to LS._ ccf7771
   - _Switched from `JavaPlugin` to `JavaLanguageServerPlugin`._ c7ea1da
   - _Got rid of the Eclipse workbench dependencies._ 33b0a71
 - the handler for the language server.
