### PR TITLE
Refactor ChangeUtil: universal API converting Change to WorkspaceEdit

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
@@ -67,6 +67,14 @@ public class ChangeUtil {
 	private static final String TEMP_FILE_NAME = ".temp";
 	private static final Range ZERO_RANGE = new Range(new Position(), new Position());
 
+	/**
+	 * Converts Change to WorkspaceEdit for further consumption.
+	 *
+	 * @param change
+	 *            {@link Change} to convert
+	 * @return {@link WorkspaceEdit} converted from the change
+	 * @throws CoreException
+	 */
 	public static WorkspaceEdit convertToWorkspaceEdit(Change change) throws CoreException {
 		WorkspaceEdit edit = new WorkspaceEdit();
 		if (change instanceof CompositeChange) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
@@ -35,7 +35,6 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
-import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.DynamicValidationRefactoringChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenameCompilationUnitChange;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenamePackageChange;
 import org.eclipse.jdt.ls.core.internal.corext.util.JavaElementUtil;
@@ -68,34 +67,38 @@ public class ChangeUtil {
 	private static final String TEMP_FILE_NAME = ".temp";
 	private static final Range ZERO_RANGE = new Range(new Position(), new Position());
 
-	/**
-	 * Converts changes to resource operations if resource operations are supported
-	 * by the client otherwise converts to TextEdit changes.
-	 *
-	 * @param change
-	 *            changes after Refactoring operation
-	 * @param edit
-	 *            instance of workspace edit changes
-	 * @throws CoreException
-	 */
-	public static void convertCompositeChange(Change change, WorkspaceEdit edit) throws CoreException {
-		if (!(change instanceof CompositeChange)) {
+	public static WorkspaceEdit convertToWorkspaceEdit(Change change) throws CoreException {
+		WorkspaceEdit edit = new WorkspaceEdit();
+		if (change instanceof CompositeChange) {
+			convertCompositeChange((CompositeChange) change, edit);
+		} else {
+			convertSingleChange(change, edit);
+		}
+		return edit;
+	}
+
+	private static void convertSingleChange(Change change, WorkspaceEdit edit) throws CoreException {
+		if (change instanceof CompositeChange) {
 			return;
 		}
 
-		Change[] changes = ((CompositeChange) change).getChildren();
-		for (Change ch : changes) {
-			if (ch instanceof DynamicValidationRefactoringChange) {
-				CompositeChange compositeChange = (CompositeChange) ch;
-				for (Change child : compositeChange.getChildren()) {
-					doConvertCompositeChange(child, edit);
-				}
-			} else {
-				doConvertCompositeChange(ch, edit);
-			}
+		if (change instanceof TextChange) {
+			convertTextChange((TextChange) change, edit);
+		} else if (change instanceof ResourceChange) {
+			convertResourceChange((ResourceChange) change, edit);
 		}
 	}
 
+	private static void convertCompositeChange(CompositeChange change, WorkspaceEdit edit) throws CoreException {
+		Change[] changes = change.getChildren();
+		for (Change ch : changes) {
+			if (ch instanceof CompositeChange) {
+				convertCompositeChange((CompositeChange) ch, edit);
+			} else {
+				convertSingleChange(ch, edit);
+			}
+		}
+	}
 
 	/**
 	 * Converts changes to resource operations if resource operations are supported
@@ -107,7 +110,7 @@ public class ChangeUtil {
 	 *            instance of workspace edit changes
 	 * @throws CoreException
 	 */
-	public static void convertResourceChange(ResourceChange resourceChange, WorkspaceEdit edit) throws CoreException {
+	private static void convertResourceChange(ResourceChange resourceChange, WorkspaceEdit edit) throws CoreException {
 		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isResourceOperationSupported()) {
 			return;
 		}
@@ -123,20 +126,6 @@ public class ChangeUtil {
 			convertCUResourceChange(edit, (RenameCompilationUnitChange) resourceChange);
 		} else if (resourceChange instanceof RenamePackageChange) {
 			convertRenamePackcageChange(edit, (RenamePackageChange) resourceChange);
-		}
-	}
-
-	private static void doConvertCompositeChange(Change change, WorkspaceEdit edit) throws CoreException {
-		Object modifiedElement = change.getModifiedElement();
-		if (!(modifiedElement instanceof IJavaElement)) {
-			return;
-		}
-
-		if (change instanceof TextChange) {
-			convertTextChange(edit, (IJavaElement) modifiedElement, (TextChange) change);
-		} else if (change instanceof ResourceChange) {
-			ResourceChange resourceChange = (ResourceChange) change;
-			convertResourceChange(resourceChange, edit);
 		}
 	}
 
@@ -204,13 +193,18 @@ public class ChangeUtil {
 		edit.getDocumentChanges().add(Either.forRight(rf));
 	}
 
-	private static void convertTextChange(WorkspaceEdit root, IJavaElement element, TextChange textChange) {
+	private static void convertTextChange(TextChange textChange, WorkspaceEdit rootEdit) {
+		Object modifiedElement = textChange.getModifiedElement();
+		if (!(modifiedElement instanceof IJavaElement)) {
+			return;
+		}
+
 		TextEdit textEdits = textChange.getEdit();
 		if (textEdits == null) {
 			return;
 		}
-		ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
-		convertTextEdit(root, compilationUnit, textEdits);
+		ICompilationUnit compilationUnit = (ICompilationUnit) ((IJavaElement) modifiedElement).getAncestor(IJavaElement.COMPILATION_UNIT);
+		convertTextEdit(rootEdit, compilationUnit, textEdits);
 	}
 
 	private static void convertTextEdit(WorkspaceEdit root, ICompilationUnit unit, TextEdit edit) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.internal.ui.text.correction.ProblemLocationCore;
 import org.eclipse.jdt.ls.core.internal.ChangeUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.TextEditConverter;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
 import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
 import org.eclipse.jdt.ls.core.internal.corrections.QuickFixProcessor;
@@ -47,9 +46,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.CompositeChange;
-import org.eclipse.ltk.core.refactoring.TextChange;
-import org.eclipse.ltk.core.refactoring.resource.ResourceChange;
 
 public class CodeActionHandler {
 
@@ -157,7 +153,6 @@ public class CodeActionHandler {
 		}
 	}
 
-
 	public static IProblemLocationCore[] getProblemLocationCores(ICompilationUnit unit, List<Diagnostic> diagnostics) {
 		IProblemLocationCore[] locations = new IProblemLocationCore[diagnostics.size()];
 		for (int i = 0; i < diagnostics.size(); i++) {
@@ -182,19 +177,20 @@ public class CodeActionHandler {
 	}
 
 	public static WorkspaceEdit convertChangeToWorkspaceEdit(ICompilationUnit unit, Change change) throws CoreException {
-		WorkspaceEdit $ = new WorkspaceEdit();
-
-		if (change instanceof TextChange) {
-			TextEditConverter converter = new TextEditConverter(unit, ((TextChange) change).getEdit());
-			String uri = JDTUtils.toURI(unit);
-			$.getChanges().put(uri, converter.convert());
-		} else if (change instanceof ResourceChange) {
-			ChangeUtil.convertResourceChange((ResourceChange) change, $);
-		} else if (change instanceof CompositeChange) {
-			ChangeUtil.convertCompositeChange(change, $);
-		}
-
-		return $;
+		//		WorkspaceEdit $ = new WorkspaceEdit();
+		//
+		//		if (change instanceof TextChange) {
+		//			TextEditConverter converter = new TextEditConverter(unit, ((TextChange) change).getEdit());
+		//			String uri = JDTUtils.toURI(unit);
+		//			$.getChanges().put(uri, converter.convert());
+		//		} else if (change instanceof ResourceChange) {
+		//			ChangeUtil.convertResourceChange((ResourceChange) change, $);
+		//		} else if (change instanceof CompositeChange) {
+		//			ChangeUtil.convertCompositeChange(change, $);
+		//		}
+		//
+		//		return $;
+		return ChangeUtil.convertToWorkspaceEdit(change);
 	}
 
 	public static CompilationUnit getASTRoot(ICompilationUnit unit) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -45,7 +45,6 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.ltk.core.refactoring.Change;
 
 public class CodeActionHandler {
 
@@ -134,7 +133,7 @@ public class CodeActionHandler {
 			CUCorrectionCommandProposal commandProposal = (CUCorrectionCommandProposal) proposal;
 			command = new Command(name, commandProposal.getCommand(), commandProposal.getCommandArguments());
 		} else {
-			WorkspaceEdit edit = convertChangeToWorkspaceEdit(unit, proposal.getChange());
+			WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(proposal.getChange());
 			if (!ChangeUtil.hasChanges(edit)) {
 				return Optional.empty();
 			}
@@ -174,23 +173,6 @@ public class CodeActionHandler {
 			// return 0
 		}
 		return $;
-	}
-
-	public static WorkspaceEdit convertChangeToWorkspaceEdit(ICompilationUnit unit, Change change) throws CoreException {
-		//		WorkspaceEdit $ = new WorkspaceEdit();
-		//
-		//		if (change instanceof TextChange) {
-		//			TextEditConverter converter = new TextEditConverter(unit, ((TextChange) change).getEdit());
-		//			String uri = JDTUtils.toURI(unit);
-		//			$.getChanges().put(uri, converter.convert());
-		//		} else if (change instanceof ResourceChange) {
-		//			ChangeUtil.convertResourceChange((ResourceChange) change, $);
-		//		} else if (change instanceof CompositeChange) {
-		//			ChangeUtil.convertCompositeChange(change, $);
-		//		}
-		//
-		//		return $;
-		return ChangeUtil.convertToWorkspaceEdit(change);
 	}
 
 	public static CompilationUnit getASTRoot(ICompilationUnit unit) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalPositionGroupCore;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalPositionGroupCore.PositionInformation;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.ChangeUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
@@ -72,7 +73,7 @@ public class GetRefactorEditHandler {
 			}
 
 			Change change = proposal.getChange();
-			WorkspaceEdit edit = CodeActionHandler.convertChangeToWorkspaceEdit(unit, change);
+			WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
 			LinkedProposalModelCore linkedProposalModel = proposal.getLinkedProposalModel();
 			Command additionalCommand = null;
 			if (linkedProposalModel != null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandler.java
@@ -92,7 +92,7 @@ public class RenameHandler {
 			}
 
 			Change change = create.getChange();
-			ChangeUtil.convertCompositeChange(change, edit);
+			return ChangeUtil.convertToWorkspaceEdit(change);
 		} catch (CoreException ex) {
 			JavaLanguageServerPlugin.logException("Problem with rename for " + params.getTextDocument().getUri(), ex);
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ChangeUtilTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ChangeUtilTest.java
@@ -87,7 +87,7 @@ public class ChangeUtilTest extends AbstractProjectsManagerBasedTest {
 		String newName = "ENew.java";
 		RenameCompilationUnitChange change = new RenameCompilationUnitChange(cu, newName);
 		String oldUri = JDTUtils.toURI(cu);
-		String newUri = ResourceUtils.fixURI(URI.create(oldUri).resolve("..").resolve(newName));
+		String newUri = ResourceUtils.fixURI(URI.create(oldUri).resolve(newName));
 
 		WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ChangeUtilTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ChangeUtilTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.changes.RenameCompilationUnitChange;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.eclipse.lsp4j.RenameFile;
+import org.eclipse.lsp4j.ResourceOperation;
+import org.eclipse.lsp4j.TextDocumentEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.text.edits.InsertEdit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/**
+ * @author Yan Zhang
+ *
+ */
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChangeUtilTest extends AbstractProjectsManagerBasedTest {
+
+	private ClientPreferences clientPreferences;
+
+	private IPackageFragmentRoot sourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		IJavaProject javaProject = newEmptyProject();
+		sourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src"));
+		clientPreferences = preferenceManager.getClientPreferences();
+		when(clientPreferences.isResourceOperationSupported()).thenReturn(true);
+	}
+
+	// Text Changes
+	@Test
+	public void testConvertCompilationUnitChange() throws CoreException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "", false, null);
+		CompilationUnitChange change = new CompilationUnitChange("insertText", cu);
+		String newText = "// some content";
+		change.setEdit(new InsertEdit(0, newText));
+
+		WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
+
+		assertEquals(edit.getDocumentChanges().size(), 1);
+
+		TextDocumentEdit textDocumentEdit = edit.getDocumentChanges().get(0).getLeft();
+		assertNotNull(textDocumentEdit);
+		assertEquals(textDocumentEdit.getEdits().size(), 1);
+
+		TextEdit textEdit = textDocumentEdit.getEdits().get(0);
+		assertEquals(textEdit.getNewText(), newText);
+	}
+
+	// Resource Changes
+	@Test
+	public void testConvertRenameCompilationUnitChange() throws CoreException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "", false, null);
+		String newName = "ENew.java";
+		RenameCompilationUnitChange change = new RenameCompilationUnitChange(cu, newName);
+		String oldUri = JDTUtils.toURI(cu);
+		String newUri = ResourceUtils.fixURI(URI.create(oldUri).resolve("..").resolve(newName));
+
+		WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
+
+		assertEquals(edit.getDocumentChanges().size(), 1);
+
+		ResourceOperation resourceOperation = edit.getDocumentChanges().get(0).getRight();
+		assertTrue(resourceOperation instanceof RenameFile);
+
+		assertEquals(((RenameFile) resourceOperation).getOldUri(), oldUri);
+		assertEquals(((RenameFile) resourceOperation).getNewUri(), newUri);
+	}
+
+	//Composite Changes
+	@Test
+	public void testConvertSimpleCompositeChange() throws CoreException {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "", false, null);
+		CompositeChange change = new CompositeChange("simple composite change");
+
+		RenameCompilationUnitChange resourceChange = new RenameCompilationUnitChange(cu, "ENew.java");
+		change.add(resourceChange);
+		CompilationUnitChange textChange = new CompilationUnitChange("insertText", cu);
+		textChange.setEdit(new InsertEdit(0, "// some content"));
+		change.add(textChange);
+
+		WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
+		assertEquals(edit.getDocumentChanges().size(), 2);
+		assertTrue(edit.getDocumentChanges().get(0).getRight() instanceof RenameFile);
+		assertTrue(edit.getDocumentChanges().get(1).getLeft() instanceof TextDocumentEdit);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractFieldTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/ExtractFieldTest.java
@@ -28,12 +28,12 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.ls.core.internal.ChangeUtil;
 import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractFieldRefactoring;
 import org.eclipse.jdt.ls.core.internal.correction.AbstractSelectionTest;
 import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
-import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
 import org.eclipse.jdt.ls.core.internal.text.correction.ExtractProposalUtility.InitializeScope;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -568,7 +568,7 @@ public class ExtractFieldTest extends AbstractSelectionTest {
 		assertTrue("precondition was supposed to pass but was " + checkInputResult.toString(), checkInputResult.isOK());
 
 		Change change = refactoring.createChange(new NullProgressMonitor());
-		WorkspaceEdit edit = CodeActionHandler.convertChangeToWorkspaceEdit(cu, change);
+		WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(change);
 		assertNotNull(change);
 		String actual = evaluateChanges(edit.getChanges());
 		assertEquals(expected, actual);


### PR DESCRIPTION
Currently for each type of `Change`, there's a corresponding public method located in `ChangeUtil`, which is not elegant or consistent. E.g.
* void convert**CompositeChange**(**Change** change, WorkspaceEdit edit) 
* void convertResourceChange(ResourceChange resourceChange, WorkspaceEdit edit) 
* void convertTextChange(WorkspaceEdit root, **IJavaElement** element, TextChange textChange)
* etc.

Anytime you want to convert a `Change` to a `WorkspaceEdit`, you have to explicitly call the corresponding utility based on the type of Change. 

This PR refactors the utility and use `ChangeUtil.convertToWorkspaceEdit(Change change)` as the **only** entry to convert `Change` to `WorkspaceEdit`. 