### PR TITLE
Use proper symbols for interfaces, enums, enum values and constants

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -50,12 +51,16 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	// @formatter:off
 	public static final Set<CompletionItemKind> SUPPORTED_KINDS = ImmutableSet.of(CompletionItemKind.Constructor,
 																				CompletionItemKind.Class,
+																				CompletionItemKind.Constant,
+																				CompletionItemKind.Interface,
+																				CompletionItemKind.Enum,
+																				CompletionItemKind.EnumMember,
 																				CompletionItemKind.Module,
 																				CompletionItemKind.Field,
 																				CompletionItemKind.Keyword,
 																				CompletionItemKind.Reference,
 																				CompletionItemKind.Variable,
-																				CompletionItemKind.Function,
+																				CompletionItemKind.Method,
 																				CompletionItemKind.Text);
 	// @formatter:on
 
@@ -116,7 +121,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 	public CompletionItem toCompletionItem(CompletionProposal proposal, int index) {
 		final CompletionItem $ = new CompletionItem();
-		$.setKind(mapKind(proposal.getKind()));
+		$.setKind(mapKind(proposal));
 		Map<String, String> data = new HashMap<>();
 		// append data field so that resolve request can use it.
 		data.put(CompletionResolveHandler.DATA_FIELD_URI, JDTUtils.toURI(unit));
@@ -137,22 +142,38 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	}
 
 
-	private CompletionItemKind mapKind(final int kind) {
+	private CompletionItemKind mapKind(final CompletionProposal proposal) {
 		//When a new CompletionItemKind is added, don't forget to update SUPPORTED_KINDS
+		int kind = proposal.getKind();
+		int flags = proposal.getFlags();
 		switch (kind) {
 		case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
 		case CompletionProposal.CONSTRUCTOR_INVOCATION:
 			return CompletionItemKind.Constructor;
 		case CompletionProposal.ANONYMOUS_CLASS_DECLARATION:
 		case CompletionProposal.TYPE_REF:
+			if (Flags.isInterface(flags)) {
+				return CompletionItemKind.Interface;
+			} else if (Flags.isEnum(flags)) {
+				return CompletionItemKind.Enum;
+			}
 			return CompletionItemKind.Class;
 		case CompletionProposal.FIELD_IMPORT:
 		case CompletionProposal.METHOD_IMPORT:
 		case CompletionProposal.METHOD_NAME_REFERENCE:
 		case CompletionProposal.PACKAGE_REF:
 		case CompletionProposal.TYPE_IMPORT:
+		case CompletionProposal.MODULE_DECLARATION:
+		case CompletionProposal.MODULE_REF:
 			return CompletionItemKind.Module;
 		case CompletionProposal.FIELD_REF:
+			if (Flags.isEnum(flags)) {
+				return CompletionItemKind.EnumMember;
+			}
+			if (Flags.isStatic(flags) && Flags.isFinal(flags)) {
+				return CompletionItemKind.Constant;
+			}
+			return CompletionItemKind.Field;
 		case CompletionProposal.FIELD_REF_WITH_CASTED_RECEIVER:
 			return CompletionItemKind.Field;
 		case CompletionProposal.KEYWORD:
@@ -166,7 +187,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		case CompletionProposal.METHOD_REF:
 		case CompletionProposal.METHOD_REF_WITH_CASTED_RECEIVER:
 		case CompletionProposal.POTENTIAL_METHOD_DECLARATION:
-			return CompletionItemKind.Function;
+			return CompletionItemKind.Method;
 			//text
 		case CompletionProposal.ANNOTATION_ATTRIBUTE_REF:
 		case CompletionProposal.JAVADOC_BLOCK_TAG:

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/Bar.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/Bar.java
@@ -18,4 +18,11 @@ public class Bar {
 		
 		void bar() {}
 	}
+	
+	public static final String EMPTY = "";
+	
+	
+	public enum Foo {
+		Bar, Zoo
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -460,7 +460,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		// Check completion item
 		assertEquals("SECONDS", secondsFieldItem.getInsertText());
 		assertEquals("SECONDS : TimeUnit", secondsFieldItem.getLabel());
-		assertEquals(CompletionItemKind.Field, secondsFieldItem.getKind());
+		assertEquals(CompletionItemKind.EnumMember, secondsFieldItem.getKind());
 		assertEquals("999999210", secondsFieldItem.getSortText());
 		assertNull(secondsFieldItem.getTextEdit());
 
@@ -521,7 +521,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(ci);
 
 		assertEquals("put", ci.getInsertText());
-		assertEquals(CompletionItemKind.Function, ci.getKind());
+		assertEquals(CompletionItemKind.Method, ci.getKind());
 		assertEquals("999999019", ci.getSortText());
 		assertNull(ci.getTextEdit());
 
@@ -556,7 +556,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(ci);
 
 		assertEquals("put", ci.getInsertText());
-		assertEquals(CompletionItemKind.Function, ci.getKind());
+		assertEquals(CompletionItemKind.Method, ci.getKind());
 		assertEquals("999999019", ci.getSortText());
 		assertNull(ci.getTextEdit());
 
@@ -606,7 +606,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci);
 
 			assertEquals("test", ci.getInsertText());
-			assertEquals(CompletionItemKind.Function, ci.getKind());
+			assertEquals(CompletionItemKind.Method, ci.getKind());
 			assertEquals("999999163", ci.getSortText());
 			assertNull(ci.getTextEdit());
 
@@ -641,7 +641,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci);
 
 			assertEquals("test", ci.getInsertText());
-			assertEquals(CompletionItemKind.Function, ci.getKind());
+			assertEquals(CompletionItemKind.Method, ci.getKind());
 			assertEquals("999999163", ci.getSortText());
 			assertNull(ci.getTextEdit());
 
@@ -677,7 +677,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci);
 
 			assertEquals("test", ci.getInsertText());
-			assertEquals(CompletionItemKind.Function, ci.getKind());
+			assertEquals(CompletionItemKind.Method, ci.getKind());
 			assertEquals("999999163", ci.getSortText());
 			assertNull(ci.getTextEdit());
 
@@ -780,7 +780,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		assertEquals(1, list.getItems().size());
 		CompletionItem item = list.getItems().get(0);
-		assertEquals(CompletionItemKind.Class, item.getKind());
+		assertEquals(CompletionItemKind.Interface, item.getKind());
 		assertEquals("Map", item.getInsertText());
 		assertNull(item.getAdditionalTextEdits());
 		assertNull(item.getTextEdit());
@@ -1282,7 +1282,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(ci);
 
 		assertEquals("getStrField", ci.getInsertText());
-		assertEquals(CompletionItemKind.Function, ci.getKind());
+		assertEquals(CompletionItemKind.Method, ci.getKind());
 		assertEquals("999999979", ci.getSortText());
 		assertNull(ci.getTextEdit());
 
@@ -1317,7 +1317,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(ci);
 
 		assertEquals("isBoolField", ci.getInsertText());
-		assertEquals(CompletionItemKind.Function, ci.getKind());
+		assertEquals(CompletionItemKind.Method, ci.getKind());
 		assertEquals("999999979", ci.getSortText());
 		assertNull(ci.getTextEdit());
 
@@ -1351,7 +1351,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(ci);
 
 		assertEquals("setStrField", ci.getInsertText());
-		assertEquals(CompletionItemKind.Function, ci.getKind());
+		assertEquals(CompletionItemKind.Method, ci.getKind());
 		assertEquals("999999979", ci.getSortText());
 		assertNull(ci.getTextEdit());
 
@@ -2043,7 +2043,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 					"    public void foo(int x) {\n" + // conflicting method, no static import possible
 					"    }\n" +
 					"}\n");
