### PR TITLE
Enable the 'Invert conditions' fix

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.QuickFixProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.text.correction.AdvancedQuickAssistProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
@@ -56,6 +57,8 @@ public class CodeActionHandler {
 
 	private QuickAssistProcessor quickAssistProcessor;
 
+	private AdvancedQuickAssistProcessor advancedQuickAssistProcessor;
+
 	private SourceAssistProcessor sourceAssistProcessor;
 
 	private PreferenceManager preferenceManager;
@@ -64,6 +67,7 @@ public class CodeActionHandler {
 		this.preferenceManager = preferenceManager;
 		this.sourceAssistProcessor = new SourceAssistProcessor(preferenceManager);
 		this.quickAssistProcessor = new QuickAssistProcessor(preferenceManager);
+		this.advancedQuickAssistProcessor = new AdvancedQuickAssistProcessor();
 	}
 
 	/**
@@ -95,6 +99,13 @@ public class CodeActionHandler {
 			candidates.addAll(corrections);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Problem resolving quick assist code actions", e);
+		}
+
+		try {
+			List<CUCorrectionProposal> corrections = this.advancedQuickAssistProcessor.getAssists(params, context, locations);
+			candidates.addAll(corrections);
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logException("Problem resolving advanced quick assist code actions", e);
 		}
 
 		candidates.sort(new CUCorrectionProposalComparator());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InvertConditionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InvertConditionTest.java
@@ -1,0 +1,513 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.refactoring;
+
+import java.util.Hashtable;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.jdt.ls.core.internal.correction.AbstractSelectionTest;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Range;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InvertConditionTest extends AbstractSelectionTest {
+
+	private IJavaProject testProject;
+
+	private IPackageFragmentRoot testSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		testProject = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+
+		testProject.setOptions(options);
+		testSourceFolder = testProject.getPackageFragmentRoot(testProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testInvertLessOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 < 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 >= 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 < 5", "3 < 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertGreaterOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 > 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 <= 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 > 5", "3 > 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertLessEqualsOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 <= 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 > 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 <= 5", "3 <= 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertGreaterEqualsOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 >= 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 < 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 >= 5", "3 >= 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertEqualsOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 == 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 != 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 == 5", "3 == 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertNotEqualsOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 != 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (3 == 5)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "3 != 5", "3 != 5".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertConditionalAndOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (true && true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (false || false)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true && true", "true && true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertConditionalOrOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (true || true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (false && false)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true || true", "true || true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertAndOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (true & true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (false | false)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true & true", "true & true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertOrOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (true | true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (false & false)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true | true", "true | true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertXorOperator() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (true ^ true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (!(true ^ true))\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true ^ true", "true ^ true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertBooleanLiteral() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        while (true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        while (false)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "true", "true".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertBooleanLiteralWithParentheses() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        while (!(!true))\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        while (!true)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "!(!true)", "!(!true)".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertComplexCondition() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        for (int i = 4; i > 3 && i < 10; i++)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        for (int i = 4; i <= 3 || i >= 10; i++)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "i > 3 && i < 10", "i > 3 && i < 10".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertVariable() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        boolean isValid = true;\n");
+		buf.append("        if (isValid)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        boolean isValid = true;\n");
+		buf.append("        if (!isValid)\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "isValid", "isValid".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+
+	@Test
+	public void testInvertMethodCalling() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public boolean isValid() {\n");
+		buf.append("        return true;\n");
+		buf.append("    }\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (isValid())\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public boolean isValid() {\n");
+		buf.append("        return true;\n");
+		buf.append("    }\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        if (!isValid())\n");
+		buf.append("            return;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Invert conditions", buf.toString(), CodeActionKind.Refactor);
+		Range replacedRange = CodeActionUtil.getRange(cu, "isValid()", "isValid()".length());
+		assertCodeActions(cu, replacedRange, expected);
+	}
+}


### PR DESCRIPTION
Signed-off-by: sheche@microsoft.com <sheche@microsoft.com>

This PR is to enable the fix: `invert conditions`. Some of the GIF for illustration:

Invert operators:
![Kapture 2019-07-18 at 19 39 07](https://user-images.githubusercontent.com/6193897/61455361-de852600-a995-11e9-9f83-0dd600b62477.gif)


Invert method calling
![Kapture 2019-07-18 at 19 43 17](https://user-images.githubusercontent.com/6193897/61455374-e93fbb00-a995-11e9-874e-00944139749a.gif)


Invert variable
![Kapture 2019-07-18 at 19 41 20](https://user-images.githubusercontent.com/6193897/61455389-f2308c80-a995-11e9-9904-9732946d71aa.gif)
