### PR TITLE
Auto rename the extracted node generated by the refactoring 'extract to variable/constant/method'

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractRefactoring.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.refactoring.code;
+
+import org.eclipse.jdt.core.dom.rewrite.ITrackedNodePosition;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+
+public abstract class ExtractRefactoring extends Refactoring {
+	public abstract ITrackedNodePosition getExtractedNodePosition();
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/structure/CompilationUnitRewrite.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/structure/CompilationUnitRewrite.java
@@ -1,0 +1,445 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2018 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Originally copied from org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc, - copied to jdt.core.manipulation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.refactoring.structure;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.manipulation.CodeStyleConfiguration;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ltk.core.refactoring.CategorizedTextEditGroup;
+import org.eclipse.ltk.core.refactoring.GroupCategorySet;
+import org.eclipse.text.edits.MultiTextEdit;
+import org.eclipse.text.edits.TextEdit;
+import org.eclipse.text.edits.TextEditGroup;
+
+/**
+ * A {@link CompilationUnitRewrite} holds all data structures that are typically
+ * required for non-trivial refactorings. All getters are initialized lazily to
+ * avoid lengthy processing in
+ * {@link org.eclipse.ltk.core.refactoring.Refactoring#checkInitialConditions(org.eclipse.core.runtime.IProgressMonitor)}.
+ * <p>
+ * Bindings are resolved by default, but can be disabled with
+ * <code>setResolveBindings(false)</code>. Statements recovery is enabled by
+ * default, but can be disabled with <code>setStatementsRecovery(false)</code>.
+ * Bindings recovery is disabled by default, but can be enabled with
+ * <code>setBindingRecovery(true)</code>.
+ * </p>
+ *
+ * see JDTUIHelperClasses
+ */
+public class CompilationUnitRewrite {
+	//TODO: add RefactoringStatus fStatus;?
+	private ICompilationUnit fCu;
+	private List<TextEditGroup> fTextEditGroups = new ArrayList<>();
+
+	private CompilationUnit fRoot; // lazily initialized
+	private ASTRewrite fRewrite; // lazily initialized
+	private ImportRewrite fImportRewrite; // lazily initialized
+	private ImportRemover fImportRemover; // lazily initialized
+	private boolean fResolveBindings = true;
+	private boolean fStatementsRecovery = true;
+	private boolean fBindingsRecovery = false;
+	private final WorkingCopyOwner fOwner;
+	private IDocument fRememberContent = null;
+	private Map fFormatterOptions;
+
+	public CompilationUnitRewrite(ICompilationUnit cu) {
+		this(null, cu, null, null);
+	}
+
+	public CompilationUnitRewrite(WorkingCopyOwner owner, ICompilationUnit cu) {
+		this(owner, cu, null, null);
+	}
+
+	public CompilationUnitRewrite(ICompilationUnit cu, CompilationUnit root) {
+		this(null, cu, root, null);
+	}
+
+	public CompilationUnitRewrite(WorkingCopyOwner owner, ICompilationUnit cu, CompilationUnit root, Map formatterOptions) {
+		fOwner = owner;
+		fCu = cu;
+		fRoot = root;
+		fFormatterOptions = formatterOptions;
+	}
+
+	public Map getFormatterOptions() {
+		return fFormatterOptions;
+	}
+
+	public void setFormatterOptions(Map formatterOptions) {
+		this.fFormatterOptions = formatterOptions;
+	}
+
+	public void rememberContent() {
+		fRememberContent = new Document();
+	}
+
+	/**
+	 * Controls whether the compiler should provide binding information for the AST
+	 * nodes it creates. To be effective, this method must be called before any of
+	 * {@link #getRoot()},{@link #getASTRewrite()}, {@link #getImportRemover()}.
+	 * This method has no effect if the target object has been created with
+	 * {@link #CompilationUnitRewrite(ICompilationUnit, CompilationUnit)}.
+	 * <p>
+	 * Defaults to <b><code>true</code></b> (do resolve bindings).
+	 * </p>
+	 *
+	 * @param resolve
+	 *            <code>true</code> if bindings are wanted, and <code>false</code>
+	 *            if bindings are not of interest
+	 * @see org.eclipse.jdt.core.dom.ASTParser#setResolveBindings(boolean) Note: The
+	 *      default value (<code>true</code>) differs from the one of the
+	 *      corresponding method in ASTParser.
+	 */
+	public void setResolveBindings(boolean resolve) {
+		fResolveBindings = resolve;
+	}
+
+	/**
+	 * Controls whether the compiler should perform statements recovery. To be
+	 * effective, this method must be called before any of
+	 * {@link #getRoot()},{@link #getASTRewrite()}, {@link #getImportRemover()}.
+	 * This method has no effect if the target object has been created with
+	 * {@link #CompilationUnitRewrite(ICompilationUnit, CompilationUnit)}.
+	 * <p>
+	 * Defaults to <b><code>true</code></b> (do perform statements recovery).
+	 * </p>
+	 *
+	 * @param statementsRecovery
+	 *            whether statements recovery should be performed
+	 * @see org.eclipse.jdt.core.dom.ASTParser#setStatementsRecovery(boolean)
+	 */
+	public void setStatementsRecovery(boolean statementsRecovery) {
+		fStatementsRecovery = statementsRecovery;
+	}
+
+	/**
+	 * Controls whether the compiler should perform bindings recovery. To be
+	 * effective, this method must be called before any of
+	 * {@link #getRoot()},{@link #getASTRewrite()}, {@link #getImportRemover()}.
+	 * This method has no effect if the target object has been created with
+	 * {@link #CompilationUnitRewrite(ICompilationUnit, CompilationUnit)}.
+	 * <p>
+	 * Defaults to <b><code>false</code></b> (do not perform bindings recovery).
+	 * </p>
+	 *
+	 * @param bindingsRecovery
+	 *            whether bindings recovery should be performed
+	 * @see org.eclipse.jdt.core.dom.ASTParser#setBindingsRecovery(boolean)
+	 */
+	public void setBindingRecovery(boolean bindingsRecovery) {
+		fBindingsRecovery = bindingsRecovery;
+	}
+
+	public void clearASTRewrite() {
+		fRewrite = null;
+		fTextEditGroups = new ArrayList<>();
+	}
+
+	public void clearImportRewrites() {
+		fImportRewrite = null;
+		fImportRemover = null;
+	}
+
+	public void clearASTAndImportRewrites() {
+		clearASTRewrite();
+		clearImportRewrites();
+	}
+
+	public CategorizedTextEditGroup createCategorizedGroupDescription(String name, GroupCategorySet set) {
+		CategorizedTextEditGroup result = new CategorizedTextEditGroup(name, set);
+		fTextEditGroups.add(result);
+		return result;
+	}
+
+	public TextEditGroup createGroupDescription(String name) {
+		TextEditGroup result = new TextEditGroup(name);
+		fTextEditGroups.add(result);
+		return result;
+	}
+
+	/**
+	 * Creates a compilation unit change based on the events recorded by this
+	 * compilation unit rewrite.
+	 *
+	 * @param generateGroups
+	 *            <code>true</code> to generate text edit groups, <code>false</code>
+	 *            otherwise
+	 * @return a {@link CompilationUnitChange}, or <code>null</code> for an empty
+	 *         change
+	 * @throws CoreException
+	 *             when text buffer acquisition or import rewrite text edit creation
+	 *             fails
+	 * @throws IllegalArgumentException
+	 *             when the AST rewrite encounters problems
+	 * @since 3.6
+	 */
+	public CompilationUnitChange createChange(boolean generateGroups) throws CoreException {
+		return createChange(generateGroups, null);
+	}
+
+	/**
+	 * Creates a compilation unit change based on the events recorded by this
+	 * compilation unit rewrite.
+	 * <p>
+	 * DO NOT REMOVE, used in a product.
+	 * </p>
+	 *
+	 * @return a {@link org.eclipse.jdt.core.refactoring.CompilationUnitChange}, or
+	 *         <code>null</code> for an empty change
+	 * @throws CoreException
+	 *             when text buffer acquisition or import rewrite text edit creation
+	 *             fails
+	 * @throws IllegalArgumentException
+	 *             when the AST rewrite encounters problems
+	 * @deprecated since 3.5, replaced by {@link #createChange(boolean)}
+	 */
+	@Deprecated
+	public org.eclipse.jdt.internal.corext.refactoring.changes.CompilationUnitChange createChange() throws CoreException {
+		CompilationUnitChange change = createChange(true);
+		if (change == null) {
+			return null;
+		}
+		return new org.eclipse.jdt.internal.corext.refactoring.changes.CompilationUnitChange(change);
+	}
+
+	/**
+	 * Creates a compilation unit change based on the events recorded by this
+	 * compilation unit rewrite.
+	 *
+	 * @param generateGroups
+	 *            <code>true</code> to generate text edit groups, <code>false</code>
+	 *            otherwise
+	 * @param monitor
+	 *            the progress monitor or <code>null</code>
+	 * @return a {@link CompilationUnitChange}, or <code>null</code> for an empty
+	 *         change
+	 * @throws CoreException
+	 *             when text buffer acquisition or import rewrite text edit creation
+	 *             fails
+	 * @throws IllegalArgumentException
+	 *             when the AST rewrite encounters problems
+	 */
+	public CompilationUnitChange createChange(boolean generateGroups, IProgressMonitor monitor) throws CoreException {
+		return createChange(fCu.getElementName(), generateGroups, monitor);
+	}
+
+	/**
+	 * Creates a compilation unit change based on the events recorded by this
+	 * compilation unit rewrite.
+	 *
+	 * @param name
+	 *            the name of the change to create
+	 * @param generateGroups
+	 *            <code>true</code> to generate text edit groups, <code>false</code>
+	 *            otherwise
+	 * @param monitor
+	 *            the progress monitor or <code>null</code>
+	 * @return a {@link CompilationUnitChange}, or <code>null</code> for an empty
+	 *         change
+	 * @throws CoreException
+	 *             when text buffer acquisition or import rewrite text edit creation
+	 *             fails
+	 * @throws IllegalArgumentException
+	 *             when the AST rewrite encounters problems
+	 */
+	public CompilationUnitChange createChange(String name, boolean generateGroups, IProgressMonitor monitor) throws CoreException {
+		CompilationUnitChange cuChange = new CompilationUnitChange(name, fCu);
+		MultiTextEdit multiEdit = new MultiTextEdit();
+		cuChange.setEdit(multiEdit);
+		return attachChange(cuChange, generateGroups, monitor);
+	}
+
+	/**
+	 * Attaches the changes of this compilation unit rewrite to the given CU Change.
+	 * The given change <b>must</b> either have no root edit, or a MultiTextEdit as
+	 * a root edit. The edits in the given change <b>must not</b> overlap with the
+	 * changes of this compilation unit.
+	 *
+	 * @param cuChange
+	 *            existing CompilationUnitChange with a MultiTextEdit root or no
+	 *            root at all.
+	 * @param generateGroups
+	 *            <code>true</code> to generate text edit groups, <code>false</code>
+	 *            otherwise
+	 * @param monitor
+	 *            the progress monitor or <code>null</code>
+	 * @return a change combining the changes of this rewrite and the given rewrite,
+	 *         or <code>null</code> for an empty change
+	 * @throws CoreException
+	 *             when text buffer acquisition or import rewrite text edit creation
+	 *             fails
+	 */
+	public CompilationUnitChange attachChange(CompilationUnitChange cuChange, boolean generateGroups, IProgressMonitor monitor) throws CoreException {
+		try {
+			boolean needsAstRewrite = fRewrite != null; // TODO: do we need something like ASTRewrite#hasChanges() here?
+			boolean needsImportRemoval = fImportRemover != null && fImportRemover.hasRemovedNodes();
+			boolean needsImportRewrite = fImportRewrite != null && fImportRewrite.hasRecordedChanges() || needsImportRemoval;
+			if (!needsAstRewrite && !needsImportRemoval && !needsImportRewrite) {
+				return null;
+			}
+
+			MultiTextEdit multiEdit = (MultiTextEdit) cuChange.getEdit();
+			if (multiEdit == null) {
+				multiEdit = new MultiTextEdit();
+				cuChange.setEdit(multiEdit);
+			}
+
+			if (needsAstRewrite) {
+				// clean up garbage from earlier calls to ASTRewrite#rewriteAST(..), see https://bugs.eclipse.org/bugs/show_bug.cgi?id=408334#c2
+				clearGroupDescriptionEdits();
+				TextEdit rewriteEdit;
+				Map formatter = this.fFormatterOptions == null ? getCu().getJavaProject().getOptions(true) : this.fFormatterOptions;
+				if (fRememberContent != null) {
+					rewriteEdit = fRewrite.rewriteAST(fRememberContent, formatter);
+				} else {
+					try {
+						IDocument document = new Document(fCu.getSource());
+						rewriteEdit = fRewrite.rewriteAST(document, formatter);
+					} catch (JavaModelException e) {
+						rewriteEdit = fRewrite.rewriteAST();
+					}
+				}
+				if (!isEmptyEdit(rewriteEdit)) {
+					multiEdit.addChild(rewriteEdit);
+					if (generateGroups) {
+						for (Iterator<TextEditGroup> iter = fTextEditGroups.iterator(); iter.hasNext();) {
+							TextEditGroup group = iter.next();
+							cuChange.addTextEditGroup(group);
+						}
+					}
+				}
+			}
+			if (needsImportRemoval) {
+				fImportRemover.applyRemoves(getImportRewrite());
+			}
+			if (needsImportRewrite) {
+				TextEdit importsEdit = fImportRewrite.rewriteImports(monitor);
+				if (!isEmptyEdit(importsEdit)) {
+					multiEdit.addChild(importsEdit);
+					String importUpdateName = RefactoringCoreMessages.ASTData_update_imports;
+					cuChange.addTextEditGroup(new TextEditGroup(importUpdateName, importsEdit));
+				}
+			} else {
+
+			}
+			if (isEmptyEdit(multiEdit)) {
+				return null;
+			}
+			return cuChange;
+		} finally {
+			if (monitor != null) {
+				monitor.done();
+			}
+		}
+	}
+
+	private static boolean isEmptyEdit(TextEdit edit) {
+		return edit.getClass() == MultiTextEdit.class && !edit.hasChildren();
+	}
+
+	public ICompilationUnit getCu() {
+		return fCu;
+	}
+
+	public CompilationUnit getRoot() {
+		if (fRoot == null) {
+			fRoot = new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL).parse(fCu, fOwner, fResolveBindings, fStatementsRecovery, fBindingsRecovery, null);
+		}
+		return fRoot;
+	}
+
+	public AST getAST() {
+		return getRoot().getAST();
+	}
+
+	public ASTRewrite getASTRewrite() {
+		if (fRewrite == null) {
+			fRewrite = ASTRewrite.create(getRoot().getAST());
+			if (fRememberContent != null) { // wain until ast rewrite is accessed first
+				try {
+					fRememberContent.set(fCu.getSource());
+				} catch (JavaModelException e) {
+					fRememberContent = null;
+				}
+			}
+		}
+		return fRewrite;
+	}
+
+	public ImportRewrite getImportRewrite() {
+		if (fImportRewrite == null) {
+			// lazily initialized to avoid lengthy processing in checkInitialConditions(..)
+			try {
+				/* If bindings are to be resolved, then create the AST, so that
+				 * ImportRewrite#setUseContextToFilterImplicitImports(boolean) will be set to true
+				 * and ContextSensitiveImportRewriteContext etc. can be used. */
+				if (fRoot == null && !fResolveBindings) {
+					fImportRewrite = CodeStyleConfiguration.createImportRewrite(fCu, true);
+				} else {
+					fImportRewrite = createImportRewrite(getRoot(), true);
+				}
+			} catch (CoreException e) {
+				JavaManipulationPlugin.log(e);
+				throw new IllegalStateException(e.getMessage()); // like ASTParser#createAST(..) does
+			}
+		}
+		return fImportRewrite;
+
+	}
+
+	private ImportRewrite createImportRewrite(CompilationUnit astRoot, boolean restoreExistingImports) {
+		ImportRewrite rewrite = CodeStyleConfiguration.createImportRewrite(astRoot, restoreExistingImports);
+		if (astRoot.getAST().hasResolvedBindings()) {
+			rewrite.setUseContextToFilterImplicitImports(true);
+		}
+		return rewrite;
+	}
+
+	public ImportRemover getImportRemover() {
+		if (fImportRemover == null) {
+			fImportRemover = new ImportRemover(fCu.getJavaProject(), getRoot());
+		}
+		return fImportRemover;
+	}
+
+	private void clearGroupDescriptionEdits() {
+		for (Iterator<TextEditGroup> iter = fTextEditGroups.iterator(); iter.hasNext();) {
+			TextEditGroup group = iter.next();
+			group.clearTextEdits();
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/RefactoringCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/RefactoringCorrectionProposal.java
@@ -68,4 +68,8 @@ public class RefactoringCorrectionProposal extends LinkedCorrectionProposal {
 		}
 		return super.getAdditionalProposalInfo(monitor);
 	}
+
+	public Refactoring getRefactoring() {
+		return fRefactoring;
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Red Hat Inc. and others.
+ * Copyright (c) 2016-2019 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -138,7 +138,7 @@ public class FormatterHandler {
 		return null;
 	}
 
-	private static Map<String, String> getOptions(FormattingOptions options, ICompilationUnit cu) {
+	public static Map<String, String> getOptions(FormattingOptions options, ICompilationUnit cu) {
 		Map<String, String> eclipseOptions = cu.getJavaProject().getOptions(true);
 
 		Map<String, String> customOptions = options.entrySet().stream().filter(map -> chekIfValueIsNotNull(map.getValue())).collect(toMap(e -> e.getKey(), e -> getOptionValue(e.getValue())));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractRefactoring;
+import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
+import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.RefactoringCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.text.correction.ExtractProposalUtility;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.ltk.core.refactoring.Change;
+
+public class GetRefactorEditHandler {
+	public static final String RENAME_COMMAND = "java.action.rename";
+
+	public static RefactorWorkspaceEdit getEditsForRefactor(GetRefactorEditParams params) {
+		final ICompilationUnit unit = JDTUtils.resolveCompilationUnit(params.context.getTextDocument().getUri());
+		if (unit == null) {
+			return null;
+		}
+		int start = DiagnosticsHelper.getStartOffset(unit, params.context.getRange());
+		int end = DiagnosticsHelper.getEndOffset(unit, params.context.getRange());
+		InnovationContext context = new InnovationContext(unit, start, end - start);
+		context.setASTRoot(CodeActionHandler.getASTRoot(unit));
+		IProblemLocationCore[] locations = CodeActionHandler.getProblemLocationCores(unit, params.context.getContext().getDiagnostics());
+		boolean problemsAtLocation = locations.length != 0;
+
+		try {
+			Map formatterOptions = params.options == null ? null : FormatterHandler.getOptions(params.options, unit);
+			RefactoringCorrectionProposal proposal = null;
+			if (ExtractProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(params.command) || ExtractProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(params.command)
+					|| ExtractProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(params.command)) {
+				proposal = (RefactoringCorrectionProposal) getExtractVariableProposal(params.context, context, problemsAtLocation, params.command, formatterOptions);
+			} else if (ExtractProposalUtility.EXTRACT_METHOD_COMMAND.equals(params.command)) {
+				proposal = (RefactoringCorrectionProposal) getExtractMethodProposal(params.context, context, context.getCoveringNode(), problemsAtLocation, formatterOptions);
+			}
+
+			if (proposal == null) {
+				return null;
+			}
+
+			Change change = proposal.getChange();
+			WorkspaceEdit edit = CodeActionHandler.convertChangeToWorkspaceEdit(unit, change);
+			ExtractRefactoring extractRefactoring = (ExtractRefactoring) proposal.getRefactoring();
+			Command additionalCommand = null;
+			if (extractRefactoring.getExtractedNodePosition() != null) {
+				int offset = extractRefactoring.getExtractedNodePosition().getStartPosition();
+				int length = extractRefactoring.getExtractedNodePosition().getLength();
+				RenamePosition renamePosition = new RenamePosition(JDTUtils.toURI(unit), offset, length);
+				additionalCommand = new Command("Rename", RENAME_COMMAND, Arrays.asList(renamePosition));
+			}
+
+			return new RefactorWorkspaceEdit(edit, additionalCommand);
+		} catch (CoreException e) {
+			// do nothing.
+		}
+
+		return null;
+	}
+
+	private static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, String refactorType, Map formatterOptions) throws CoreException {
+		if (ExtractProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(refactorType)) {
+			return ExtractProposalUtility.getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, false);
+		}
+
+		if (ExtractProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(refactorType)) {
+			return ExtractProposalUtility.getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, false);
+		}
+
+		if (ExtractProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(refactorType)) {
+			return ExtractProposalUtility.getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, false);
+		}
+
+		return null;
+	}
+
+	private static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formatterOptions) throws CoreException {
+		return ExtractProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, formatterOptions, false);
+	}
+
+	public static class RenamePosition {
+		public String uri;
+		public int offset;
+		public int length;
+
+		public RenamePosition(String uri, int offset, int length) {
+			this.uri = uri;
+			this.offset = offset;
+			this.length = length;
+		}
+	}
+
+	public static class RefactorWorkspaceEdit {
+		/**
+		 * The workspace edit this code action performs.
+		 */
+		public WorkspaceEdit edit;
+		/**
+		 * A command this code action executes. If a code action provides a edit and a
+		 * command, first the edit is executed and then the command.
+		 */
+		public Command command;
+
+		public RefactorWorkspaceEdit(WorkspaceEdit edit) {
+			this.edit = edit;
+		}
+
+		public RefactorWorkspaceEdit(WorkspaceEdit edit, Command command) {
+			this.edit = edit;
+			this.command = command;
+		}
+	}
+
+	public static class GetRefactorEditParams {
+		public String command;
+		public CodeActionParams context;
+		public FormattingOptions options;
+
+		public GetRefactorEditParams(String command, CodeActionParams context) {
+			this.command = command;
+			this.context = context;
+		}
+
+		public GetRefactorEditParams(String command, CodeActionParams context, FormattingOptions options) {
+			this.command = command;
+			this.context = context;
+			this.options = options;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -56,6 +56,8 @@ import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler.
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler.GenerateDelegateMethodsParams;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler.CheckToStringResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler.GenerateToStringParams;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.GetRefactorEditParams;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.RefactorWorkspaceEdit;
 import org.eclipse.jdt.ls.core.internal.handlers.HashCodeEqualsHandler.CheckHashCodeEqualsResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.HashCodeEqualsHandler.GenerateHashCodeEqualsParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.AddOverridableMethodParams;
@@ -839,6 +841,12 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	public CompletableFuture<WorkspaceEdit> generateDelegateMethods(GenerateDelegateMethodsParams params) {
 		logInfo(">> java/generateDelegateMethods");
 		return computeAsync((monitor) -> GenerateDelegateMethodsHandler.generateDelegateMethods(params));
+	}
+
+	@Override
+	public CompletableFuture<RefactorWorkspaceEdit> getRefactorEdit(GetRefactorEditParams params) {
+		logInfo(">> java/getRefactorEdit");
+		return computeAsync((monitor) -> GetRefactorEditHandler.getEditsForRefactor(params));
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
@@ -21,6 +21,8 @@ import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler.
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler.GenerateDelegateMethodsParams;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler.CheckToStringResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler.GenerateToStringParams;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.GetRefactorEditParams;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.RefactorWorkspaceEdit;
 import org.eclipse.jdt.ls.core.internal.handlers.HashCodeEqualsHandler.CheckHashCodeEqualsResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.HashCodeEqualsHandler.GenerateHashCodeEqualsParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.AddOverridableMethodParams;
@@ -92,4 +94,7 @@ public interface JavaProtocolExtensions {
 
 	@JsonRequest
 	CompletableFuture<WorkspaceEdit> generateDelegateMethods(GenerateDelegateMethodsParams params);
+
+	@JsonRequest
+	CompletableFuture<RefactorWorkspaceEdit> getRefactorEdit(GetRefactorEditParams params);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -197,6 +197,10 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("generateDelegateMethodsPromptSupport", "false").toString());
 	}
 
+	public boolean isAdvancedExtractRefactoringSupported() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("advancedExtractRefactoringSupport", "false").toString());
+	}
+
 	public boolean isSupportsCompletionDocumentationMarkdown() {
 		//@formatter:off
 		return v3supported && capabilities.getTextDocument().getCompletion() != null

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CUCorrectionCommandProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CUCorrectionCommandProposal.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.text.correction;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
+
+public class CUCorrectionCommandProposal extends CUCorrectionProposal {
+
+	private String command;
+	private List<Object> commandArguments;
+
+	/**
+	 * @param name
+	 * @param kind
+	 * @param cu
+	 * @param relevance
+	 */
+	public CUCorrectionCommandProposal(String name, String kind, ICompilationUnit cu, int relevance, String command, List<Object> commandArguments) {
+		super(name, kind, cu, null, relevance);
+		this.command = command;
+		this.commandArguments = commandArguments;
+	}
+
+	public String getCommand() {
+		return command;
+	}
+
+	public List<Object> getCommandArguments() {
+		return commandArguments;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ExtractProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ExtractProposalUtility.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+* Copyright (c) 2019 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.text.correction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractConstantRefactoring;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractMethodRefactoring;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractTempRefactoring;
+import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
+import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.RefactoringCorrectionProposal;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+
+public class ExtractProposalUtility {
+	public static final String APPLY_REFACTORING_COMMAND_ID = "java.action.applyRefactoringCommand";
+	public static final String EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND = "extractVariableAllOccurrence";
+	public static final String EXTRACT_VARIABLE_COMMAND = "extractVariable";
+	public static final String EXTRACT_CONSTANT_COMMAND = "extractConstant";
+	public static final String EXTRACT_METHOD_COMMAND = "extractMethod";
+
+	public static List<CUCorrectionProposal> getExtractVariableProposals(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation) throws CoreException {
+		return getExtractVariableProposals(params, context, problemsAtLocation, false);
+	}
+
+	public static List<CUCorrectionProposal> getExtractVariableCommandProposals(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation) throws CoreException {
+		return getExtractVariableProposals(params, context, problemsAtLocation, true);
+	}
+
+	public static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation) throws CoreException {
+		return getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, null, false);
+	}
+
+	public static CUCorrectionProposal getExtractMethodCommandProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation) throws CoreException {
+		return getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, null, true);
+	}
+
+	private static List<CUCorrectionProposal> getExtractVariableProposals(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, boolean returnAsCommand) throws CoreException {
+		if (!supportsExtractVariable(context)) {
+			return null;
+		}
+
+		List<CUCorrectionProposal> proposals = new ArrayList<>();
+		CUCorrectionProposal proposal = getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, null, returnAsCommand);
+		if (proposal != null) {
+			proposals.add(proposal);
+		}
+
+		proposal = getExtractVariableProposal(params, context, problemsAtLocation, null, returnAsCommand);
+		if (proposal != null) {
+			proposals.add(proposal);
+		}
+
+		proposal = getExtractConstantProposal(params, context, problemsAtLocation, null, returnAsCommand);
+		if (proposal != null) {
+			proposals.add(proposal);
+		}
+
+		return proposals;
+	}
+
+	private static boolean supportsExtractVariable(IInvocationContext context) {
+		ASTNode node = context.getCoveredNode();
+		if (!(node instanceof Expression)) {
+			if (context.getSelectionLength() != 0) {
+				return false;
+			}
+
+			node = context.getCoveringNode();
+			if (!(node instanceof Expression)) {
+				return false;
+			}
+		}
+
+		final Expression expression = (Expression) node;
+		ITypeBinding binding = expression.resolveTypeBinding();
+		if (binding == null || Bindings.isVoidType(binding)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public static CUCorrectionProposal getExtractVariableAllOccurrenceProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		final ICompilationUnit cu = context.getCompilationUnit();
+		ExtractTempRefactoring extractTempRefactoring = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formatterOptions);
+		if (extractTempRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+			String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_all_description;
+			int relevance;
+			if (context.getSelectionLength() == 0) {
+				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL_ZERO_SELECTION;
+			} else if (problemsAtLocation) {
+				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL_ERROR;
+			} else {
+				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL;
+			}
+
+			if (returnAsCommand) {
+				return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, params));
+			}
+
+			extractTempRefactoring.setReplaceAllOccurrences(true);
+			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
+			extractTempRefactoring.setLinkedProposalModel(linkedProposalModel);
+			extractTempRefactoring.setCheckResultForCompileProblems(false);
+			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, extractTempRefactoring, relevance) {
+				@Override
+				protected void init(Refactoring refactoring) throws CoreException {
+					ExtractTempRefactoring etr = (ExtractTempRefactoring) refactoring;
+					etr.setTempName(etr.guessTempName()); // expensive
+				}
+			};
+			proposal.setLinkedProposalModel(linkedProposalModel);
+			return proposal;
+		}
+
+		return null;
+	}
+
+	public static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		final ICompilationUnit cu = context.getCompilationUnit();
+		ExtractTempRefactoring extractTempRefactoringSelectedOnly = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formatterOptions);
+		extractTempRefactoringSelectedOnly.setReplaceAllOccurrences(false);
+		if (extractTempRefactoringSelectedOnly.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+			String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_description;
+			int relevance;
+			if (context.getSelectionLength() == 0) {
+				relevance = IProposalRelevance.EXTRACT_LOCAL_ZERO_SELECTION;
+			} else if (problemsAtLocation) {
+				relevance = IProposalRelevance.EXTRACT_LOCAL_ERROR;
+			} else {
+				relevance = IProposalRelevance.EXTRACT_LOCAL;
+			}
+
+			if (returnAsCommand) {
+				return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_VARIABLE_COMMAND, params));
+			}
+
+			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
+			extractTempRefactoringSelectedOnly.setLinkedProposalModel(linkedProposalModel);
+			extractTempRefactoringSelectedOnly.setCheckResultForCompileProblems(false);
+			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, extractTempRefactoringSelectedOnly, relevance) {
+				@Override
+				protected void init(Refactoring refactoring) throws CoreException {
+					ExtractTempRefactoring etr = (ExtractTempRefactoring) refactoring;
+					etr.setTempName(etr.guessTempName()); // expensive
+				}
+			};
+			proposal.setLinkedProposalModel(linkedProposalModel);
+			return proposal;
+		}
+
+		return null;
+	}
+
+	public static CUCorrectionProposal getExtractConstantProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		final ICompilationUnit cu = context.getCompilationUnit();
+		ExtractConstantRefactoring extractConstRefactoring = new ExtractConstantRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formatterOptions);
+		if (extractConstRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+			String label = CorrectionMessages.QuickAssistProcessor_extract_to_constant_description;
+			int relevance;
+			if (context.getSelectionLength() == 0) {
+				relevance = IProposalRelevance.EXTRACT_CONSTANT_ZERO_SELECTION;
+			} else if (problemsAtLocation) {
+				relevance = IProposalRelevance.EXTRACT_CONSTANT_ERROR;
+			} else {
+				relevance = IProposalRelevance.EXTRACT_CONSTANT;
+			}
+
+			if (returnAsCommand) {
+				return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_CONSTANT, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_CONSTANT_COMMAND, params));
+			}
+
+			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
+			extractConstRefactoring.setLinkedProposalModel(linkedProposalModel);
+			extractConstRefactoring.setCheckResultForCompileProblems(false);
+			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_CONSTANT, cu, extractConstRefactoring, relevance) {
+				@Override
+				protected void init(Refactoring refactoring) throws CoreException {
+					ExtractConstantRefactoring etr = (ExtractConstantRefactoring) refactoring;
+					etr.setConstantName(etr.guessConstantName()); // expensive
+				}
+			};
+			proposal.setLinkedProposalModel(linkedProposalModel);
+			return proposal;
+		}
+
+		return null;
+	}
+
+	public static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formattingOptions, boolean returnAsCommand) throws CoreException {
+		if (!(coveringNode instanceof Expression) && !(coveringNode instanceof Statement) && !(coveringNode instanceof Block)) {
+			return null;
+		}
+		if (coveringNode instanceof Block) {
+			List<Statement> statements = ((Block) coveringNode).statements();
+			int startIndex = getIndex(context.getSelectionOffset(), statements);
+			if (startIndex == -1) {
+				return null;
+			}
+			int endIndex = getIndex(context.getSelectionOffset() + context.getSelectionLength(), statements);
+			if (endIndex == -1 || endIndex <= startIndex) {
+				return null;
+			}
+		}
+
+		final ICompilationUnit cu = context.getCompilationUnit();
+		final ExtractMethodRefactoring extractMethodRefactoring = new ExtractMethodRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength(), formattingOptions);
+		String uniqueMethodName = getUniqueMethodName(coveringNode, "extracted");
+		extractMethodRefactoring.setMethodName(uniqueMethodName);
+		if (extractMethodRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+			String label = CorrectionMessages.QuickAssistProcessor_extractmethod_description;
+			int relevance = problemsAtLocation ? IProposalRelevance.EXTRACT_METHOD_ERROR : IProposalRelevance.EXTRACT_METHOD;
+			if (returnAsCommand) {
+				return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_METHOD_COMMAND, params));
+			}
+
+			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
+			extractMethodRefactoring.setLinkedProposalModel(linkedProposalModel);
+			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD, cu, extractMethodRefactoring, relevance);
+			proposal.setLinkedProposalModel(linkedProposalModel);
+			return proposal;
+		}
+
+		return null;
+	}
+
+	private static String getUniqueMethodName(ASTNode astNode, String suggestedName) throws JavaModelException {
+		while (astNode != null && !(astNode instanceof TypeDeclaration || astNode instanceof AnonymousClassDeclaration)) {
+			astNode = astNode.getParent();
+		}
+		if (astNode instanceof TypeDeclaration) {
+			ITypeBinding typeBinding = ((TypeDeclaration) astNode).resolveBinding();
+			if (typeBinding == null) {
+				return suggestedName;
+			}
+			IType type = (IType) typeBinding.getJavaElement();
+			if (type == null) {
+				return suggestedName;
+			}
+			IMethod[] methods = type.getMethods();
+
+			int suggestedPostfix = 2;
+			String resultName = suggestedName;
+			while (suggestedPostfix < 1000) {
+				if (!hasMethod(methods, resultName)) {
+					return resultName;
+				}
+				resultName = suggestedName + suggestedPostfix++;
+			}
+		}
+		return suggestedName;
+	}
+
+	private static boolean hasMethod(IMethod[] methods, String name) {
+		for (IMethod method : methods) {
+			if (name.equals(method.getElementName())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static int getIndex(int offset, List<Statement> statements) {
+		for (int i = 0; i < statements.size(); i++) {
+			Statement s = statements.get(i);
+			if (offset <= s.getStartPosition()) {
+				return i;
+			}
+			if (offset < s.getStartPosition() + s.getLength()) {
+				return -1;
+			}
+		}
+		return statements.size();
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -30,13 +30,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
@@ -83,7 +80,6 @@ import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.Type;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.TypeMethodReference;
 import org.eclipse.jdt.core.dom.UnionType;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
@@ -107,13 +103,9 @@ import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
-import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corext.fix.LambdaExpressionsCleanUp;
 import org.eclipse.jdt.ls.core.internal.corext.fix.LambdaExpressionsFix;
-import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractConstantRefactoring;
-import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractMethodRefactoring;
-import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractTempRefactoring;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ASTRewriteCorrectionProposal;
@@ -121,11 +113,11 @@ import org.eclipse.jdt.ls.core.internal.corrections.proposals.AssignToVariableAs
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.FixCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
-import org.eclipse.jdt.ls.core.internal.corrections.proposals.RefactoringCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.TypeChangeCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jface.text.link.LinkedPositionGroup;
 import org.eclipse.lsp4j.CodeActionKind;
-import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.lsp4j.CodeActionParams;
 
 /**
   */
@@ -148,10 +140,13 @@ public class QuickAssistProcessor {
 	public static final String CONVERT_TO_MESSAGE_FORMAT_ID = "org.eclipse.jdt.ls.correction.convertToMessageFormat.assist"; //$NON-NLS-1$;
 	public static final String EXTRACT_METHOD_INPLACE_ID = "org.eclipse.jdt.ls.correction.extractMethodInplace.assist"; //$NON-NLS-1$;
 
-	public QuickAssistProcessor() {
+	private PreferenceManager preferenceManager;
+
+	public QuickAssistProcessor(PreferenceManager preferenceManager) {
+		this.preferenceManager = preferenceManager;
 	}
 
-	public List<CUCorrectionProposal> getAssists(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
+	public List<CUCorrectionProposal> getAssists(CodeActionParams params, IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
 		ASTNode coveringNode = context.getCoveringNode();
 		if (coveringNode != null) {
 			ArrayList<ASTNode> coveredNodes = getFullyCoveredNodes(context, coveringNode);
@@ -182,8 +177,8 @@ public class QuickAssistProcessor {
 				//				getInvertEqualsProposal(context, coveringNode, resultingCollections);
 				//				getArrayInitializerToArrayCreation(context, coveringNode, resultingCollections);
 				//				getCreateInSuperClassProposals(context, coveringNode, resultingCollections);
-				getExtractVariableProposal(context, problemsAtLocation, resultingCollections);
-				getExtractMethodProposal(context, coveringNode, problemsAtLocation, resultingCollections);
+				getExtractVariableProposal(params, context, problemsAtLocation, resultingCollections);
+				getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, resultingCollections);
 				//				getInlineLocalProposal(context, coveringNode, resultingCollections);
 				//				getConvertLocalToFieldProposal(context, coveringNode, resultingCollections);
 				//				getConvertAnonymousToNestedProposal(context, coveringNode, resultingCollections);
@@ -503,53 +498,23 @@ public class QuickAssistProcessor {
 		return true;
 	}
 
-	private static int getIndex(int offset, List<Statement> statements) {
-		for (int i = 0; i < statements.size(); i++) {
-			Statement s = statements.get(i);
-			if (offset <= s.getStartPosition()) {
-				return i;
-			}
-			if (offset < s.getStartPosition() + s.getLength()) {
-				return -1;
-			}
-		}
-		return statements.size();
-	}
-
-	private static boolean getExtractMethodProposal(IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Collection<CUCorrectionProposal> proposals) throws CoreException {
-		if (!(coveringNode instanceof Expression) && !(coveringNode instanceof Statement) && !(coveringNode instanceof Block)) {
+	private boolean getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Collection<CUCorrectionProposal> proposals) throws CoreException {
+		if (proposals == null) {
 			return false;
 		}
-		if (coveringNode instanceof Block) {
-			List<Statement> statements = ((Block) coveringNode).statements();
-			int startIndex = getIndex(context.getSelectionOffset(), statements);
-			if (startIndex == -1) {
-				return false;
-			}
-			int endIndex = getIndex(context.getSelectionOffset() + context.getSelectionLength(), statements);
-			if (endIndex == -1 || endIndex <= startIndex) {
-				return false;
-			}
+
+		CUCorrectionProposal proposal = null;
+		if (this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported()) {
+			proposal = ExtractProposalUtility.getExtractMethodCommandProposal(params, context, coveringNode, problemsAtLocation);
+		} else {
+			proposal = ExtractProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation);
 		}
 
-		if (proposals == null) {
-			return true;
+		if (proposal == null) {
+			return false;
 		}
 
-		final ICompilationUnit cu = context.getCompilationUnit();
-		final ExtractMethodRefactoring extractMethodRefactoring = new ExtractMethodRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
-		String uniqueMethodName = getUniqueMethodName(coveringNode, "extracted");
-		extractMethodRefactoring.setMethodName(uniqueMethodName);
-		if (extractMethodRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-			String label = CorrectionMessages.QuickAssistProcessor_extractmethod_description;
-			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
-			extractMethodRefactoring.setLinkedProposalModel(linkedProposalModel);
-
-			int relevance = problemsAtLocation ? IProposalRelevance.EXTRACT_METHOD_ERROR : IProposalRelevance.EXTRACT_METHOD;
-			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD, cu, extractMethodRefactoring, relevance);
-			proposal.setLinkedProposalModel(linkedProposalModel);
-			proposals.add(proposal);
-		}
+		proposals.add(proposal);
 		return true;
 	}
 
@@ -591,110 +556,24 @@ public class QuickAssistProcessor {
 		return true;
 	}
 
-	private static boolean getExtractVariableProposal(IInvocationContext context, boolean problemsAtLocation, Collection<CUCorrectionProposal> proposals) throws CoreException {
-
-		ASTNode node = context.getCoveredNode();
-
-		if (!(node instanceof Expression)) {
-			if (context.getSelectionLength() != 0) {
-				return false;
-			}
-			node = context.getCoveringNode();
-			if (!(node instanceof Expression)) {
-				return false;
-			}
-		}
-		final Expression expression = (Expression) node;
-
-		ITypeBinding binding = expression.resolveTypeBinding();
-		if (binding == null || Bindings.isVoidType(binding)) {
+	private boolean getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Collection<CUCorrectionProposal> proposals) throws CoreException {
+		if (proposals == null) {
 			return false;
 		}
-		if (proposals == null) {
-			return true;
+
+		List<CUCorrectionProposal> newProposals = null;
+		if (this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported()) {
+			newProposals = ExtractProposalUtility.getExtractVariableCommandProposals(params, context, problemsAtLocation);
+		} else {
+			newProposals = ExtractProposalUtility.getExtractVariableProposals(params, context, problemsAtLocation);
 		}
 
-		final ICompilationUnit cu = context.getCompilationUnit();
-		ExtractTempRefactoring extractTempRefactoring = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
-		if (extractTempRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-			extractTempRefactoring.setReplaceAllOccurrences(true);
-			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
-			extractTempRefactoring.setLinkedProposalModel(linkedProposalModel);
-			extractTempRefactoring.setCheckResultForCompileProblems(false);
-
-			String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_all_description;
-			int relevance;
-			if (context.getSelectionLength() == 0) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL_ZERO_SELECTION;
-			} else if (problemsAtLocation) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL_ERROR;
-			} else {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ALL;
-			}
-			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, extractTempRefactoring, relevance) {
-				@Override
-				protected void init(Refactoring refactoring) throws CoreException {
-					ExtractTempRefactoring etr = (ExtractTempRefactoring) refactoring;
-					etr.setTempName(etr.guessTempName()); // expensive
-				}
-			};
-			proposal.setLinkedProposalModel(linkedProposalModel);
-			proposals.add(proposal);
+		if (newProposals == null || newProposals.isEmpty()) {
+			return false;
 		}
 
-		ExtractTempRefactoring extractTempRefactoringSelectedOnly = new ExtractTempRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
-		extractTempRefactoringSelectedOnly.setReplaceAllOccurrences(false);
-		if (extractTempRefactoringSelectedOnly.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
-			extractTempRefactoringSelectedOnly.setLinkedProposalModel(linkedProposalModel);
-			extractTempRefactoringSelectedOnly.setCheckResultForCompileProblems(false);
-
-			String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_description;
-			int relevance;
-			if (context.getSelectionLength() == 0) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ZERO_SELECTION;
-			} else if (problemsAtLocation) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ERROR;
-			} else {
-				relevance = IProposalRelevance.EXTRACT_LOCAL;
-			}
-			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_VARIABLE, cu, extractTempRefactoringSelectedOnly, relevance) {
-				@Override
-				protected void init(Refactoring refactoring) throws CoreException {
-					ExtractTempRefactoring etr = (ExtractTempRefactoring) refactoring;
-					etr.setTempName(etr.guessTempName()); // expensive
-				}
-			};
-			proposal.setLinkedProposalModel(linkedProposalModel);
-			proposals.add(proposal);
-		}
-
-		ExtractConstantRefactoring extractConstRefactoring = new ExtractConstantRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
-		if (extractConstRefactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
-			extractConstRefactoring.setLinkedProposalModel(linkedProposalModel);
-			extractConstRefactoring.setCheckResultForCompileProblems(false);
-
-			String label = CorrectionMessages.QuickAssistProcessor_extract_to_constant_description;
-			int relevance;
-			if (context.getSelectionLength() == 0) {
-				relevance = IProposalRelevance.EXTRACT_CONSTANT_ZERO_SELECTION;
-			} else if (problemsAtLocation) {
-				relevance = IProposalRelevance.EXTRACT_CONSTANT_ERROR;
-			} else {
-				relevance = IProposalRelevance.EXTRACT_CONSTANT;
-			}
-			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_CONSTANT, cu, extractConstRefactoring, relevance) {
-				@Override
-				protected void init(Refactoring refactoring) throws CoreException {
-					ExtractConstantRefactoring etr = (ExtractConstantRefactoring) refactoring;
-					etr.setConstantName(etr.guessConstantName()); // expensive
-				}
-			};
-			proposal.setLinkedProposalModel(linkedProposalModel);
-			proposals.add(proposal);
-		}
-		return false;
+		proposals.addAll(newProposals);
+		return true;
 	}
 
 	/**
@@ -945,42 +824,6 @@ public class QuickAssistProcessor {
 			}
 		}
 		return newNames;
-	}
-
-	private static String getUniqueMethodName(ASTNode astNode, String suggestedName) throws JavaModelException {
-		while (astNode != null && !(astNode instanceof TypeDeclaration || astNode instanceof AnonymousClassDeclaration)) {
-			astNode = astNode.getParent();
-		}
-		if (astNode instanceof TypeDeclaration) {
-			ITypeBinding typeBinding = ((TypeDeclaration) astNode).resolveBinding();
-			if (typeBinding == null) {
-				return suggestedName;
-			}
-			IType type = (IType) typeBinding.getJavaElement();
-			if (type == null) {
-				return suggestedName;
-			}
-			IMethod[] methods = type.getMethods();
-
-			int suggestedPostfix = 2;
-			String resultName = suggestedName;
-			while (suggestedPostfix < 1000) {
-				if (!hasMethod(methods, resultName)) {
-					return resultName;
-				}
-				resultName = suggestedName + suggestedPostfix++;
-			}
-		}
-		return suggestedName;
-	}
-
-	private static boolean hasMethod(IMethod[] methods, String name) {
-		for (IMethod method : methods) {
-			if (name.equals(method.getElementName())) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	private static String createName(String candidate, List<String> excludedNames) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/CodeActionUtil.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/CodeActionUtil.java
@@ -33,9 +33,14 @@ public class CodeActionUtil {
 	}
 
 	public static CodeActionParams constructCodeActionParams(ICompilationUnit unit, String search) throws JavaModelException {
+		final Range range = getRange(unit, search);
+		return constructCodeActionParams(unit, range);
+
+	}
+
+	public static CodeActionParams constructCodeActionParams(ICompilationUnit unit, Range range) {
 		CodeActionParams params = new CodeActionParams();
 		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
-		final Range range = getRange(unit, search);
 		params.setRange(range);
 		params.setContext(new CodeActionContext(Collections.emptyList()));
 		return params;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/AbstractSourceTestCase.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/codemanipulation/AbstractSourceTestCase.java
@@ -85,7 +85,7 @@ public class AbstractSourceTestCase extends AbstractProjectsManagerBasedTest {
 		initCodeTemplates();
 	}
 
-	protected void compareSource(String expected, String actual) throws IOException {
+	public static void compareSource(String expected, String actual) throws IOException {
 		if (actual == null || expected == null) {
 			if (actual == expected) {
 				return;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
@@ -299,7 +299,7 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 		return evaluateChanges(uri, edits);
 	}
 
-	private String evaluateChanges(Map<String, List<TextEdit>> changes) throws BadLocationException, JavaModelException {
+	protected String evaluateChanges(Map<String, List<TextEdit>> changes) throws BadLocationException, JavaModelException {
 		Iterator<Entry<String, List<TextEdit>>> editEntries = changes.entrySet().iterator();
 		Entry<String, List<TextEdit>> entry = editEntries.next();
 		assertNotNull("No edits generated", entry);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.refactoring;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
+import org.eclipse.jdt.ls.core.internal.correction.AbstractSelectionTest;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandlerTest;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.eclipse.jdt.ls.core.internal.text.correction.ExtractProposalUtility;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AdvancedExtractTest extends AbstractSelectionTest {
+	private IJavaProject fJProject1;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+	}
+
+	@Override
+	protected ClientPreferences initPreferenceManager(boolean supportClassFileContents) {
+		ClientPreferences clientPreferences = super.initPreferenceManager(supportClassFileContents);
+		when(clientPreferences.isAdvancedExtractRefactoringSupported()).thenReturn(true);
+		return clientPreferences;
+	}
+
+	@Test
+	public void testExtractVariable() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, selection);
+		Assert.assertEquals(4, codeActions.size());
+		Command extractConstantCommand = CodeActionHandlerTest.getCommand(codeActions.get(0));
+		Assert.assertNotNull(extractConstantCommand);
+		Assert.assertEquals(ExtractProposalUtility.APPLY_REFACTORING_COMMAND_ID, extractConstantCommand.getCommand());
+		Assert.assertNotNull(extractConstantCommand.getArguments());
+		Assert.assertEquals(2, extractConstantCommand.getArguments().size());
+		Assert.assertEquals(ExtractProposalUtility.EXTRACT_CONSTANT_COMMAND, extractConstantCommand.getArguments().get(0));
+
+		Command extractMethodCommand = CodeActionHandlerTest.getCommand(codeActions.get(1));
+		Assert.assertNotNull(extractMethodCommand);
+		Assert.assertEquals(ExtractProposalUtility.APPLY_REFACTORING_COMMAND_ID, extractMethodCommand.getCommand());
+		Assert.assertNotNull(extractMethodCommand.getArguments());
+		Assert.assertEquals(2, extractMethodCommand.getArguments().size());
+		Assert.assertEquals(ExtractProposalUtility.EXTRACT_METHOD_COMMAND, extractMethodCommand.getArguments().get(0));
+
+		Command extractVariableAllCommand = CodeActionHandlerTest.getCommand(codeActions.get(2));
+		Assert.assertNotNull(extractVariableAllCommand);
+		Assert.assertEquals(ExtractProposalUtility.APPLY_REFACTORING_COMMAND_ID, extractVariableAllCommand.getCommand());
+		Assert.assertNotNull(extractVariableAllCommand.getArguments());
+		Assert.assertEquals(2, extractVariableAllCommand.getArguments().size());
+		Assert.assertEquals(ExtractProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, extractVariableAllCommand.getArguments().get(0));
+
+		Command extractVariableCommand = CodeActionHandlerTest.getCommand(codeActions.get(3));
+		Assert.assertNotNull(extractVariableCommand);
+		Assert.assertEquals(ExtractProposalUtility.APPLY_REFACTORING_COMMAND_ID, extractVariableCommand.getCommand());
+		Assert.assertNotNull(extractVariableCommand.getArguments());
+		Assert.assertEquals(2, extractVariableCommand.getArguments().size());
+		Assert.assertEquals(ExtractProposalUtility.EXTRACT_VARIABLE_COMMAND, extractVariableCommand.getArguments().get(0));
+	}
+
+	@Test
+	public void testExtractMethod() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public int foo(boolean b1, boolean b2) {\n");
+		buf.append("        int n = 0;\n");
+		buf.append("        int i = 0;\n");
+		buf.append("        /*[*/\n");
+		buf.append("        if (b1)\n");
+		buf.append("            i = 1;\n");
+		buf.append("        if (b2)\n");
+		buf.append("            n = n + i;\n");
+		buf.append("        /*]*/\n");
+		buf.append("        return n;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, selection);
+		Assert.assertNotNull(codeActions);
+		Either<Command, CodeAction> extractMethodAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD);
+		Assert.assertNotNull(extractMethodAction);
+		Command extractMethodCommand = CodeActionHandlerTest.getCommand(extractMethodAction);
+		Assert.assertNotNull(extractMethodCommand);
+		Assert.assertEquals(ExtractProposalUtility.APPLY_REFACTORING_COMMAND_ID, extractMethodCommand.getCommand());
+		Assert.assertNotNull(extractMethodCommand.getArguments());
+		Assert.assertEquals(2, extractMethodCommand.getArguments().size());
+		Assert.assertEquals(ExtractProposalUtility.EXTRACT_METHOD_COMMAND, extractMethodCommand.getArguments().get(0));
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/GetRefactorEditHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/GetRefactorEditHandlerTest.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.refactoring;
+
+import java.util.Hashtable;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.jdt.ls.core.internal.codemanipulation.AbstractSourceTestCase;
+import org.eclipse.jdt.ls.core.internal.correction.AbstractSelectionTest;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.GetRefactorEditParams;
+import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.RefactorWorkspaceEdit;
+import org.eclipse.jdt.ls.core.internal.text.correction.ExtractProposalUtility;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Range;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GetRefactorEditHandlerTest extends AbstractSelectionTest {
+	private IJavaProject fJProject1;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testExtractVariable() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(ExtractProposalUtility.EXTRACT_VARIABLE_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = evaluateChanges(refactorEdit.edit.getChanges());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int j = 0;\n");
+		buf.append("        int x= /*]*/j/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+
+	@Test
+	public void testExtractVariableAllOccurrence() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(ExtractProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = evaluateChanges(refactorEdit.edit.getChanges());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int j = 0;\n");
+		buf.append("        int x= /*]*/j/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+
+	@Test
+	public void testExtractConstant() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	void m(int i){\n");
+		buf.append("		int x= /*]*/0/*[*/;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(ExtractProposalUtility.EXTRACT_CONSTANT_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = evaluateChanges(refactorEdit.edit.getChanges());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class A{\n");
+		buf.append("	private static final int _0 = /*]*/0/*[*/;\n");
+		buf.append("\n");
+		buf.append("    void m(int i){\n");
+		buf.append("		int x= _0;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+
+	@Test
+	public void testExtractMethod() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public int foo(boolean b1, boolean b2) {\n");
+		buf.append("        int n = 0;\n");
+		buf.append("        int i = 0;\n");
+		buf.append("        /*[*/\n");
+		buf.append("        if (b1)\n");
+		buf.append("            i = 1;\n");
+		buf.append("        if (b2)\n");
+		buf.append("            n = n + i;\n");
+		buf.append("        /*]*/\n");
+		buf.append("        return n;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		GetRefactorEditParams editParams = new GetRefactorEditParams(ExtractProposalUtility.EXTRACT_METHOD_COMMAND, params);
+		RefactorWorkspaceEdit refactorEdit = GetRefactorEditHandler.getEditsForRefactor(editParams);
+		Assert.assertNotNull(refactorEdit);
+		Assert.assertNotNull(refactorEdit.edit);
+		String actual = evaluateChanges(refactorEdit.edit.getChanges());
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public int foo(boolean b1, boolean b2) {\n");
+		buf.append("        int n = 0;\n");
+		buf.append("        int i = 0;\n");
+		buf.append("        n = extracted(b1, b2, n, i);\n");
+		buf.append("        return n;\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private int extracted(boolean b1, boolean b2, int n, int i) {\n");
+		buf.append("        /*[*/\n");
+		buf.append("        if (b1)\n");
+		buf.append("            i = 1;\n");
+		buf.append("        if (b2)\n");
+		buf.append("            n = n + i;\n");
+		buf.append("        /*]*/\n");
+		buf.append("        return n;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		AbstractSourceTestCase.compareSource(buf.toString(), actual);
+
+		Assert.assertNotNull(refactorEdit.command);
+		Assert.assertEquals(GetRefactorEditHandler.RENAME_COMMAND, refactorEdit.command.getCommand());
+		Assert.assertNotNull(refactorEdit.command.getArguments());
+		Assert.assertEquals(1, refactorEdit.command.getArguments().size());
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix redhat-developer/vscode-java#333

The jdt.ls will return the rename position for the new extracted node, and it requires the client side to consume it to pop up the rename box.
![extractMethod](https://user-images.githubusercontent.com/14052197/60074929-b0297780-9756-11e9-96c1-99907bee918c.gif)