-				//@formatter:on
+		//@formatter:on
 
 		int[] loc = findCompletionLocation(unit, "/* */fo");
 		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
@@ -2115,6 +2115,49 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("toString() : String", ci.getLabel());
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
 		assertNull(resolvedItem.getAdditionalTextEdits());
+	}
+
+	@Test
+	public void testCompletion_Enum() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
+		//@formatter:off
+				"package org.sample;\n"
+			+	"public class Test {\n\n"
+			+   "   enum Zenum{A,B}\n"
+			+	"	void test() {\n\n"
+			+	"      Zenu\n"
+			+	"	}\n"
+			+	"}\n");
+		//@formatter:on
+		int[] loc = findCompletionLocation(unit, "   Zenu");
+
+		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+		assertNotNull(list);
+		assertEquals(1, list.getItems().size());
+		CompletionItem item = list.getItems().get(0);
+		assertEquals(CompletionItemKind.Enum, item.getKind());
+		assertEquals("Zenum", item.getInsertText());
+	}
+
+	@Test
+	public void testCompletion_Constant() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
+		//@formatter:off
+				"package org.sample;\n"
+			+	"public class Test {\n\n"
+			+	"	void test() {\n\n"
+			+	"		char c = java.io.File.pathSeparatorC \n"
+			+	"	}\n"
+			+	"}\n");
+		//@formatter:on
+		int[] loc = findCompletionLocation(unit, "pathSeparatorC");
+
+		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+		assertNotNull(list);
+		assertEquals(1, list.getItems().size());
+		CompletionItem item = list.getItems().get(0);
+		assertEquals(CompletionItemKind.Constant, item.getKind());
+		assertEquals("pathSeparatorChar", item.getInsertText());
 	}
 
 	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandlerTest.java
@@ -135,6 +135,11 @@ public class DocumentSymbolHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertHasSymbol("foo()", "MyInterface", SymbolKind.Method, symbols);
 		assertHasSymbol("MyClass", "Bar", SymbolKind.Class, symbols);
 		assertHasSymbol("bar()", "MyClass", SymbolKind.Method, symbols);
+		assertHasSymbol("Foo", "Bar", SymbolKind.Enum, symbols);
+		assertHasSymbol("Bar", "Foo", SymbolKind.EnumMember, symbols);
+		assertHasSymbol("Zoo", "Foo", SymbolKind.EnumMember, symbols);
+		assertHasSymbol("EMPTY", "Bar", SymbolKind.Constant, symbols);
+
 	}
 
 	@Test


### PR DESCRIPTION
One noticeable change is that, for methods, we no longer return
CompletionItemKind.Function but CompletionItemKind.Method instead.

Fixes #1012