### PR TITLE
Improve the mechanism to resolve the package name for empty java file

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/singlefile/lesson1/samples/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/lesson1/samples/Foo.java
@@ -1,0 +1,8 @@
+package samples;
+
+public class Foo {
+	public static void main(String[] args)
+    {
+        System.out.println("Hello World!");
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -79,4 +79,51 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 		assertTrue("Unexpected lib glob pattern: " + libGlobPattern, libGlobPattern.endsWith(projectFolder.getName() + "/lib/**"));
 	}
 
+	@Test
+	public void getPackageNameFromRelativePathOfEmptyFile() throws Exception {
+		File projectFolder = copyFiles("singlefile", true);
+		IProject invisibleProject = importRootFolder(projectFolder, "lesson1/Test.java");
+		assertTrue(invisibleProject.exists());
+
+		IPath workspaceRoot = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath javaFile = workspaceRoot.append("lesson1/Test.java");
+		String packageName = InvisibleProjectImporter.getPackageName(javaFile, workspaceRoot, JavaCore.create(invisibleProject));
+		assertEquals("lesson1", packageName);
+	}
+
+	@Test
+	public void getPackageNameFromNearbyNonEmptyFile() throws Exception {
+		File projectFolder = copyFiles("singlefile", true);
+		IProject invisibleProject = importRootFolder(projectFolder, "lesson1/samples/Empty.java");
+		assertTrue(invisibleProject.exists());
+
+		IPath workspaceRoot = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath javaFile = workspaceRoot.append("lesson1/samples/Empty.java");
+		String packageName = InvisibleProjectImporter.getPackageName(javaFile, workspaceRoot, JavaCore.create(invisibleProject));
+		assertEquals("samples", packageName);
+	}
+
+	@Test
+	public void getPackageNameInSrcEmptyFile() throws Exception {
+		File projectFolder = copyFiles("singlefile", true);
+		IProject invisibleProject = importRootFolder(projectFolder, "lesson1/src/main/java/demosamples/Empty1.java");
+		assertTrue(invisibleProject.exists());
+
+		IPath workspaceRoot = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath javaFile = workspaceRoot.append("lesson1/src/main/java/demosamples/Empty1.java");
+		String packageName = InvisibleProjectImporter.getPackageName(javaFile, workspaceRoot, JavaCore.create(invisibleProject));
+		assertEquals("main.java.demosamples", packageName);
+	}
+
+	@Test
+	public void getPackageName() throws Exception {
+		File projectFolder = copyFiles("singlefile", true);
+		IProject invisibleProject = importRootFolder(projectFolder, "Single.java");
+		assertTrue(invisibleProject.exists());
+
+		IPath workspaceRoot = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath javaFile = workspaceRoot.append("Single.java");
+		String packageName = InvisibleProjectImporter.getPackageName(javaFile, workspaceRoot, JavaCore.create(invisibleProject));
+		assertEquals("", packageName);
+	}
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fixes redhat-developer/vscode-java#750

Follow the priority below to infer the package name for an empty java file.
1. Try to search whether a nearby non-empty java file exists in the same directory. If so, use the nearby non-empty file to compute the package name.
2. Try to find whether the java file is under `src` folder. If so, compute the package name beginning from the `src` path.
3. Compute the relative path with the workspaceRoot and use that as the package name.