### PR TITLE
HashCodeEqualsHandlerTest.testGenerateHashCodeEquals_useInstanceof() fails

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
@@ -264,8 +264,6 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	public boolean equals(Object obj) {\r\n" +
 				"		if (this == obj)\r\n" +
 				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
 				"		if (!(obj instanceof B))\r\n" +
 				"			return false;\r\n" +
 				"		B other = (B) obj;\r\n" +


### PR DESCRIPTION
Fixes #1047 

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>