### PR TITLE
Fix jar detection on windows

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -213,6 +213,9 @@ public final class ResourceUtils {
 	}
 
 	public static boolean isContainedIn(IPath location, Collection<IPath> paths) {
+		if (location == null || paths == null || paths.isEmpty()) {
+			return false;
+		}
 		for (IPath path : paths) {
 			if (path.isPrefixOf(location)) {
 				return true;
@@ -232,6 +235,29 @@ public final class ResourceUtils {
 			return System.getProperty("user.home") + path.substring(1);
 		}
 		return path;
+	}
+
+	/**
+	 * Convert an {@link IPath} to a glob pattern (i.e. ending with /**)
+	 *
+	 * @param path
+	 *            the path to convert
+	 * @return a glob pattern prefixed with the path
+	 */
+	public static String toGlobPattern(IPath path) {
+		if (path == null) {
+			return null;
+		}
+		String globPattern = path.toPortableString();
+		if (path.getDevice() != null) {
+			//This seems pretty hack-ish: need to remove device as it seems to break
+			// file detection, at least on vscode
+			globPattern = globPattern.replace(path.getDevice(), "**");
+		}
+		if (!globPattern.endsWith("/")) {
+			globPattern += "/";
+		}
+		return globPattern + "**";
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ResourceUtilsTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.eclipse.jdt.ls.core.internal.ResourceUtils.toGlobPattern;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.core.runtime.Path;
+import org.junit.Test;
+
+public class ResourceUtilsTest {
+
+	@Test
+	public void testToGlobPattern() {
+		assertNull(toGlobPattern(null));
+		assertEquals("/foo/bar/**", toGlobPattern(Path.forPosix("/foo/bar")));
+		assertEquals("/foo/bar/**", toGlobPattern(Path.forPosix("/foo/bar/")));
+		assertEquals("**/foo/bar/**", toGlobPattern(Path.forWindows("c:/foo/bar/")));
+		assertEquals("**/foo/bar/**", toGlobPattern(Path.forWindows("c:\\foo\\bar")));
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -202,14 +202,14 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 			}
 		});
 		assertEquals("Unexpected watchers:\n" + toString(watchers), 8, watchers.size());
-		assertEquals(watchers.get(0).getGlobPattern(), "**/*.gradle");
-		assertEquals(watchers.get(1).getGlobPattern(), "**/*.java");
-		assertEquals(watchers.get(2).getGlobPattern(), "**/.classpath");
-		assertEquals(watchers.get(3).getGlobPattern(), "**/.project");
-		assertEquals(watchers.get(4).getGlobPattern(), "**/gradle.properties");
-		assertEquals(watchers.get(5).getGlobPattern(), "**/pom.xml");
-		assertEquals(watchers.get(6).getGlobPattern(), "**/settings/*.prefs");
-		assertEquals(watchers.get(7).getGlobPattern(), "**/src/**");
+		assertEquals("**/*.gradle", watchers.get(0).getGlobPattern());
+		assertEquals("**/*.java", watchers.get(1).getGlobPattern());
+		assertEquals("**/.classpath", watchers.get(2).getGlobPattern());
+		assertEquals("**/.project", watchers.get(3).getGlobPattern());
+		assertEquals("**/.settings/*.prefs", watchers.get(4).getGlobPattern());
+		assertEquals("**/gradle.properties", watchers.get(5).getGlobPattern());
+		assertEquals("**/pom.xml", watchers.get(6).getGlobPattern());
+		assertEquals("**/src/**", watchers.get(7).getGlobPattern());
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut");
 		String location = project.getLocation().toString();
 		IJavaProject javaProject = JavaCore.create(project);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
@@ -58,9 +58,19 @@ public abstract class AbstractInvisibleProjectBasedTest extends AbstractProjects
 	}
 
 	protected File createSourceFolderWithLibs(String name, boolean addLibs) throws Exception {
+		return createSourceFolderWithLibs(name, null, addLibs);
+	}
+
+	protected File createSourceFolderWithLibs(String name, String srcDir, boolean addLibs) throws Exception {
 		java.nio.file.Path projectPath = Files.createTempDirectory(name);
 		File projectFolder = projectPath.toFile();
-		FileUtils.copyDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/src"), projectFolder);
+		File sourceFolder;
+		if (org.apache.commons.lang3.StringUtils.isBlank(srcDir)) {
+			sourceFolder = projectFolder;
+		} else {
+			sourceFolder = new File(projectFolder, srcDir);
+		}
+		FileUtils.copyDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/src"), sourceFolder);
 		if (addLibs) {
 			addLibs(projectPath);
 		}


### PR DESCRIPTION
- don't create filewatcher with devices (prefix with ** instead of
device)
- fixed filewatcher on .settings/
- avoid generating overlapping filewatchers