### PR TITLE
Stop creating files in bin directory

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -36,6 +36,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.internal.net.ProxySelector;
 import org.eclipse.core.net.proxy.IProxyData;
 import org.eclipse.core.net.proxy.IProxyService;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -125,6 +127,10 @@ public class JavaLanguageServerPlugin extends Plugin {
 		super.start(bundleContext);
 		try {
 			Platform.getBundle(ResourcesPlugin.PI_RESOURCES).start(Bundle.START_TRANSIENT);
+			IWorkspace workspace = ResourcesPlugin.getWorkspace();
+			IWorkspaceDescription description = workspace.getDescription();
+			description.setAutoBuilding(false);
+			workspace.setDescription(description);
 		} catch (BundleException e) {
 			logException(e.getMessage(), e);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -241,7 +241,7 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 			if (JavaCore.isJavaLikeFileName(file.getName())) {
 				ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
 				//ignoring working copies, they're handled in the DocumentLifecycleHandler
-				if (!cu.isWorkingCopy()) {
+				if (cu != null && !cu.isWorkingCopy()) {
 					try {
 						document = JsonRpcHelpers.toDocument(cu.getBuffer());
 					} catch (JavaModelException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
@@ -12,7 +12,9 @@ package org.eclipse.jdt.ls.core.internal.managers;
 
 import static org.eclipse.core.resources.IProjectDescription.DESCRIPTION_FILE_NAME;
 
+import java.io.File;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -25,6 +27,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -40,6 +43,7 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 					.addExclusions("**/bin");//default Eclipse build dir
 			directories = eclipseDetector.scan(monitor);
 		}
+		directories = directories.stream().filter(path -> (new File(path.toFile(), IJavaProject.CLASSPATH_FILE_NAME).exists())).collect(Collectors.toList());
 		return !directories.isEmpty();
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -108,4 +108,5 @@ public class GradleBuildSupport implements IBuildSupport {
 	public static void saveModels() {
 		CorePlugin.listenerRegistry().dispatch(new WorkbenchShutdownEvent());
 	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -32,6 +32,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -45,7 +46,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 
 	public static final String GRADLE_HOME = "GRADLE_HOME";
 
-	private static final String BUILD_GRADLE_DESCRIPTOR = "build.gradle";
+	public static final String BUILD_GRADLE_DESCRIPTOR = "build.gradle";
 
 	public static final GradleDistribution DEFAULT_DISTRIBUTION = GradleDistribution.forVersion(GradleVersion.current().getVersion());
 
@@ -201,6 +202,9 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	}
 
 	private static boolean checkGradlePersistence(boolean shouldSynchronize, IProject project, File projectDir) {
+		if (!ProjectUtils.isJavaProject(project) || !project.getFile(IJavaProject.CLASSPATH_FILE_NAME).exists()) {
+			return true;
+		}
 		PersistentModel model = CorePlugin.modelPersistence().loadModel(project);
 		if (model.isPresent()) {
 			File persistentFile = CorePlugin.getInstance().getStateLocation().append("project-preferences").append(project.getName()).toFile();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -15,6 +15,8 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 
 /**
@@ -70,6 +72,13 @@ public interface IBuildSupport {
 			return;
 		}
 		if (changeType == CHANGE_TYPE.DELETED) {
+			if (IJavaProject.CLASSPATH_FILE_NAME.equals(resource.getName())) {
+				IProject project = resource.getProject();
+				if (ProjectUtils.isJavaProject(project)) {
+					ProjectUtils.removeJavaNatureAndBuilder(project, monitor);
+					update(project, true, monitor);
+				}
+			}
 			resource = resource.getParent();
 		}
 		if (resource != null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -145,7 +146,8 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				toImport.add(projectInfo);
 			} else {
 				IProject project = container.getProject();
-				if (ProjectUtils.isMavenProject(project)) {
+				boolean valid = !ProjectUtils.isJavaProject(project) || project.getFile(IJavaProject.CLASSPATH_FILE_NAME).exists();
+				if (ProjectUtils.isMavenProject(project) && valid) {
 					projects.add(container.getProject());
 				} else if (project != null) {
 					//Project doesn't have the Maven nature, so we (re)import it

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/classpath/.project
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/classpath/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>classpath</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/classpath2/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/classpath2/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="target"/>
+</classpath>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/classpath2/.project
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/classpath2/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>classpath2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/projects/gradle/simple-gradle/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/simple-gradle/build.gradle
@@ -9,6 +9,7 @@
 
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 sourceCompatibility = 1.7
 
@@ -29,4 +30,10 @@ dependencies {
     // testCompile dependency to testCompile 'org.testng:testng:6.8.1' and add
     // 'test.useTestNG()' to your build script.
     testCompile 'junit:junit:4.12'
+}
+
+eclipse {
+  classpath {
+    defaultOutputDir = file('target')
+  }
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerTestPlugin.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerTestPlugin.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
 import org.osgi.framework.BundleActivator;
@@ -30,6 +33,10 @@ public class JavaLanguageServerTestPlugin implements BundleActivator {
 	public void start(BundleContext context) throws Exception {
 		TestVMType.setTestJREAsDefault("1.8");
 		JavaCore.initializeAfterLoad(new NullProgressMonitor());
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IWorkspaceDescription description = workspace.getDescription();
+		description.setAutoBuilding(true);
+		workspace.setDescription(description);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.managers;
 
 import static org.eclipse.jdt.ls.core.internal.ProjectUtils.getJavaSourceLevel;
+import static org.eclipse.jdt.ls.core.internal.WorkspaceHelper.getProject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -39,6 +40,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -130,6 +132,24 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		assertEquals(2, projects.size());
 		invalid = WorkspaceHelper.getProject(INVALID);
 		assertIsMavenProject(invalid);
+	}
+
+	@Test
+	public void testDeleteClasspath() throws Exception {
+		String name = "salut";
+		importProjects("maven/" + name);
+		IProject project = getProject(name);
+		assertIsJavaProject(project);
+		assertIsMavenProject(project);
+		IFile dotClasspath = project.getFile(IJavaProject.CLASSPATH_FILE_NAME);
+		File file = dotClasspath.getRawLocation().toFile();
+		assertTrue(file.exists());
+		file.delete();
+		projectsManager.fileChanged(file.toPath().toUri().toString(), CHANGE_TYPE.DELETED);
+		project = getProject(name);
+		IFile bin = project.getFile("bin");
+		assertFalse(bin.getRawLocation().toFile().exists());
+		assertTrue(dotClasspath.exists());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/634

The issue can be reproduced in Eclipse. The reason for the issue is that JDT uses the project's path as a source folder when the project doesn't contain .classpath.
The PR works in the following way:

1) if a user deletes .classpath, Java LS will delete the Java nature and builder from the project
2) EclipseProjectImporter doesn't import those directories that don't have .classpath

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>