### PR TITLE
Cancel init or update workspace job of removed rootPaths

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -264,11 +264,11 @@ final public class InitHandler {
 			@Override
 			public boolean belongsTo(Object family) {
 				Collection<IPath> rootPathsSet = roots.stream().collect(Collectors.toSet());
-				boolean equalToRootpaths = false;
+				boolean equalToRootPaths = false;
 				if (family instanceof Collection<?>) {
-					equalToRootpaths = rootPathsSet.equals(((Collection<IPath>) family).stream().collect(Collectors.toSet()));
+					equalToRootPaths = rootPathsSet.equals(((Collection<IPath>) family).stream().collect(Collectors.toSet()));
 				}
-				return JAVA_LS_INITIALIZATION_JOBS.equals(family) || equalToRootpaths;
+				return JAVA_LS_INITIALIZATION_JOBS.equals(family) || equalToRootPaths;
 			}
 
 		};

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
@@ -259,9 +260,15 @@ final public class InitHandler {
 			/* (non-Javadoc)
 			 * @see org.eclipse.core.runtime.jobs.Job#belongsTo(java.lang.Object)
 			 */
+			@SuppressWarnings("unchecked")
 			@Override
 			public boolean belongsTo(Object family) {
-				return JAVA_LS_INITIALIZATION_JOBS.equals(family) || roots.equals(family);
+				Collection<IPath> rootPathsSet = roots.stream().collect(Collectors.toSet());
+				boolean equalToRootpaths = false;
+				if (family instanceof Collection<?>) {
+					equalToRootpaths = rootPathsSet.equals(((Collection<IPath>) family).stream().collect(Collectors.toSet()));
+				}
+				return JAVA_LS_INITIALIZATION_JOBS.equals(family) || equalToRootpaths;
 			}
 
 		};

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -260,7 +260,7 @@ final public class InitHandler {
 			 */
 			@Override
 			public boolean belongsTo(Object family) {
-				return JAVA_LS_INITIALIZATION_JOBS.equals(family);
+				return JAVA_LS_INITIALIZATION_JOBS.equals(family) || roots.equals(family);
 			}
 
 		};

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -248,6 +248,7 @@ final public class InitHandler {
 					connection.sendStatus(ServiceStatus.Started, "Ready");
 				} catch (OperationCanceledException e) {
 					connection.sendStatus(ServiceStatus.Error, "Initialization has been cancelled.");
+					return Status.CANCEL_STATUS;
 				} catch (Exception e) {
 					JavaLanguageServerPlugin.logException("Initialization failed ", e);
 					connection.sendStatus(ServiceStatus.Error, e.getMessage());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -155,7 +155,7 @@ public class ProjectsManager implements ISaveParticipant {
 
 			@Override
 			public boolean belongsTo(Object family) {
-				return IConstants.UPDATE_WORKSPACE_FOLDERS_FAMILY.equals(family) || IConstants.JOBS_FAMILY.equals(family);
+				return IConstants.UPDATE_WORKSPACE_FOLDERS_FAMILY.equals(family) || IConstants.JOBS_FAMILY.equals(family) || addedRootPaths.equals(family);
 			}
 
 			@Override
@@ -165,6 +165,11 @@ public class ProjectsManager implements ISaveParticipant {
 				try {
 					long start = System.currentTimeMillis();
 					IProject[] projects = getWorkspaceRoot().getProjects();
+					for (Job initOrUpdateJob : Job.getJobManager().find(removedRootPaths)) {
+						if (initOrUpdateJob != null) {
+							initOrUpdateJob.cancel();
+						}
+					}
 					for (IProject project : projects) {
 						if (ResourceUtils.isContainedIn(project.getLocation(), removedRootPaths)) {
 							try {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -164,11 +164,11 @@ public class ProjectsManager implements ISaveParticipant {
 			@Override
 			public boolean belongsTo(Object family) {
 				Collection<IPath> addedRootPathsSet = addedRootPaths.stream().collect(Collectors.toSet());
-				boolean equalToRootpaths = false;
+				boolean equalToRootPaths = false;
 				if (family instanceof Collection<?>) {
-					equalToRootpaths = addedRootPathsSet.equals(((Collection<IPath>) family).stream().collect(Collectors.toSet()));
+					equalToRootPaths = addedRootPathsSet.equals(((Collection<IPath>) family).stream().collect(Collectors.toSet()));
 				}
-				return IConstants.UPDATE_WORKSPACE_FOLDERS_FAMILY.equals(family) || IConstants.JOBS_FAMILY.equals(family) || equalToRootpaths;
+				return IConstants.UPDATE_WORKSPACE_FOLDERS_FAMILY.equals(family) || IConstants.JOBS_FAMILY.equals(family) || equalToRootPaths;
 			}
 
 			@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -49,9 +49,11 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 	private JavaLanguageClient client = mock(JavaLanguageClient.class);
 	private JavaClientConnection javaClient = new JavaClientConnection(client);
 	private JDTLanguageServer server;
+	private boolean autoBuild;
 
 	@Before
 	public void setup() throws Exception {
+		autoBuild = preferenceManager.getPreferences().isAutobuildEnabled();
 		server = new JDTLanguageServer(projectsManager, preferenceManager);
 		server.connectClient(client);
 		JavaLanguageServerPlugin.getInstance().setProtocol(server);
@@ -62,7 +64,8 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		server.disconnectClient();
 		JavaLanguageServerPlugin.getInstance().setProtocol(null);
 		try {
-			projectsManager.setAutoBuilding(true);
+			projectsManager.setAutoBuilding(autoBuild);
+			preferenceManager.getPreferences().setAutobuildEnabled(autoBuild);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -98,10 +97,9 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
 	public void testCancelInitJob() throws Exception {
-		Collection<IPath> rootPaths = new ArrayList<>();
 		File workspaceDir = copyFiles("maven/salut", true);
 		String rootPathURI = workspaceDir.toURI().toString();
-		rootPaths.add(ResourceUtils.canonicalFilePathFromURI(rootPathURI));
+		Collection<IPath> rootPaths = Collections.singleton(ResourceUtils.canonicalFilePathFromURI(rootPathURI));
 		InitializeParams params = new InitializeParams();
 		params.setRootUri(rootPathURI);
 		server.initialize(params);


### PR DESCRIPTION
Signed-off-by: Poytr1 <pengcheng.xu@elastic.co>

When we call `java/didChangeWorkspaceFolders`, we may remove some workspaces. However, when the removed workspace is still in the initialization phase, the initialize/update workspace job is still at WAITING status or RUNNING status. We have not canceled these jobs, and they will still execute in the background, occupying resources. The potential problem is that if I delete this workspace, I might get an exception from these jobs.
This PR is used to add a new family(rootpaths) for the initialize and update jobs, so that you can find these background workspace jobs for initializing the workspace based on removed rootpaths and try to cancel them.

@fbricon How do you think about this?