### PR TITLE
NavigateToDefinitionHandler should not return null

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
@@ -11,6 +11,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -45,7 +46,7 @@ public class NavigateToDefinitionHandler {
 			location = computeDefinitionNavigation(unit, position.getPosition().getLine(),
 					position.getPosition().getCharacter(), monitor);
 		}
-		return location == null ? null : Arrays.asList(location);
+		return location == null ? Collections.emptyList : Arrays.asList(location);
 	}
 
 	private Location computeDefinitionNavigation(ITypeRoot unit, int line, int column, IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -12,7 +12,6 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +51,8 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 	public void testGetEmptyDefinition() throws Exception {
 		List<? extends Location> definitions = handler.definition(
 				new TextDocumentPositionParams(new TextDocumentIdentifier("/foo/bar"), new Position(1, 1)), monitor);
-		assertNull(definitions);
+		assertNotNull(definitions);
+		assertEquals(0, definitions.size());
 	}
 
 	@Test
@@ -66,7 +66,8 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 		String uri = ClassFileUtil.getURI(project, "org.apache.commons.lang3.StringUtils");
 		when(preferenceManager.isClientSupportsClassFileContent()).thenReturn(false);
 		List<? extends Location> definitions = handler.definition(new TextDocumentPositionParams(new TextDocumentIdentifier(uri), new Position(20, 26)), monitor);
-		assertNull(definitions);
+		assertNotNull(definitions);
+		assertEquals(0, definitions.size());
 	}
 
 	@Test


### PR DESCRIPTION
When testing an instance of the server running locally in VSCode, I noticed quite a few error messages like the following from the node client:

![Screen Shot 2019-08-05 at 4 37 02 PM](https://user-images.githubusercontent.com/15987992/62501957-f6381900-b7a1-11e9-84c4-4cfd540198cc.png)

I tracked it down to this handler. Making this update to return an empty list instead, which makes the VSCode client happy. I've updated the tests.