### PR TITLE
Prevent aggressive classpath updates when jars don't change

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -317,7 +317,7 @@ public final class ProjectUtils {
 			newEntries.add(newEntry);
 		}
 		IClasspathEntry[] newClasspath = newEntries.toArray(new IClasspathEntry[newEntries.size()]);
-		if (!rawClasspath.equals(newClasspath)) {
+		if (!Arrays.equals(rawClasspath, newClasspath)) {
 			javaProject.setRawClasspath(newClasspath, monitor);
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Sheng Chen <sheche@microsoft.com>

It seems that here the `Arrays.equals()` is intended to be used, since the original condition in the if-block will always return true.