### PR TITLE
Only enable preview flag if JVM supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.36.1 (April 1st, 2019)](https://github.com/eclipse/eclipse.jdt.ls/milestone/54?closed=1)
+* bug fix - Only enable the preview flag if the JVM supports it. See [#975](https://github.com/eclipse/eclipse.jdt.ls/pull/975).
+
 ## [0.36.0 (March 29th, 2019)](https://github.com/eclipse/eclipse.jdt.ls/milestone/53?closed=1)
 * enhancement - added "imports" folding support. See [#555](https://github.com/redhat-developer/vscode-java/issues/555).
 * enhancement - added UI to manage ambiguous imports. See [#673](https://github.com/redhat-developer/vscode-java/issues/673).

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.io.File;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.launching.StandardVMType;
+import org.eclipse.jdt.launching.AbstractVMInstall;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstallChangedListener;
+import org.eclipse.jdt.launching.IVMInstallType;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.PropertyChangeEvent;
+import org.eclipse.jdt.launching.VMStandin;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+
+/**
+ * Configures and listens to JVM changes.
+ *
+ * @author Fred Bricon
+ *
+ */
+public class JVMConfigurator implements IVMInstallChangedListener {
+
+	public static boolean configureDefaultVM(Preferences preferences) throws CoreException {
+		if (preferences == null) {
+			return false;
+		}
+		String javaHome = preferences.getJavaHome();
+		if (javaHome != null) {
+			File jvmHome = new File(javaHome);
+			if (jvmHome.isDirectory()) {
+				IVMInstall defaultVM = JavaRuntime.getDefaultVMInstall();
+				File location = defaultVM.getInstallLocation();
+				if (!location.equals(jvmHome)) {
+					IVMInstall vm = findVM(jvmHome);
+					if (vm == null) {
+						IVMInstallType installType = JavaRuntime.getVMInstallType(StandardVMType.ID_STANDARD_VM_TYPE);
+						long unique = System.currentTimeMillis();
+						while (installType.findVMInstall(String.valueOf(unique)) != null) {
+							unique++;
+						}
+						String vmId = String.valueOf(unique);
+						VMStandin vmStandin = new VMStandin(installType, vmId);
+						String name = StringUtils.defaultIfBlank(jvmHome.getName(), "JRE");
+						vmStandin.setName(name);
+						vmStandin.setInstallLocation(jvmHome);
+						vm = vmStandin.convertToRealVM();
+					}
+					JavaRuntime.setDefaultVMInstall(vm, new NullProgressMonitor());
+					JDTUtils.setCompatibleVMs(vm.getId());
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static IVMInstall findVM(File jvmHome) {
+		IVMInstallType[] types = JavaRuntime.getVMInstallTypes();
+		for (IVMInstallType type : types) {
+			IVMInstall[] installs = type.getVMInstalls();
+			for (IVMInstall install : installs) {
+				if (jvmHome.equals(install.getInstallLocation())) {
+					return install;
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void defaultVMInstallChanged(IVMInstall previous, IVMInstall current) {
+		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
+			if (!ProjectUtils.isVisibleProject(project) && ProjectUtils.isJavaProject(project)) {
+				IJavaProject javaProject = JavaCore.create(project);
+				configureJVMSettings(javaProject, current);
+			}
+		}
+	}
+
+	@Override
+	public void vmChanged(PropertyChangeEvent event) {
+	}
+
+	@Override
+	public void vmAdded(IVMInstall vm) {
+	}
+
+	@Override
+	public void vmRemoved(IVMInstall vm) {
+	}
+
+	public static void configureJVMSettings(IJavaProject javaProject) {
+		configureJVMSettings(javaProject, JavaRuntime.getDefaultVMInstall());
+	}
+
+	public static void configureJVMSettings(IJavaProject javaProject, IVMInstall vmInstall) {
+		if (javaProject == null) {
+			return;
+		}
+		long javaVersion = 0;
+		if (vmInstall instanceof AbstractVMInstall) {
+			AbstractVMInstall jvm = (AbstractVMInstall) vmInstall;
+			javaVersion = CompilerOptions.versionToJdkLevel(jvm.getJavaVersion());
+		}
+		if (javaVersion > ClassFileConstants.JDK11) {
+			//Enable Java 12+ preview features by default and stfu about it
+			javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+			javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+		} else {
+			javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.DISABLED);
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -12,6 +12,7 @@
 package org.eclipse.jdt.ls.core.internal.managers;
 
 import static java.util.Arrays.asList;
+import static org.eclipse.jdt.ls.core.internal.JVMConfigurator.configureJVMSettings;
 import static org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin.logInfo;
 
 import java.io.File;
@@ -376,10 +377,9 @@ public class ProjectsManager implements ISaveParticipant {
 		description = project.getDescription();
 		description.setNatureIds(new String[] { JavaCore.NATURE_ID });
 		project.setDescription(description, monitor);
+
 		IJavaProject javaProject = JavaCore.create(project);
-		//Enable Java 12+ preview features by default and stfu about it
-		javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-		javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+		configureJVMSettings(javaProject);
 
 		//Add build output folder
 		if (StringUtils.isNotBlank(bin)) {
@@ -639,4 +639,5 @@ public class ProjectsManager implements ISaveParticipant {
 		}
 		return null;
 	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JVMConfiguratorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JVMConfiguratorTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstallChangedListener;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Fred Bricon
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JVMConfiguratorTest extends AbstractProjectsManagerBasedTest {
+
+	private IVMInstall originalVm;
+
+	@Before
+	public void setup() {
+		originalVm = JavaRuntime.getDefaultVMInstall();
+	}
+
+	@Override
+	@After
+	public void cleanUp() throws CoreException {
+		JavaRuntime.setDefaultVMInstall(originalVm, new NullProgressMonitor());
+	}
+
+	@Test
+	public void testDefaultVM() throws CoreException {
+		Preferences prefs = new Preferences();
+		String javaHome = new File(TestVMType.getFakeJDKsLocation(), "9").getAbsolutePath();
+		prefs.setJavaHome(javaHome);
+		boolean changed = JVMConfigurator.configureDefaultVM(prefs);
+		IVMInstall newDefaultVM = JavaRuntime.getDefaultVMInstall();
+		assertTrue("A VM hasn't been changed", changed);
+		assertNotEquals(originalVm, newDefaultVM);
+		assertEquals("9", newDefaultVM.getId());
+	}
+
+	public void testPreviewFeatureSettings() throws Exception {
+
+		IVMInstallChangedListener jvmConfigurator = new JVMConfigurator();
+		try {
+			JavaRuntime.addVMInstallChangedListener(jvmConfigurator);
+			IJavaProject defaultProject = newDefaultProject();
+			IJavaProject randomProject = newEmptyProject();
+
+			assertEquals(JavaCore.DISABLED, defaultProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+			assertEquals(JavaCore.DISABLED, randomProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+
+			TestVMType.setTestJREAsDefault("12");
+
+			assertEquals(JavaCore.ENABLED, defaultProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+			assertEquals(JavaCore.ENABLED, randomProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+
+			TestVMType.setTestJREAsDefault("1.8");
+
+			assertEquals(JavaCore.DISABLED, defaultProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+			assertEquals(JavaCore.DISABLED, randomProject.getOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, false));
+
+		} finally {
+			JavaRuntime.removeVMInstallChangedListener(jvmConfigurator);
+		}
+
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -11,10 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
@@ -23,7 +20,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,10 +27,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.launching.IVMInstall;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
-import org.eclipse.jdt.ls.core.internal.TestVMType;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -89,25 +82,6 @@ public class JDTLanguageServerTest {
 	@After
 	public void tearDown() {
 		server.disconnectClient();
-	}
-
-	@Test
-	public void testDefaultVM() throws CoreException {
-		String oldJavaHome = prefManager.getPreferences().getJavaHome();
-		IVMInstall oldVm = JavaRuntime.getDefaultVMInstall();
-		assertNotNull(oldVm);
-		try {
-			String javaHome = new File(TestVMType.getFakeJDKsLocation(), "9").getAbsolutePath();
-			prefManager.getPreferences().setJavaHome(javaHome);
-			boolean changed = server.configureVM();
-			IVMInstall defaultVM = JavaRuntime.getDefaultVMInstall();
-			assertTrue("A VM hasn't been changed", changed);
-			assertNotEquals(oldVm, defaultVM);
-			assertEquals("9", defaultVM.getId());
-		} finally {
-			prefManager.getPreferences().setJavaHome(oldJavaHome);
-			TestVMType.setTestJREAsDefault("1.8");
-		}
 	}
 
 	@Test


### PR DESCRIPTION
Fixes regression where invisible projects always compile with Java 12 when the 
preview-feature flag is enabled. See redhat-developer/vscode-java#801