### PR TITLE
Automatically detect jars in lib/ folder

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/DefaultProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/DefaultProjectBuildSupport.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import org.eclipse.core.resources.IProject;
+
+public class DefaultProjectBuildSupport extends EclipseBuildSupport implements IBuildSupport {
+
+	private ProjectsManager projectManager;
+
+	public DefaultProjectBuildSupport(ProjectsManager projectManager) {
+		this.projectManager = projectManager;
+	}
+
+	@Override
+	public boolean applies(IProject project) {
+		return projectManager.getDefaultProject().equals(project);
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.util.Set;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+
+import com.google.common.collect.Sets;
+
+public class EclipseBuildSupport implements IBuildSupport {
+
+	private Set<String> files = Sets.newHashSet(".classpath", ".project", ".factorypath");
+	private Set<String> folders = Sets.newHashSet(".settings");
+
+	@Override
+	public boolean applies(IProject project) {
+		return true; //all projects are Eclipse projects
+	}
+
+	@Override
+	public boolean isBuildFile(IResource resource) {
+		if (resource == null || resource.getProject() == null) {
+			return false;
+		}
+		IProject project = resource.getProject();
+		for (String file : files) {
+			if (resource.equals(project.getFile(file))) {
+				return true;
+			}
+		}
+		IPath path = resource.getFullPath();
+		for (String folder : folders) {
+			IPath folderPath = project.getFolder(folder).getFullPath();
+			if (folderPath.isPrefixOf(path)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 
 /**
  * @author Fred Bricon
@@ -58,7 +59,7 @@ public class GradleBuildSupport implements IBuildSupport {
 
 	@Override
 	public boolean isBuildFile(IResource resource) {
-		if (resource != null && resource.getType() == IResource.FILE && (resource.getName().endsWith(GRADLE_SUFFIX) || resource.getName().equals(GRADLE_PROPERTIES)) && resource.getProject() != null
+		if (resource != null && resource.getType() == IResource.FILE && (resource.getName().endsWith(GRADLE_SUFFIX) || resource.getName().equals(GRADLE_PROPERTIES))
 				&& ProjectUtils.isGradleProject(resource.getProject())) {
 			try {
 				if (!ProjectUtils.isJavaProject(resource.getProject())) {
@@ -90,6 +91,14 @@ public class GradleBuildSupport implements IBuildSupport {
 				}
 			}
 		}
+	}
+
+	@Override
+	public boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+		if (resource == null || !applies(resource.getProject())) {
+			return false;
+		}
+		return IBuildSupport.super.fileChanged(resource, changeType, monitor) || isBuildFile(resource);
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 
 /**
  * @author Fred Bricon
@@ -35,7 +36,9 @@ public interface IBuildSupport {
 	 * @param monitor
 	 * @throws CoreException
 	 */
-	void update(IProject resource, boolean force, IProgressMonitor monitor) throws CoreException;
+	default void update(IProject resource, boolean force, IProgressMonitor monitor) throws CoreException {
+		//do nothing
+	}
 
 	/**
 	 * Is equal to a non-forced update: {@code update(resource, false, monitor)}
@@ -43,4 +46,34 @@ public interface IBuildSupport {
 	default void update(IProject resource, IProgressMonitor monitor) throws CoreException {
 		update(resource, false, monitor);
 	}
+
+	/**
+	 *	Handle resource changes.
+	 * @param resource
+	 * 				- the resource that changed
+	 * @param changeType
+	 * 				- the type of change
+	 * @param monitor
+	 * 				- a progress monitor
+	 * @return <code>true</code> if a project configuration update is recommended next
+	 *
+	 * @throws CoreException
+	 */
+	default boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+		refresh(resource, changeType, monitor);
+		return false;
+	}
+
+	default void refresh(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+		if (resource == null) {
+			return;
+		}
+		if (changeType == CHANGE_TYPE.DELETED) {
+			resource = resource.getParent();
+		}
+		if (resource != null) {
+			resource.refreshLocal(IResource.DEPTH_INFINITE, monitor);
+		}
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
+
+/**
+ * @author Fred Bricon
+ *
+ */
+public class InvisibleProjectBuildSupport extends EclipseBuildSupport implements IBuildSupport {
+
+	static final String LIB_FOLDER = "lib";
+
+	private UpdateClasspathJob updateClasspathJob;
+
+	public InvisibleProjectBuildSupport() {
+		this(UpdateClasspathJob.getInstance());
+	}
+
+	public InvisibleProjectBuildSupport(UpdateClasspathJob updateClasspathJob) {
+		this.updateClasspathJob = updateClasspathJob;
+	}
+
+	@Override
+	public boolean applies(IProject project) {
+		return project != null && project.isAccessible() && !ProjectUtils.isVisibleProject(project);
+	}
+
+	@Override
+	public boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+		if (resource == null || !applies(resource.getProject())) {
+			return false;
+		}
+		refresh(resource, changeType, monitor);
+		IProject invisibleProject = resource.getProject();
+		IPath realFolderPath = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK).getLocation();
+		if (realFolderPath != null) {
+			IPath libFolderPath = realFolderPath.append(LIB_FOLDER);
+			if (libFolderPath.isPrefixOf(resource.getLocation())) {
+				updateClasspathJob.updateClasspath(JavaCore.create(invisibleProject), libFolderPath);
+			}
+		}
+		return false;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Microsoft Corporation and others.
+ * Copyright (c) 2018-2019 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
@@ -78,25 +79,30 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 
 		String invisibleProjectName = ProjectUtils.getWorkspaceInvisibleProjectName(rootPath);
 		IProject invisibleProject = ResourcesPlugin.getWorkspace().getRoot().getProject(invisibleProjectName);
+		IPath libFolder = new Path(InvisibleProjectBuildSupport.LIB_FOLDER);
+		IFolder workspaceLinkFolder = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK);
+		IPath relativeSourcePath = sourceDirectory.makeRelativeTo(rootPath);
+		IPath sourcePath = relativeSourcePath.isEmpty() ? workspaceLinkFolder.getFullPath() : workspaceLinkFolder.getFolder(relativeSourcePath).getFullPath();
 		if (!invisibleProject.exists()) {
 			try {
 				JavaLanguageServerPlugin.logInfo("Try to create an invisible project for the workspace " + rootPath);
 				invisibleProject = ProjectUtils.createInvisibleProjectIfNotExist(rootPath);
-				IFolder workspaceLinkFolder = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK);
-				IPath relativeSourcePath = sourceDirectory.makeRelativeTo(rootPath);
-				IPath sourcePath = relativeSourcePath.isEmpty() ? workspaceLinkFolder.getFullPath() : workspaceLinkFolder.getFolder(relativeSourcePath).getFullPath();
 				List<IProject> subProjects = ProjectUtils.getVisibleProjects(rootPath);
 				List<IPath> subProjectPaths = subProjects.stream().map(project -> {
 					IPath relativePath = project.getLocation().makeRelativeTo(rootPath);
 					return workspaceLinkFolder.getFolder(relativePath).getFullPath();
 				}).collect(Collectors.toList());
+				subProjectPaths.add(libFolder);
 				IJavaProject javaProject = JavaCore.create(invisibleProject);
 				ProjectUtils.addSourcePath(sourcePath, subProjectPaths.toArray(new IPath[0]), javaProject);
 				JavaLanguageServerPlugin.logInfo("Successfully created a workspace invisible project " + invisibleProjectName);
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException("Failed to create the invisible project.", e);
+				return;
 			}
 		}
+		IJavaProject javaProject = JavaCore.create(invisibleProject);
+		ProjectUtils.updateBinaries(javaProject, rootPath.append(libFolder), monitor);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
@@ -113,5 +114,13 @@ public class MavenBuildSupport implements IBuildSupport {
 
 	public void setShouldCollectProjects(boolean shouldCollectProjects) {
 		this.shouldCollectProjects = shouldCollectProjects;
+	}
+
+	@Override
+	public boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+		if (resource == null || !applies(resource.getProject())) {
+			return false;
+		}
+		return IBuildSupport.super.fileChanged(resource, changeType, monitor) || isBuildFile(resource);
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/UpdateClasspathJob.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/UpdateClasspathJob.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+
+/**
+ * Job updating project classpath to match content of library folders.
+ */
+public class UpdateClasspathJob extends WorkspaceJob {
+
+	private static final long SCHEDULE_DELAY = 1000L;
+
+	private final Set<UpdateClasspathRequest> queue = new LinkedHashSet<>();
+
+	private static final UpdateClasspathJob instance = new UpdateClasspathJob();
+
+	UpdateClasspathJob() {
+		super("Update classpath Job");
+	}
+
+	@Override
+	public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+		final List<UpdateClasspathRequest> requests;
+		synchronized (this.queue) {
+			requests = new ArrayList<>(this.queue);
+			this.queue.clear();
+		}
+		Map<IJavaProject, Set<IPath>> reqPerProject = requests.stream().collect(Collectors.groupingBy(UpdateClasspathRequest::getProject, Collectors.mapping(UpdateClasspathRequest::getLibPath, Collectors.toSet())));
+
+		for (Map.Entry<IJavaProject, Set<IPath>> reqs : reqPerProject.entrySet()) {
+			if (monitor.isCanceled()) {
+				return Status.CANCEL_STATUS;
+			}
+			updateClasspath(reqs.getKey(), reqs.getValue(), monitor);
+		}
+		synchronized (queue) {
+			if (!queue.isEmpty()) {
+				schedule(SCHEDULE_DELAY);
+			}
+		}
+		return Status.OK_STATUS;
+	}
+
+	private void updateClasspath(IJavaProject project, Set<IPath> libFolders, IProgressMonitor monitor) throws CoreException {
+		ProjectUtils.updateBinaries(project, libFolders, monitor);
+	}
+
+	public void updateClasspath(IJavaProject project, IPath libPath) {
+		if (project == null || libPath == null) {
+			return;
+		}
+		queue(new UpdateClasspathRequest(project, libPath));
+		schedule(SCHEDULE_DELAY);
+	}
+
+	void update(UpdateClasspathRequest updateRequest) {
+		queue(updateRequest);
+		schedule(SCHEDULE_DELAY);
+	}
+
+	void queue(UpdateClasspathRequest updateRequest) {
+		synchronized (queue) {
+			queue.add(updateRequest);
+		}
+	}
+
+	static class UpdateClasspathRequest {
+		private IJavaProject project;
+		private IPath libPath;
+
+		UpdateClasspathRequest(IJavaProject project, IPath libPath) {
+			this.project = project;
+			this.libPath = libPath;
+		}
+
+		IPath getLibPath() {
+			return libPath;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(libPath, project);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			UpdateClasspathRequest other = (UpdateClasspathRequest) obj;
+			return Objects.equals(libPath, other.libPath) && Objects.equals(project, other.project);
+		}
+
+		IJavaProject getProject() {
+			return project;
+		}
+
+	}
+
+	public static UpdateClasspathJob getInstance() {
+		return instance;
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaProjectHelper.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaProjectHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,6 +10,9 @@
  *     Ferenc Hechler, ferenc_hechler@users.sourceforge.net - 83258 [jar exporter] Deploy java application as executable jar
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
@@ -89,5 +92,9 @@ public class JavaProjectHelper {
 		System.arraycopy(oldEntries, 0, newEntries, 0, nEntries);
 		newEntries[nEntries] = cpe;
 		jproject.setRawClasspath(newEntries, null);
+	}
+
+	public static String toString(IClasspathEntry[] classpath) {
+		return Arrays.stream(classpath).map(cpe -> " - " + cpe.getPath().toString()).collect(Collectors.joining("\n"));
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IProject;
@@ -188,6 +189,7 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
 		when(mockCapabilies.isWorkspaceChangeWatchedFilesDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+
 		importProjects(Arrays.asList("maven/salut", "gradle/simple-gradle"));
 		newEmptyProject();
 		List<FileSystemWatcher> watchers = projectsManager.registerWatchers();
@@ -198,8 +200,8 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 				return o1.getGlobPattern().compareTo(o2.getGlobPattern());
 			}
 		});
-		assertEquals(watchers.size(), 5);
-		assertEquals(watchers.get(0).getGlobPattern(), ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() + "/TestProject/src/**");
+		assertEquals("Unexpected watchers:\n" + toString(watchers), 5, watchers.size());
+		assertEquals(watchers.get(0).getGlobPattern(), getWorkingProjectDirectory().getAbsolutePath() + "/TestProject/src/**");
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("simple-gradle");
 		String location = project.getLocation().toString();
 		assertEquals(watchers.get(1).getGlobPattern(), location + "/src/main/java/**");
@@ -235,6 +237,10 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 			}
 		});
 		assertEquals(newWatchers, watchers);
+	}
+
+	private String toString(List<FileSystemWatcher> watchers) {
+		return watchers.stream().map(FileSystemWatcher::getGlobPattern).collect(Collectors.joining("\n"));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+
+/**
+ * Base class for Invisible project tests.
+ *
+ * @author Fred Bricon
+ *
+ */
+public abstract class AbstractInvisibleProjectBasedTest extends AbstractProjectsManagerBasedTest {
+
+	protected IProject copyAndImportFolder(String folder, String triggerFile) throws Exception {
+		File projectFolder = copyFiles(folder, true);
+		return importRootFolder(projectFolder, triggerFile);
+	}
+
+	/**
+	 * Creates a temporary folder prefixed with <code>name</code> containing sources
+	 * and jars under a lib directory.
+	 */
+	protected File createSourceFolderWithLibs(String name) throws Exception {
+		return createSourceFolderWithLibs(name, true);
+	}
+
+	/**
+	 * Creates a temporary folder prefixed with <code>name</code> containing sources
+	 * but without its required jars.
+	 */
+	protected File createSourceFolderWithMissingLibs(String name) throws Exception {
+		return createSourceFolderWithLibs(name, false);
+	}
+
+	protected File createSourceFolderWithLibs(String name, boolean addLibs) throws Exception {
+		java.nio.file.Path projectPath = Files.createTempDirectory(name);
+		File projectFolder = projectPath.toFile();
+		FileUtils.copyDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/src"), projectFolder);
+		if (addLibs) {
+			addLibs(projectPath);
+		}
+		return projectFolder;
+	}
+
+	protected void addLibs(java.nio.file.Path projectPath) throws Exception {
+		java.nio.file.Path libPath = Files.createDirectories(projectPath.resolve(InvisibleProjectBuildSupport.LIB_FOLDER));
+		File libFile = libPath.toFile();
+		FileUtils.copyFileToDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/foo.jar"), libFile);
+		FileUtils.copyFileToDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/foo-sources.jar"), libFile);
+	}
+
+	protected IProject importRootFolder(File projectFolder, String triggerFile) throws Exception {
+		IPath rootPath = Path.fromOSString(projectFolder.getAbsolutePath());
+		if (StringUtils.isNotBlank(triggerFile)) {
+			IPath triggerFilePath = rootPath.append(triggerFile);
+			Preferences preferences = preferenceManager.getPreferences();
+			preferences.setTriggerFiles(Arrays.asList(triggerFilePath));
+		}
+		final List<IPath> roots = Arrays.asList(rootPath);
+		IWorkspaceRunnable runnable = new IWorkspaceRunnable() {
+			@Override
+			public void run(IProgressMonitor monitor) throws CoreException {
+				projectsManager.initializeProjects(roots, monitor);
+			}
+		};
+		JavaCore.run(runnable, null, monitor);
+		waitForBackgroundJobs();
+		String invisibleProjectName = ProjectUtils.getWorkspaceInvisibleProjectName(rootPath);
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(invisibleProjectName);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -109,12 +109,13 @@ public abstract class AbstractProjectsManagerBasedTest {
 	});
 
 	@Before
-	public void initProjectManager() throws CoreException {
+	public void initProjectManager() throws Exception {
 		clientRequests.clear();
 
 		logListener = new SimpleLogListener();
 		Platform.addLogListener(logListener);
 		preferences = new Preferences();
+		preferences.setRootPaths(Collections.singleton(new Path(getWorkingProjectDirectory().getAbsolutePath())));
 		if (preferenceManager == null) {
 			preferenceManager = mock(PreferenceManager.class);
 		}
@@ -155,7 +156,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 	protected IJavaProject newEmptyProject() throws Exception {
 		IProject testProject = ResourcesPlugin.getWorkspace().getRoot().getProject(TEST_PROJECT_NAME);
 		assertEquals(false, testProject.exists());
-		projectsManager.createJavaProject(testProject, new NullProgressMonitor());
+		projectsManager.createJavaProject(testProject, new Path(getWorkingProjectDirectory().getAbsolutePath()).append(TEST_PROJECT_NAME), "src", "bin", new NullProgressMonitor());
 		waitForBackgroundJobs();
 		return JavaCore.create(testProject);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.IJobChangeListener;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.JavaProjectHelper;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Fred Bricon
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBasedTest {
+
+	@Test
+	public void testDynamicLibDetection() throws Exception {
+		File projectFolder = createSourceFolderWithMissingLibs("dynamicLibDetection");
+		IProject project = importRootFolder(projectFolder, "Test.java");
+		List<IMarker> errors = ResourceUtils.getErrorMarkers(project);
+		assertEquals("Unexpected errors " + ResourceUtils.toString(errors), 2, errors.size());
+
+		//Add jars to fix compilation errors
+		addLibs(projectFolder.toPath());
+		Path libPath = projectFolder.toPath().resolve(InvisibleProjectBuildSupport.LIB_FOLDER);
+
+		Path jar = libPath.resolve("foo.jar");
+		projectsManager.fileChanged(jar.toUri().toString(), CHANGE_TYPE.CREATED);
+		waitForBackgroundJobs();
+		{
+			IJavaProject javaProject = JavaCore.create(project);
+			IClasspathEntry[] classpath = javaProject.getRawClasspath();
+			assertEquals("Unexpected classpath:\n" + JavaProjectHelper.toString(classpath), 3, classpath.length);
+			assertEquals("foo.jar", classpath[2].getPath().lastSegment());
+			assertEquals("foo-sources.jar", classpath[2].getSourceAttachmentPath().lastSegment());
+		}
+
+		//remove sources
+		Path sources = libPath.resolve("foo-sources.jar");
+		Files.deleteIfExists(sources);
+		projectsManager.fileChanged(sources.toUri().toString(), CHANGE_TYPE.DELETED);
+		waitForBackgroundJobs();
+		{
+			IJavaProject javaProject = JavaCore.create(project);
+			IClasspathEntry[] classpath = javaProject.getRawClasspath();
+			assertEquals("Unexpected classpath:\n" + JavaProjectHelper.toString(classpath), 3, classpath.length);
+			assertEquals("foo.jar", classpath[2].getPath().lastSegment());
+			assertNull(classpath[2].getSourceAttachmentPath());
+		}
+		assertNoErrors(project);
+
+
+		//remove lib folder
+		Files.deleteIfExists(jar);//lib needs to be empty
+		Files.deleteIfExists(libPath);
+		projectsManager.fileChanged(libPath.toUri().toString(), CHANGE_TYPE.DELETED);
+		waitForBackgroundJobs();
+		{
+			IJavaProject javaProject = JavaCore.create(project);
+			IClasspathEntry[] classpath = javaProject.getRawClasspath();
+			assertEquals("Unexpected classpath:\n" + JavaProjectHelper.toString(classpath), 2, classpath.length);
+		}
+		//back to square 1
+		errors = ResourceUtils.getErrorMarkers(project);
+		assertEquals("Unexpected errors " + ResourceUtils.toString(errors), 2, errors.size());
+
+	}
+
+	@Test
+	public void testDebounceJarDetection() throws Exception {
+		File projectFolder = createSourceFolderWithMissingLibs("dynamicLibDetection");
+		IProject project = importRootFolder(projectFolder, "Test.java");
+		List<IMarker> errors = ResourceUtils.getErrorMarkers(project);
+		assertEquals("Unexpected errors " + ResourceUtils.toString(errors), 2, errors.size());
+
+		//Add jars to fix compilation errors
+		addLibs(projectFolder.toPath());
+
+		Path libPath = projectFolder.toPath().resolve(InvisibleProjectBuildSupport.LIB_FOLDER);
+
+		int[] jobInvocations = new int[1];
+		IJobChangeListener listener = new JobChangeAdapter() {
+			@Override
+			public void scheduled(IJobChangeEvent event) {
+				if (event.getJob() instanceof UpdateClasspathJob) {
+					jobInvocations[0] = jobInvocations[0] + 1;
+				}
+			}
+		};
+		try {
+			Job.getJobManager().addJobChangeListener(listener);
+			//Spam the service
+			for (int i = 0; i < 50; i++) {
+				projectsManager.fileChanged(libPath.resolve("foo.jar").toUri().toString(), CHANGE_TYPE.CREATED);
+				projectsManager.fileChanged(libPath.resolve("foo-sources.jar").toUri().toString(), CHANGE_TYPE.CREATED);
+				Thread.sleep(5);
+			}
+			waitForBackgroundJobs();
+			assertEquals("Update classpath job should have been invoked once", 1, jobInvocations[0]);
+		} finally {
+			Job.getJobManager().removeJobChangeListener(listener);
+		}
+
+		{
+			IJavaProject javaProject = JavaCore.create(project);
+			IClasspathEntry[] classpath = javaProject.getRawClasspath();
+			assertEquals("Unexpected classpath:\n" + JavaProjectHelper.toString(classpath), 3, classpath.length);
+			assertEquals("foo.jar", classpath[2].getPath().lastSegment());
+			assertEquals("foo-sources.jar", classpath[2].getSourceAttachmentPath().lastSegment());
+		}
+
+	}
+
+}


### PR DESCRIPTION
... in the root directory of  standalone files / invisible projects

- a file watcher on lib/** is added for invisible projects
- source for foo.jar is automatically detected if there's a
foo-sources.jar in the lib/ folder
- multiple file events are handled so that classpath modifications are
minimized