### PR TITLE
Remove duplicate feature (Javadoc hovers) from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Features
 * Code completion
 * Javadoc hovers
 * Code actions / refactoring
-* Javadoc hovers
 * Code outline
 * Code navigation
 * Code lens (references/implementations)


### PR DESCRIPTION
As specified in the title :-)