### PR TITLE
Register static commands at initialization

### DIFF
--- a/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.delegateCommandHandler.exsd
+++ b/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.delegateCommandHandler.exsd
@@ -81,6 +81,13 @@
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="static" type="boolean">
+            <annotation>
+               <documentation>
+                  Static commands are registered at the JDT LS initialization and are independent of the LS configuration settings
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -68,10 +68,13 @@ final public class InitHandler {
 	private JavaClientConnection connection;
 	private PreferenceManager preferenceManager;
 
-	public InitHandler(ProjectsManager manager, PreferenceManager preferenceManager, JavaClientConnection connection) {
+	private WorkspaceExecuteCommandHandler commandHandler;
+
+	public InitHandler(ProjectsManager manager, PreferenceManager preferenceManager, JavaClientConnection connection, WorkspaceExecuteCommandHandler commandHandler) {
 		this.projectsManager = manager;
 		this.connection = connection;
 		this.preferenceManager = preferenceManager;
+		this.commandHandler = commandHandler;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -174,13 +177,13 @@ final public class InitHandler {
 			capabilities.setCodeActionProvider(Boolean.TRUE);
 		}
 		if (!preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
-			Set<String> commands = WorkspaceExecuteCommandHandler.getAllCommands();
+			Set<String> commands = commandHandler.getAllCommands();
 			if (!commands.isEmpty()) {
 				capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(commands)));
 			}
 		} else {
 			// Send static command at the startup - they remain registered all the time
-			Set<String> staticCommands = WorkspaceExecuteCommandHandler.getStaticCommands();
+			Set<String> staticCommands = commandHandler.getStaticCommands();
 			if (!staticCommands.isEmpty()) {
 				capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(staticCommands)));
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -174,8 +174,16 @@ final public class InitHandler {
 			capabilities.setCodeActionProvider(Boolean.TRUE);
 		}
 		if (!preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
-			Set<String> commands = WorkspaceExecuteCommandHandler.getCommands();
-			capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(commands)));
+			Set<String> commands = WorkspaceExecuteCommandHandler.getAllCommands();
+			if (!commands.isEmpty()) {
+				capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(commands)));
+			}
+		} else {
+			// Send static command at the startup - they remain registered all the time
+			Set<String> staticCommands = WorkspaceExecuteCommandHandler.getStaticCommands();
+			if (!staticCommands.isEmpty()) {
+				capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(new ArrayList<>(staticCommands)));
+			}
 		}
 		if (!preferenceManager.getClientPreferences().isWorkspaceSymbolDynamicRegistered()) {
 			capabilities.setWorkspaceSymbolProvider(Boolean.TRUE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -290,7 +290,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		}
 		if (preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isExecuteCommandEnabled(), Preferences.EXECUTE_COMMAND_ID, Preferences.WORKSPACE_EXECUTE_COMMAND,
-					new ExecuteCommandOptions(new ArrayList<>(WorkspaceExecuteCommandHandler.getCommands())));
+					new ExecuteCommandOptions(new ArrayList<>(WorkspaceExecuteCommandHandler.getNonStaticCommands())));
 		}
 		if (preferenceManager.getClientPreferences().isCodeActionDynamicRegistered()) {
 			toggleCapability(preferenceManager.getClientPreferences().isCodeActionDynamicRegistered(), Preferences.CODE_ACTION_ID, Preferences.CODE_ACTION, getCodeActionOptions());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -144,6 +144,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	private DocumentLifeCycleHandler documentLifeCycleHandler;
 	private WorkspaceDiagnosticsHandler workspaceDiagnosticsHandler;
 	private JVMConfigurator jvmConfigurator;
+	private WorkspaceExecuteCommandHandler commandHandler;
 
 	private Set<String> registeredCapabilities = new HashSet<>(3);
 
@@ -154,10 +155,15 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	}
 
 	public JDTLanguageServer(ProjectsManager projects, PreferenceManager preferenceManager) {
+		this(projects, preferenceManager, WorkspaceExecuteCommandHandler.getInstance());
+	}
+
+	public JDTLanguageServer(ProjectsManager projects, PreferenceManager preferenceManager, WorkspaceExecuteCommandHandler commandHandler) {
 		this.pm = projects;
 		this.preferenceManager = preferenceManager;
 		this.jvmConfigurator = new JVMConfigurator();
 		JavaRuntime.addVMInstallChangedListener(jvmConfigurator);
+		this.commandHandler = commandHandler;
 	}
 
 	public void connectClient(JavaLanguageClient client) {
@@ -182,7 +188,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
 		logInfo(">> initialize");
-		InitHandler handler = new InitHandler(pm, preferenceManager, client);
+		InitHandler handler = new InitHandler(pm, preferenceManager, client, commandHandler);
 		return CompletableFuture.completedFuture(handler.initialize(params));
 	}
 
