### PR TITLE
Fix ChangeUtil for non-MultiTextEdit conversion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
@@ -54,6 +54,7 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.ltk.core.refactoring.resource.ResourceChange;
+import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
 
 /**
@@ -212,12 +213,14 @@ public class ChangeUtil {
 		convertTextEdit(root, compilationUnit, textEdits);
 	}
 
-	private static void convertTextEdit(WorkspaceEdit root, ICompilationUnit unit, TextEdit textEdits) {
-		TextEdit[] children = textEdits.getChildren();
-		if (children.length == 0) {
-			return;
+	private static void convertTextEdit(WorkspaceEdit root, ICompilationUnit unit, TextEdit edit) {
+		TextEdit[] textEdits;
+		if (edit instanceof MultiTextEdit) {
+			textEdits = edit.getChildren();
+		} else {
+			textEdits = new TextEdit[] { edit };
 		}
-		for (TextEdit textEdit : children) {
+		for (TextEdit textEdit : textEdits) {
 			TextEditConverter converter = new TextEditConverter(unit, textEdit);
 			String uri = JDTUtils.toURI(unit);
 			if (JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isResourceOperationSupported()) {


### PR DESCRIPTION
Signed-off-by: Yan Zhang <yanzh@microsoft.com>

#### Reason
When I was passing a simple `InsertEdit`, this method failed to process the edit as it had no children.

#### Change
- For `MultiTextEdit`, process its children; otherwise process the edit itself.
- Remove the zero-length check as it's already guarded by the for-loop. There's also no NPE risk as `TextEdit.getChildren()` always returns a non-null array.
