### PR TITLE
Modified to use WorkspaceEdit on OrganizeImports.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -168,8 +168,12 @@ public class CodeActionHandler {
 			// TODO: Should set WorkspaceEdit directly instead of Command
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(proposal.getKind());
-			codeAction.setCommand(command);
 			codeAction.setDiagnostics(context.getDiagnostics());
+			if (preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported()) {
+				codeAction.setEdit(edit);
+			} else {
+				codeAction.setCommand(command);
+			}
 			return Optional.of(Either.forRight(codeAction));
 		} else {
 			return Optional.of(Either.forLeft(command));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -149,7 +149,9 @@ public class CodeActionHandler {
 	private Optional<Either<Command, CodeAction>> getCodeActionFromProposal(ChangeCorrectionProposal proposal, CodeActionContext context) throws CoreException {
 		String name = proposal.getName();
 
-		Command command;
+		Command command = null;
+		WorkspaceEdit edit = null;
+		boolean useWorkspaceEdit = preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported();
 		if (proposal instanceof CUCorrectionCommandProposal) {
 			CUCorrectionCommandProposal commandProposal = (CUCorrectionCommandProposal) proposal;
 			command = new Command(name, commandProposal.getCommand(), commandProposal.getCommandArguments());
@@ -157,19 +159,20 @@ public class CodeActionHandler {
 			RefactoringCorrectionCommandProposal commandProposal = (RefactoringCorrectionCommandProposal) proposal;
 			command = new Command(name, commandProposal.getCommand(), commandProposal.getCommandArguments());
 		} else {
-			WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(proposal.getChange());
+			edit = ChangeUtil.convertToWorkspaceEdit(proposal.getChange());
 			if (!ChangeUtil.hasChanges(edit)) {
 				return Optional.empty();
 			}
-			command = new Command(name, COMMAND_ID_APPLY_EDIT, Collections.singletonList(edit));
+			if (!useWorkspaceEdit) {
+				command = new Command(name, COMMAND_ID_APPLY_EDIT, Collections.singletonList(edit));
+			}
 		}
 
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(proposal.getKind())) {
-			// TODO: Should set WorkspaceEdit directly instead of Command
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(proposal.getKind());
 			codeAction.setDiagnostics(context.getDiagnostics());
-			if (preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported()) {
+			if (useWorkspaceEdit) {
 				codeAction.setEdit(edit);
 			} else {
 				codeAction.setCommand(command);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -179,10 +179,18 @@ public class SourceAssistProcessor {
 	}
 
 	private Optional<Either<Command, CodeAction>> getOrganizeImportsAction(CodeActionParams params) {
-		Command command = new Command(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description, COMMAND_ID_ACTION_ORGANIZEIMPORTS, Collections.singletonList(params));
 		CodeAction codeAction = new CodeAction(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description);
 		codeAction.setKind(CodeActionKind.SourceOrganizeImports);
-		codeAction.setCommand(command);
+		if (preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported()) {
+			final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
+			final IInvocationContext context = getInnovationContext(params);
+			final TextEdit edit = getOrganizeImportsProposal(context);
+			final WorkspaceEdit workspaceEdit = convertToWorkspaceEdit(unit, edit);
+			codeAction.setEdit(workspaceEdit);
+		} else {
+			Command command = new Command(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description, COMMAND_ID_ACTION_ORGANIZEIMPORTS, Collections.singletonList(params));
+			codeAction.setCommand(command);
+		}
 		codeAction.setDiagnostics(Collections.EMPTY_LIST);
 		return Optional.of(Either.forRight(codeAction));
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -179,18 +179,10 @@ public class SourceAssistProcessor {
 	}
 
 	private Optional<Either<Command, CodeAction>> getOrganizeImportsAction(CodeActionParams params) {
+		Command command = new Command(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description, COMMAND_ID_ACTION_ORGANIZEIMPORTS, Collections.singletonList(params));
 		CodeAction codeAction = new CodeAction(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description);
 		codeAction.setKind(CodeActionKind.SourceOrganizeImports);
-		if (preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported()) {
-			final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
-			final IInvocationContext context = getInnovationContext(params);
-			final TextEdit edit = getOrganizeImportsProposal(context);
-			final WorkspaceEdit workspaceEdit = convertToWorkspaceEdit(unit, edit);
-			codeAction.setEdit(workspaceEdit);
-		} else {
-			Command command = new Command(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description, COMMAND_ID_ACTION_ORGANIZEIMPORTS, Collections.singletonList(params));
-			codeAction.setCommand(command);
-		}
+		codeAction.setCommand(command);
 		codeAction.setDiagnostics(Collections.EMPTY_LIST);
 		return Optional.of(Either.forRight(codeAction));
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -352,7 +352,11 @@ public class SourceAssistProcessor {
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(kind)) {
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(kind);
-			codeAction.setCommand(command);
+			if (preferenceManager.getClientPreferences().isWorkspaceApplyEditSupported()) {
+				codeAction.setEdit(workspaceEdit);
+			} else {
+				codeAction.setCommand(command);
+			}
 			codeAction.setDiagnostics(context.getDiagnostics());
 			return Optional.of(Either.forRight(codeAction));
 		} else {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerUseWorkspaceEditTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerUseWorkspaceEditTest.java
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2019 mikoto2000 and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     mikoto2000 - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
+import org.eclipse.jdt.ls.core.internal.LanguageServerWorkingCopyOwner;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Gorkem Ercan
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CodeActionHandlerUseWorkspaceEditTest extends AbstractCompilationUnitBasedTest {
+
+	@Mock
+	private JavaClientConnection connection;
+
+
+	@Override
+	@Before
+	public void setup() throws Exception{
+		importProjects("eclipse/hello");
+		project = WorkspaceHelper.getProject("hello");
+		wcOwner = new LanguageServerWorkingCopyOwner(connection);
+		server = new JDTLanguageServer(projectsManager, this.preferenceManager);
+	}
+
+	@Test
+	public void testCodeAction_removeUnusedImport() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"import java.sql.*; \n" +
+						"public class Foo {\n"+
+						"	void foo() {\n"+
+						"	}\n"+
+				"}\n");
+
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, "java.sql");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnusedImport), range))));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertTrue(codeActions.size() >= 3);
+		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
+		Assert.assertEquals(codeActions.get(1).getRight().getKind(), CodeActionKind.QuickFix);
+		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
+		WorkspaceEdit w = codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(w);
+	}
+
+	@Test
+	public void testCodeAction_removeUnterminatedString() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						"String s = \"some str\n" +
+						"	}\n"+
+				"}\n");
+
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, "some str");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnterminatedString), range))));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertFalse(codeActions.isEmpty());
+		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
+		WorkspaceEdit w = codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(w);
+	}
+
+	@Test
+	public void testCodeAction_exception() throws JavaModelException {
+		URI uri = project.getFile("nopackage/Test.java").getRawLocationURI();
+		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
+		try {
+			cu.becomeWorkingCopy(new NullProgressMonitor());
+			CodeActionParams params = new CodeActionParams();
+			params.setTextDocument(new TextDocumentIdentifier(uri.toString()));
+			final Range range = new Range();
+			range.setStart(new Position(0, 17));
+			range.setEnd(new Position(0, 17));
+			params.setRange(range);
+			CodeActionContext context = new CodeActionContext();
+			context.setDiagnostics(Collections.emptyList());
+			params.setContext(context);
+			List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+			Assert.assertNotNull(codeActions);
+		} finally {
+			cu.discardWorkingCopy();
+		}
+	}
+
+	@Test
+	@Ignore
+	public void testCodeAction_superfluousSemicolon() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						";" +
+						"	}\n"+
+				"}\n");
+
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, ";");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.SuperfluousSemicolon), range))));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertEquals(1, codeActions.size());
+		Assert.assertEquals(codeActions.get(0), CodeActionKind.QuickFix);
+		Command c = getCommand(codeActions.get(0));
+		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
+		Assert.assertNotNull(c.getArguments());
+		Assert.assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
+		WorkspaceEdit we = (WorkspaceEdit) c.getArguments().get(0);
+		List<org.eclipse.lsp4j.TextEdit> edits = we.getChanges().get(JDTUtils.toURI(unit));
+		Assert.assertEquals(1, edits.size());
+		Assert.assertEquals("", edits.get(0).getNewText());
+		Assert.assertEquals(range, edits.get(0).getRange());
+	}
+
+	@Test
+	public void test_noUnnecessaryCodeActions() throws Exception{
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+				"src/org/sample/Foo.java",
+				"package org.sample;\n"+
+				"\n"+
+				"public class Foo {\n"+
+				"	private String foo;\n"+
+				"	public String getFoo() {\n"+
+				"	  return foo;\n"+
+				"	}\n"+
+				"   \n"+
+				"	public void setFoo(String newFoo) {\n"+
+				"	  foo = newFoo;\n"+
+				"	}\n"+
+				"}\n");
+		//@formatter:on
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, "String foo;");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Collections.emptyList()));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertFalse("No need for organize imports action", containsKind(codeActions, CodeActionKind.SourceOrganizeImports));
+		Assert.assertFalse("No need for generate getter and setter action", containsKind(codeActions, JavaCodeActionKind.SOURCE_GENERATE_ACCESSORS));
+	}
+
+	private List<Either<Command, CodeAction>> getCodeActions(CodeActionParams params) {
+		return server.codeAction(params).join();
+	}
+
+	public static Command getCommand(Either<Command, CodeAction> codeAction) {
+		return codeAction.isLeft() ? codeAction.getLeft() : codeAction.getRight().getCommand();
+	}
+
+	private Diagnostic getDiagnostic(String code, Range range){
+		Diagnostic $ = new Diagnostic();
+		$.setCode(code);
+		$.setRange(range);
+		$.setSeverity(DiagnosticSeverity.Error);
+		$.setMessage("Test Diagnostic");
+		return $;
+	}
+
+	public static boolean containsKind(List<Either<Command, CodeAction>> codeActions, String kind) {
+		for (Either<Command, CodeAction> action : codeActions) {
+			String actionKind = action.getLeft() == null ? action.getRight().getKind() : action.getLeft().getCommand();
+			if (Objects.equals(actionKind, kind)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected ClientPreferences initPreferenceManager(boolean supportClassFileContents) {
+		PreferenceManager.initialize();
+		when(preferenceManager.getPreferences()).thenReturn(preferences);
+		when(preferenceManager.getPreferences(any())).thenReturn(preferences);
+		when(preferenceManager.isClientSupportsClassFileContent()).thenReturn(supportClassFileContents);
+		ClientPreferences clientPreferences = mock(ClientPreferences.class);
+		when(clientPreferences.isProgressReportSupported()).thenReturn(true);
+		when(clientPreferences.isSemanticHighlightingSupported()).thenReturn(true);
+		when(preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
+		when(clientPreferences.isSupportedCodeActionKind(anyString())).thenReturn(true);
+		when(clientPreferences.isOverrideMethodsPromptSupported()).thenReturn(true);
+		when(clientPreferences.isHashCodeEqualsPromptSupported()).thenReturn(true);
+		when(clientPreferences.isGenerateToStringPromptSupported()).thenReturn(true);
+		when(clientPreferences.isAdvancedGenerateAccessorsSupported()).thenReturn(true);
+		when(clientPreferences.isGenerateConstructorsPromptSupported()).thenReturn(true);
+		when(clientPreferences.isGenerateDelegateMethodsPromptSupported()).thenReturn(true);
+		when(clientPreferences.isWorkspaceApplyEditSupported()).thenReturn(true);
+		return clientPreferences;
+	}
+}


### PR DESCRIPTION
This PR is part of #376.

Modified to use WorkspaceEdit on OrganizeImports if client supported `workspace/applyEdit`.

Needed those client capabilities and initialization parameters for use WorkspaceEdit.

- kind: `quickfix`
    - `workspace/applyEdit` is `true`
    - `textDocument/codeAction/codeActionLiteralSupport/codeActionKind/valueSet` contains `quickfix`
- kind: `source.organizeImports`
    - `workspace/applyEdit` is `true`
    - `initializationOptions/extendedClientCapabilities/advancedOrganizeImportsSupport` is `true`