@@ -290,7 +296,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 		}
 		if (preferenceManager.getClientPreferences().isExecuteCommandDynamicRegistrationSupported()) {
 			toggleCapability(preferenceManager.getPreferences().isExecuteCommandEnabled(), Preferences.EXECUTE_COMMAND_ID, Preferences.WORKSPACE_EXECUTE_COMMAND,
-					new ExecuteCommandOptions(new ArrayList<>(WorkspaceExecuteCommandHandler.getNonStaticCommands())));
+					new ExecuteCommandOptions(new ArrayList<>(commandHandler.getNonStaticCommands())));
 		}
 		if (preferenceManager.getClientPreferences().isCodeActionDynamicRegistered()) {
 			toggleCapability(preferenceManager.getClientPreferences().isCodeActionDynamicRegistered(), Preferences.CODE_ACTION_ID, Preferences.CODE_ACTION, getCodeActionOptions());
@@ -440,9 +446,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
 		logInfo(">> workspace/executeCommand " + (params == null ? null : params.getCommand()));
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
 		return computeAsync((monitor) -> {
-			return handler.executeCommand(params, monitor);
+			return commandHandler.executeCommand(params, monitor);
 		});
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler.java
@@ -38,6 +38,15 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
 public class WorkspaceExecuteCommandHandler {
 
+	private static WorkspaceExecuteCommandHandler instance = null;
+
+	public static WorkspaceExecuteCommandHandler getInstance() {
+		if (instance == null) {
+			instance = new WorkspaceExecuteCommandHandler();
+		}
+		return instance;
+	}
+
 	/**
 	 * Extension point ID for the delegate command handler.
 	 */
@@ -112,9 +121,13 @@ public class WorkspaceExecuteCommandHandler {
 		}
 	}
 
-	private static Set<DelegateCommandHandlerDescriptor> fgContributedCommandHandlers;
+	private Set<DelegateCommandHandlerDescriptor> fgContributedCommandHandlers;
 
-	private static synchronized Set<DelegateCommandHandlerDescriptor> getDelegateCommandHandlerDescriptors() {
+	private WorkspaceExecuteCommandHandler() {
+
+	}
+
+	private synchronized Set<DelegateCommandHandlerDescriptor> getDelegateCommandHandlerDescriptors() {
 		if (fgContributedCommandHandlers == null) {
 			IConfigurationElement[] elements = Platform.getExtensionRegistry().getConfigurationElementsFor(EXTENSION_POINT_ID);
 			fgContributedCommandHandlers = Stream.of(elements).map(e -> new DelegateCommandHandlerDescriptor(e)).collect(Collectors.toSet());
@@ -122,7 +135,7 @@ public class WorkspaceExecuteCommandHandler {
 		return fgContributedCommandHandlers;
 	}
 
-	public static Set<String> getStaticCommands() {
+	public Set<String> getStaticCommands() {
 		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
 		Set<String> commands = new HashSet<>();
 		for (DelegateCommandHandlerDescriptor handler : handlers) {
@@ -131,7 +144,7 @@ public class WorkspaceExecuteCommandHandler {
 		return commands;
 	}
 
-	public static Set<String> getNonStaticCommands() {
+	public Set<String> getNonStaticCommands() {
 		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
 		Set<String> commands = new HashSet<>();
 		for (DelegateCommandHandlerDescriptor handler : handlers) {
@@ -140,7 +153,7 @@ public class WorkspaceExecuteCommandHandler {
 		return commands;
 	}
 
-	public static Set<String> getAllCommands() {
+	public Set<String> getAllCommands() {
 		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
 		Set<String> commands = new HashSet<>();
 		for (DelegateCommandHandlerDescriptor handler : handlers) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandler.java
@@ -45,6 +45,8 @@ public class WorkspaceExecuteCommandHandler {
 
 	private static final String COMMAND = "command";
 
+	private static final String STATIC = "static";
+
 	private static final String CLASS = "class";
 
 	private static final String ID = "id";
@@ -53,7 +55,9 @@ public class WorkspaceExecuteCommandHandler {
 
 		private final IConfigurationElement fConfigurationElement;
 
-		private Set<String> fCommandIds;
+		private Set<String> fStaticCommandIds = new HashSet<>();;
+		private Set<String> fNonStaticCommandIds = new HashSet<>();
+		private Set<String> fAllCommands = new HashSet<>();
 
 		private IDelegateCommandHandler fDelegateCommandHandlerInstance;
 
@@ -61,12 +65,31 @@ public class WorkspaceExecuteCommandHandler {
 			fConfigurationElement = element;
 
 			IConfigurationElement[] children = fConfigurationElement.getChildren(COMMAND);
-			fCommandIds = Stream.of(children).map(c -> c.getAttribute(ID)).collect(Collectors.toSet());
+			Stream.of(children).forEach(c -> {
+				String id = c.getAttribute(ID);
+				if (Boolean.valueOf(c.getAttribute(STATIC))) {
+					fStaticCommandIds.add(id);
+				} else {
+					fNonStaticCommandIds.add(id);
+				}
+				fAllCommands.add(id);
+			});
 			fDelegateCommandHandlerInstance = null;
+
+			JavaLanguageServerPlugin.logInfo("Static Commands: " + fStaticCommandIds);
+			JavaLanguageServerPlugin.logInfo("Non-Static Commands: " + fNonStaticCommandIds);
 		}
 
-		public Set<String> getCommands() {
-			return fCommandIds;
+		public Set<String> getStaticCommands() {
+			return fStaticCommandIds;
+		}
+
+		public Set<String> getNonStaticCommands() {
+			return fNonStaticCommandIds;
+		}
+
+		public Set<String> getAllCommands() {
+			return fAllCommands;
 		}
 
 		public synchronized IDelegateCommandHandler getDelegateCommandHandler() {
@@ -99,14 +122,33 @@ public class WorkspaceExecuteCommandHandler {
 		return fgContributedCommandHandlers;
 	}
 
-	public static Set<String> getCommands() {
+	public static Set<String> getStaticCommands() {
 		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
 		Set<String> commands = new HashSet<>();
 		for (DelegateCommandHandlerDescriptor handler : handlers) {
-			commands.addAll(handler.getCommands());
+			commands.addAll(handler.getStaticCommands());
 		}
 		return commands;
 	}
+
+	public static Set<String> getNonStaticCommands() {
+		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
+		Set<String> commands = new HashSet<>();
+		for (DelegateCommandHandlerDescriptor handler : handlers) {
+			commands.addAll(handler.getNonStaticCommands());
+		}
+		return commands;
+	}
+
+	public static Set<String> getAllCommands() {
+		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
+		Set<String> commands = new HashSet<>();
+		for (DelegateCommandHandlerDescriptor handler : handlers) {
+			commands.addAll(handler.getAllCommands());
+		}
+		return commands;
+	}
+
 	/**
 	 * Execute workspace command and invoke language server delegate command
 	 * handler for matching command
@@ -125,7 +167,7 @@ public class WorkspaceExecuteCommandHandler {
 
 		Set<DelegateCommandHandlerDescriptor> handlers = getDelegateCommandHandlerDescriptors();
 
-		Collection<DelegateCommandHandlerDescriptor> candidates = handlers.stream().filter(desc -> desc.getCommands().contains(params.getCommand())).collect(Collectors.toSet()); //no cancellation here but it's super fast so it's ok.
+		Collection<DelegateCommandHandlerDescriptor> candidates = handlers.stream().filter(desc -> desc.getAllCommands().contains(params.getCommand())).collect(Collectors.toSet()); //no cancellation here but it's super fast so it's ok.
 
 		if (candidates.size() > 1) {
 			Exception ex = new IllegalStateException(String.format("Found multiple delegateCommandHandlers (%s) matching command %s", candidates, params.getCommand()));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceExecuteCommandHandlerTest.java
@@ -31,7 +31,7 @@ public class WorkspaceExecuteCommandHandlerTest extends AbstractProjectsManagerB
 
 	@Test
 	public void testExecuteCommand() {
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
+		WorkspaceExecuteCommandHandler handler = WorkspaceExecuteCommandHandler.getInstance();
 		ExecuteCommandParams params = new ExecuteCommandParams();
 		params.setCommand("testcommand1");
 		params.setArguments(Arrays.asList("hello", "world"));
@@ -48,7 +48,7 @@ public class WorkspaceExecuteCommandHandlerTest extends AbstractProjectsManagerB
 		expectedEx.expect(ResponseErrorException.class);
 		expectedEx.expectMessage("No delegateCommandHandler for testcommand.not.existing");
 
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
+		WorkspaceExecuteCommandHandler handler = WorkspaceExecuteCommandHandler.getInstance();
 		ExecuteCommandParams params = new ExecuteCommandParams();
 		params.setCommand("testcommand.not.existing");
 		params.setArguments(Arrays.asList("hello", "world"));
@@ -80,7 +80,7 @@ public class WorkspaceExecuteCommandHandlerTest extends AbstractProjectsManagerB
 
 		});
 
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
+		WorkspaceExecuteCommandHandler handler = WorkspaceExecuteCommandHandler.getInstance();
 		ExecuteCommandParams params = new ExecuteCommandParams();
 		params.setCommand("dup");
 		handler.executeCommand(params, monitor);
@@ -91,7 +91,7 @@ public class WorkspaceExecuteCommandHandlerTest extends AbstractProjectsManagerB
 		expectedEx.expect(ResponseErrorException.class);
 		expectedEx.expectMessage("Unsupported");
 
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
+		WorkspaceExecuteCommandHandler handler = WorkspaceExecuteCommandHandler.getInstance();
 		ExecuteCommandParams params = new ExecuteCommandParams();
 		params.setCommand("testcommand.throwexception");
 		handler.executeCommand(params, monitor);
@@ -102,7 +102,7 @@ public class WorkspaceExecuteCommandHandlerTest extends AbstractProjectsManagerB
 		expectedEx.expect(ResponseErrorException.class);
 		expectedEx.expectMessage("The workspace/executeCommand has empty params or command");
 
-		WorkspaceExecuteCommandHandler handler = new WorkspaceExecuteCommandHandler();
+		WorkspaceExecuteCommandHandler handler = WorkspaceExecuteCommandHandler.getInstance();
 		ExecuteCommandParams params = null;
 		handler.executeCommand(params, monitor);
 	}


### PR DESCRIPTION
Signed-off-by: BoykoAlex <aboyko@pivotal.io>

Fixes #1084 

Commands registered via `org.eclipse.jdt.ls.core.delegetaeCommandHandler`can have an optional `static` boolean attribute. If the attribute is `true` command is considered as "static" command registration of which is independent of configuration settings, i.e. the command is registered always.
"Static" commands are therefore always registered at the JDT LS initialization stage. While other commands that depend on configuration settings will be registered via dynamic capability registration if it is supported by the client (just like they were registered before).