### PR TITLE
Batch Maven project imports to reduce memory consumption

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
@@ -136,7 +136,11 @@ public final class JobHelpers {
 	}
 
 	private static void waitForBuildJobs() {
-		waitForJobs(BuildJobMatcher.INSTANCE, MAX_TIME_MILLIS);
+		waitForBuildJobs(MAX_TIME_MILLIS);
+	}
+
+	public static void waitForBuildJobs(int maxTimeMilis) {
+		waitForJobs(BuildJobMatcher.INSTANCE, maxTimeMilis);
 	}
 
 	public static void waitForInitializeJobs() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -13,6 +13,7 @@ package org.eclipse.jdt.ls.core.internal.managers;
 import java.io.File;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -42,6 +43,7 @@ import org.eclipse.m2e.core.embedder.MavenModelManager;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
 import org.eclipse.m2e.core.internal.preferences.ProblemSeverity;
+import org.eclipse.m2e.core.project.IMavenProjectImportResult;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.LocalProjectScanner;
 import org.eclipse.m2e.core.project.MavenProjectInfo;
@@ -49,6 +51,10 @@ import org.eclipse.m2e.core.project.ProjectImportConfiguration;
 
 @SuppressWarnings("restriction")
 public class MavenProjectImporter extends AbstractProjectImporter {
+
+	private static final int MAX_PROJECTS_TO_IMPORT = 50;
+
+	private static final long MAX_MEMORY = 1536 * 1024 * 1024; // 1.5g
 
 	public static final String IMPORTING_MAVEN_PROJECTS = "Importing Maven project(s)";
 
@@ -149,8 +155,36 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			}
 		}
 		if (!toImport.isEmpty()) {
-			ProjectImportConfiguration importConfig = new ProjectImportConfiguration();
-			configurationManager.importProjects(toImport, importConfig, subMonitor.split(75));
+			if (toImport.size() > MAX_PROJECTS_TO_IMPORT && Runtime.getRuntime().maxMemory() <= MAX_MEMORY) {
+				JavaLanguageServerPlugin.logInfo("Projects size:" + toImport.size());
+				Iterator<MavenProjectInfo> iter = toImport.iterator();
+				List<IMavenProjectImportResult> results = new ArrayList<>(MAX_PROJECTS_TO_IMPORT);
+				SubMonitor monitor2 = SubMonitor.convert(monitor, toImport.size() * 2);
+				int it = 1;
+				while (iter.hasNext()) {
+					int percent = Math.min(100, it++ * 100 * MAX_PROJECTS_TO_IMPORT / (toImport.size() + 1));
+					monitor2.setTaskName(percent + "% " + IMPORTING_MAVEN_PROJECTS);
+					List<MavenProjectInfo> importPartial = new ArrayList<>();
+					int i = 0;
+					while (i++ < MAX_PROJECTS_TO_IMPORT && iter.hasNext()) {
+						importPartial.add(iter.next());
+					}
+					ProjectImportConfiguration importConfig = new ProjectImportConfiguration();
+					List<IMavenProjectImportResult> result = configurationManager.importProjects(importPartial, importConfig, monitor2.split(MAX_PROJECTS_TO_IMPORT));
+					results.addAll(result);
+					monitor2.setWorkRemaining(toImport.size() * 2 - it * MAX_PROJECTS_TO_IMPORT);
+				}
+				List<IProject> imported = new ArrayList<>(results.size());
+				for (IMavenProjectImportResult result : results) {
+					imported.add(result.getProject());
+				}
+				monitor2.setTaskName("Updating Maven project(s)");
+				updateProjects(imported, lastWorkspaceStateSaved, monitor2.split(projects.size()));
+				monitor2.done();
+			} else {
+				ProjectImportConfiguration importConfig = new ProjectImportConfiguration();
+				configurationManager.importProjects(toImport, importConfig, subMonitor.split(75));
+			}
 		}
 		subMonitor.setWorkRemaining(20);
 		updateProjects(projects, lastWorkspaceStateSaved, subMonitor.split(20));


### PR DESCRIPTION
Fixes #982 

Projects: 
- https://github.com/spring-projects/spring-boot
- https://github.com/apache/incubator-dubbo
- https://github.com/apache/incubator-druid
- https://github.com/eclipse/che

Test cases:
- import the 1st time (no existing workspace, empty maven repository, 1GB)
- import the 1st time (no existing workspace, empty maven repository, 2GB)
- import the 1st time (no existing workspace, full maven repository, 1GB)
- import the 1st time (no existing workspace, full maven repository, 2GB)
- reopen the same folder (existing workspace, full maven repository, 1GB)
- reopen the same folder (existing workspace, full maven repository, 2GB)

vsix: https://raw.githubusercontent.com/snjeza/vscode-test/master/java-0.43.2.vsix

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>