### PR TITLE
Use user settings to control generating comments for getter and setter

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
@@ -43,15 +43,16 @@ import org.eclipse.text.edits.TextEdit;
 
 public class GenerateGetterSetterOperation {
 	private final static int generateVisibility = Modifier.PUBLIC;
-	private final static boolean generateComments = true;
 
 	private final IType type;
 	private CompilationUnit astRoot;
+	private boolean generateComments = true;
 
-	public GenerateGetterSetterOperation(IType type, CompilationUnit astRoot) {
+	public GenerateGetterSetterOperation(IType type, CompilationUnit astRoot, boolean generateComments) {
 		Assert.isNotNull(type);
 		this.type = type;
 		this.astRoot = astRoot;
+		this.generateComments = generateComments;
 	}
 
 	public static boolean supportsGetterSetter(IType type) throws JavaModelException {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GetterSetterCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GetterSetterCorrectionSubProcessor.java
@@ -51,6 +51,7 @@ import org.eclipse.jdt.ls.core.internal.corext.refactoring.RefactoringAvailabili
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.sef.SelfEncapsulateFieldRefactoring;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.ltk.core.refactoring.Change;
 
@@ -83,8 +84,10 @@ public class GetterSetterCorrectionSubProcessor {
 		public static Change getRefactoringChange(IField field) {
 			SelfEncapsulateFieldRefactoring refactoring;
 			try {
+				Preferences preferences = JavaLanguageServerPlugin.getPreferencesManager().getPreferences();
 				refactoring = new SelfEncapsulateFieldRefactoring(field);
 
+				refactoring.setGenerateJavadoc(preferences.isCodeGenerationTemplateGenerateComments());
 				refactoring.setVisibility(Flags.AccPublic);
 				refactoring.setConsiderVisibility(false);//private field references are just searched in local file
 				refactoring.checkInitialConditions(new NullProgressMonitor());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.GenerateGetterSetterOperation;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.GenerateGetterSetterOperation.AccessorField;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -44,17 +45,18 @@ public class GenerateAccessorsHandler {
 			return null;
 		}
 
-		TextEdit edit = generateAccessors(type, params.accessors);
+		Preferences preferences = JavaLanguageServerPlugin.getPreferencesManager().getPreferences();
+		TextEdit edit = generateAccessors(type, params.accessors, preferences.isCodeGenerationTemplateGenerateComments());
 		return (edit == null) ? null : SourceAssistProcessor.convertToWorkspaceEdit(type.getCompilationUnit(), edit);
 	}
 
-	public static TextEdit generateAccessors(IType type, AccessorField[] accessors) {
+	public static TextEdit generateAccessors(IType type, AccessorField[] accessors, boolean generateComments) {
 		if (type == null || type.getCompilationUnit() == null) {
 			return null;
 		}
 
 		try {
-			GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, null);
+			GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, null, generateComments);
 			return operation.createTextEdit(null, accessors);
 		} catch (OperationCanceledException | CoreException e) {
 			JavaLanguageServerPlugin.logException("Failed to generate the accessors.", e);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -196,7 +196,7 @@ public class SourceAssistProcessor {
 			if (accessors == null || accessors.length == 0) {
 				return Optional.empty();
 			} else if (accessors.length == 1 || !preferenceManager.getClientPreferences().isAdvancedGenerateAccessorsSupported()) {
-				GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, context.getASTRoot());
+				GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, context.getASTRoot(), preferenceManager.getPreferences().isCodeGenerationTemplateGenerateComments());
 				TextEdit edit = operation.createTextEdit(null, accessors);
 				return convertToWorkspaceEditAction(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateGetterSetterAction_label, JavaCodeActionKind.SOURCE_GENERATE_ACCESSORS, edit);
 			} else {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterAndSetterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterAndSetterTest.java
@@ -33,13 +33,21 @@ import org.junit.Test;
 public class GenerateGetterAndSetterTest extends AbstractSourceTestCase {
 
 	private void runAndApplyOperation(IType type) throws OperationCanceledException, CoreException, MalformedTreeException, BadLocationException {
-		TextEdit edit = runOperation(type);
+		runAndApplyOperation(type, true);
+	}
+
+	private TextEdit runOperation(IType type) throws OperationCanceledException, CoreException {
+		return runOperation(type, true);
+	}
+
+	private void runAndApplyOperation(IType type, boolean generateComments) throws OperationCanceledException, CoreException, MalformedTreeException, BadLocationException {
+		TextEdit edit = runOperation(type, generateComments);
 		ICompilationUnit unit = type.getCompilationUnit();
 		JavaModelUtil.applyEdit(unit, edit, true, null);
 	}
 
-	private TextEdit runOperation(IType type) throws OperationCanceledException, CoreException {
-		GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, null);
+	private TextEdit runOperation(IType type, boolean generateComments) throws OperationCanceledException, CoreException {
+		GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, null, generateComments);
 		return operation.createTextEdit(null);
 	}
 
@@ -578,6 +586,29 @@ public class GenerateGetterAndSetterTest extends AbstractSourceTestCase {
 						"	 */\r\n" +
 						"	public static void setField1(String field1) {\r\n" +
 						"		A.field1 = field1;\r\n" +
+						"	}\r\n" +
+						"}";
+		/* @formatter:on */
+
+		compareSource(expected, fClassA.getSource());
+	}
+
+	@Test
+	public void testWithoutGeneratingComments() throws Exception {
+		IField field1 = fClassA.createField("String field1;", null, false, new NullProgressMonitor());
+		runAndApplyOperation(fClassA, false);
+
+		/* @formatter:off */
+		String expected= "public class A {\r\n" +
+						"\r\n" +
+						"	String field1;\r\n" +
+						"\r\n" +
+						"	public String getField1() {\r\n" +
+						"		return field1;\r\n" +
+						"	}\r\n" +
+						"\r\n" +
+						"	public void setField1(String field1) {\r\n" +
+						"		this.field1 = field1;\r\n" +
 						"	}\r\n" +
 						"}";
 		/* @formatter:on */

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandlerTest.java
@@ -144,7 +144,7 @@ public class GenerateAccessorsHandlerTest extends AbstractSourceTestCase {
 
 	private void generateAccessors(IType type) throws ValidateEditException, CoreException {
 		AccessorField[] accessors = GenerateAccessorsHandler.getUnimplementedAccessors(type);
-		TextEdit edit = GenerateAccessorsHandler.generateAccessors(type, accessors);
+		TextEdit edit = GenerateAccessorsHandler.generateAccessors(type, accessors, true);
 		assertNotNull(edit);
 		JavaModelUtil.applyEdit(type.getCompilationUnit(), edit, true, null);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -116,6 +116,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		Platform.addLogListener(logListener);
 		preferences = new Preferences();
 		preferences.setRootPaths(Collections.singleton(new Path(getWorkingProjectDirectory().getAbsolutePath())));
+		preferences.setCodeGenerationTemplateGenerateComments(true);
 		if (preferenceManager == null) {
 			preferenceManager = mock(PreferenceManager.class);
 		}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

In the quick fix and source action for getter and setter, reuse the global user settings to control whether generating JavaDoc.

Relates to #872