### PR TITLE
Signature help should select the 1st parameter after the opening round bracket

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java
@@ -68,7 +68,7 @@ public class SignatureHelpHandler {
 					for (int i = 0; i < infos.size(); i++) {
 						if (infos.get(i).getParameters().size() >= currentParameter + 1) {
 							help.setActiveSignature(i);
-							help.setActiveParameter(currentParameter);
+							help.setActiveParameter(currentParameter < 0 ? 0 : currentParameter);
 							break;
 						}
 					}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -89,6 +89,7 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals(help.getSignatures().size(), 1);
 		assertEquals(help.getSignatures().get(0).getLabel(), "foo(String s) : int");
 		assertTrue(help.getSignatures().get(0).getDocumentation().getLeft().length() > 0);
+		assertEquals(help.getActiveParameter(), (Integer) 0);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #947 

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>