### PR TITLE
Support move instance method and static member

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JSONUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JSONUtility.java
@@ -11,6 +11,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.util.HashMap;
+
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
@@ -25,6 +29,21 @@ public class JSONUtility {
 	 * @throws IllegalArgumentException if clazz is null
 	 */
 	public static <T> T toModel(Object object, Class<T> clazz){
+		return toModel(new Gson(), object, clazz);
+	}
+
+	/**
+	 * Converts given JSON objects to given Model objects with the customized
+	 * TypeAdapters from lsp4j.
+	 *
+	 * @throws IllegalArgumentException
+	 *             if clazz is null
+	 */
+	public static <T> T toLsp4jModel(Object object, Class<T> clazz) {
+		return toModel(new MessageJsonHandler(new HashMap<>()).getGson(), object, clazz);
+	}
+
+	private static <T> T toModel(Gson gson, Object object, Class<T> clazz) {
 		if(object == null){
 			return null;
 		}
@@ -32,18 +51,14 @@ public class JSONUtility {
 			throw new IllegalArgumentException("Class can not be null");
 		}
 		if(object instanceof JsonElement){
-			Gson gson = new Gson();
 			return gson.fromJson((JsonElement) object, clazz);
 		}
 		if (clazz.isInstance(object)) {
 			return clazz.cast(object);
 		}
 		if (object instanceof String) {
-			Gson gson = new Gson();
 			return gson.fromJson((String) object, clazz);
 		}
 		return null;
 	}
-
-
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.maven.shared.utils.StringUtils;
 import org.eclipse.buildship.core.internal.configuration.GradleProjectNature;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -116,6 +117,23 @@ public final class ProjectUtils {
 
 	public static IProject[] getAllProjects() {
 		return ResourcesPlugin.getWorkspace().getRoot().getProjects();
+	}
+
+	public static IProject getProject(String projectName) {
+		if (StringUtils.isBlank(projectName)) {
+			return null;
+		}
+
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+	}
+
+	public static IJavaProject getJavaProject(String projectName) {
+		IProject project = getProject(projectName);
+		if (project != null && isJavaProject(project)) {
+			return JavaCore.create(project);
+		}
+
+		return null;
 	}
 
 	public static boolean addSourcePath(IPath sourcePath, IJavaProject project) throws CoreException {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -892,7 +892,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<List<SymbolInformation>> searchSymbols(SearchSymbolParams params) {
 		logInfo(">> java/searchSymbols");
-		return computeAsyncWithClientProgress((monitor) -> WorkspaceSymbolHandler.search(params.getQuery(), params.top, params.projectName, params.sourceOnly, monitor));
+		return computeAsyncWithClientProgress((monitor) -> WorkspaceSymbolHandler.search(params.getQuery(), params.maxResults, params.projectName, params.sourceOnly, monitor));
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -64,6 +64,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveDestinationsRes
 import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.AddOverridableMethodParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.OverridableMethodsResponse;
+import org.eclipse.jdt.ls.core.internal.handlers.WorkspaceSymbolHandler.SearchSymbolParams;
 import org.eclipse.jdt.ls.core.internal.lsp.JavaProtocolExtensions;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.FormatterManager;
@@ -390,9 +391,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
 		logInfo(">> workspace/symbol");
-		WorkspaceSymbolHandler handler = new WorkspaceSymbolHandler(preferenceManager);
 		return computeAsync((monitor) -> {
-			return handler.search(params.getQuery(), monitor);
+			return WorkspaceSymbolHandler.search(params.getQuery(), monitor);
 		});
 	}
 
@@ -887,6 +887,12 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	public CompletableFuture<RefactorWorkspaceEdit> move(MoveParams params) {
 		logInfo(">> java/move");
 		return computeAsyncWithClientProgress((monitor) -> MoveHandler.move(params, monitor));
+	}
+
+	@Override
+	public CompletableFuture<List<SymbolInformation>> searchSymbols(SearchSymbolParams params) {
+		logInfo(">> java/searchSymbols");
+		return computeAsyncWithClientProgress((monitor) -> WorkspaceSymbolHandler.search(params.getQuery(), params.top, params.projectName, params.sourceOnly, monitor));
 	}
 
 	public void sendStatus(ServiceStatus serverStatus, String status) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
@@ -27,11 +27,13 @@ public class JdtDomModels {
 		public String bindingKey;
 		public String name;
 		public String type;
+		public boolean isField;
 
 		public LspVariableBinding(IVariableBinding binding) {
 			this.bindingKey = binding.getKey();
 			this.name = binding.getName();
 			this.type = binding.getType().getName();
+			this.isField = binding.isField();
 		}
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandler.java
@@ -253,6 +253,10 @@ public class MoveHandler {
 	}
 
 	public static RefactorWorkspaceEdit move(MoveParams moveParams, IProgressMonitor monitor) {
+		if (moveParams == null) {
+			return new RefactorWorkspaceEdit("moveParams should not be empty.");
+		}
+
 		// TODO Currently resource move operation only supports CU.
 		if ("moveResource".equalsIgnoreCase(moveParams.moveKind)) {
 			String targetUri = null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -13,7 +13,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.maven.shared.utils.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
@@ -44,7 +44,7 @@ public class WorkspaceSymbolHandler{
 		return search(query, 0, projectName, sourceOnly, monitor);
 	}
 
-	public static List<SymbolInformation> search(String query, int top, String projectName, boolean sourceOnly, IProgressMonitor monitor) {
+	public static List<SymbolInformation> search(String query, int maxResults, String projectName, boolean sourceOnly, IProgressMonitor monitor) {
 		ArrayList<SymbolInformation> symbols = new ArrayList<>();
 		if (StringUtils.isBlank(query)) {
 			return symbols;
@@ -81,7 +81,7 @@ public class WorkspaceSymbolHandler{
 							symbolInformation.setKind(mapKind(match));
 							symbolInformation.setLocation(location);
 							symbols.add(symbolInformation);
-							if (top > 0 && symbols.size() >= top) {
+							if (maxResults > 0 && symbols.size() >= maxResults) {
 								monitor.setCanceled(true);
 							}
 						}
@@ -139,7 +139,7 @@ public class WorkspaceSymbolHandler{
 	public static class SearchSymbolParams extends WorkspaceSymbolParams {
 		public String projectName;
 		public boolean sourceOnly;
-		public int top;
+		public int maxResults;
 
 		public SearchSymbolParams(String query, String projectName) {
 			super(query);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -11,11 +11,13 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.shared.utils.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
@@ -25,51 +27,72 @@ import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.core.search.TypeNameMatchRequestor;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.WorkspaceSymbolParams;
 
 public class WorkspaceSymbolHandler{
 
-	private PreferenceManager preferenceManager;
-
-	public WorkspaceSymbolHandler(PreferenceManager preferenceManager) {
-		this.preferenceManager = preferenceManager;
+	public static List<SymbolInformation> search(String query, IProgressMonitor monitor) {
+		return search(query, 0, null, false, monitor);
 	}
 
-	public List<SymbolInformation> search(String query, IProgressMonitor monitor) {
-		if (query == null || query.trim().isEmpty()) {
-			return Collections.emptyList();
+	public static List<SymbolInformation> search(String query, String projectName, boolean sourceOnly, IProgressMonitor monitor) {
+		return search(query, 0, projectName, sourceOnly, monitor);
+	}
+
+	public static List<SymbolInformation> search(String query, int top, String projectName, boolean sourceOnly, IProgressMonitor monitor) {
+		ArrayList<SymbolInformation> symbols = new ArrayList<>();
+		if (StringUtils.isBlank(query)) {
+			return symbols;
 		}
 
 		try {
-			ArrayList<SymbolInformation> symbols = new ArrayList<>();
-			new SearchEngine().searchAllTypeNames(null,SearchPattern.R_PATTERN_MATCH, query.toCharArray(), SearchPattern.R_CAMELCASE_MATCH, IJavaSearchConstants.TYPE, createSearchScope(),new TypeNameMatchRequestor() {
+			monitor.beginTask("Searching the types...", 100);
+			IJavaSearchScope searchScope = createSearchScope(projectName, sourceOnly);
+			int typeMatchRule = SearchPattern.R_CAMELCASE_MATCH;
+			if (query.contains("*") || query.contains("?")) {
+				typeMatchRule |= SearchPattern.R_PATTERN_MATCH;
+			}
+			new SearchEngine().searchAllTypeNames(null, SearchPattern.R_PATTERN_MATCH, query.trim().toCharArray(), typeMatchRule, IJavaSearchConstants.TYPE, searchScope, new TypeNameMatchRequestor() {
 
 				@Override
 				public void acceptTypeNameMatch(TypeNameMatch match) {
-					SymbolInformation symbolInformation = new SymbolInformation();
-					symbolInformation.setContainerName(match.getTypeContainerName());
-					symbolInformation.setName(match.getSimpleTypeName());
-					symbolInformation.setKind(mapKind(match));
-					Location location;
 					try {
-						if (match.getType().isBinary()) {
-							location = JDTUtils.toLocation(match.getType().getClassFile());
-						}  else {
-							location = JDTUtils.toLocation(match.getType());
+						Location location = null;
+						try {
+							if (!sourceOnly && match.getType().isBinary()) {
+								location = JDTUtils.toLocation(match.getType().getClassFile());
+							} else if (!match.getType().isBinary()) {
+								location = JDTUtils.toLocation(match.getType());
+							}
+						} catch (Exception e) {
+							JavaLanguageServerPlugin.logException("Unable to determine location for " + match.getSimpleTypeName(), e);
+							return;
+						}
+
+						if (location != null) {
+							SymbolInformation symbolInformation = new SymbolInformation();
+							symbolInformation.setContainerName(match.getTypeContainerName());
+							symbolInformation.setName(match.getSimpleTypeName());
+							symbolInformation.setKind(mapKind(match));
+							symbolInformation.setLocation(location);
+							symbols.add(symbolInformation);
+							if (top > 0 && symbols.size() >= top) {
+								monitor.setCanceled(true);
+							}
 						}
 					} catch (Exception e) {
-						JavaLanguageServerPlugin.logException("Unable to determine location for " +  match.getSimpleTypeName(), e);
+						JavaLanguageServerPlugin.logException("Unable to determine location for " + match.getSimpleTypeName(), e);
 						return;
 					}
-					symbolInformation.setLocation(location);
-					symbols.add(symbolInformation);
 				}
 
 				private SymbolKind mapKind(TypeNameMatch match) {
-					int flags= match.getModifiers();
+					int flags = match.getModifiers();
 					if (Flags.isInterface(flags)) {
 						return SymbolKind.Interface;
 					}
@@ -82,15 +105,45 @@ public class WorkspaceSymbolHandler{
 					return SymbolKind.Class;
 				}
 			}, IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH, monitor);
-			return symbols;
 		} catch (Exception e) {
-			JavaLanguageServerPlugin.logException("Problem getting search for" +  query, e);
+			if (e instanceof OperationCanceledException) {
+				// ignore.
+			} else {
+				JavaLanguageServerPlugin.logException("Problem getting search for" + query, e);
+			}
+		} finally {
+			monitor.done();
 		}
-		return Collections.emptyList();
+
+		return symbols;
 	}
 
-	private IJavaSearchScope createSearchScope() throws JavaModelException {
-		return JDTUtils.createSearchScope(null, preferenceManager);
+	private static IJavaSearchScope createSearchScope(String projectName, boolean sourceOnly) throws JavaModelException {
+		IJavaProject[] targetProjects;
+		IJavaProject project = ProjectUtils.getJavaProject(projectName);
+		if (project != null) {
+			targetProjects = new IJavaProject[] { project };
+		} else {
+			targetProjects = ProjectUtils.getJavaProjects();
+		}
+
+		int scope = IJavaSearchScope.REFERENCED_PROJECTS | IJavaSearchScope.SOURCES;
+		PreferenceManager preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
+		if (!sourceOnly && preferenceManager != null && preferenceManager.isClientSupportsClassFileContent()) {
+			scope |= IJavaSearchScope.APPLICATION_LIBRARIES | IJavaSearchScope.SYSTEM_LIBRARIES;
+		}
+
+		return SearchEngine.createJavaSearchScope(targetProjects, scope);
 	}
 
+	public static class SearchSymbolParams extends WorkspaceSymbolParams {
+		public String projectName;
+		public boolean sourceOnly;
+		public int top;
+
+		public SearchSymbolParams(String query, String projectName) {
+			super(query);
+			this.projectName = projectName;
+		}
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.lsp;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
@@ -29,7 +30,9 @@ import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveDestinationsRes
 import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.AddOverridableMethodParams;
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.OverridableMethodsResponse;
+import org.eclipse.jdt.ls.core.internal.handlers.WorkspaceSymbolHandler.SearchSymbolParams;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
@@ -105,4 +108,7 @@ public interface JavaProtocolExtensions {
 
 	@JsonRequest
 	CompletableFuture<RefactorWorkspaceEdit> move(MoveParams params);
+
+	@JsonRequest
+	CompletableFuture<List<SymbolInformation>> searchSymbols(SearchSymbolParams params);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -24,16 +25,22 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
@@ -44,6 +51,7 @@ import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractConstantR
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractFieldRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractMethodRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractTempRefactoring;
+import org.eclipse.jdt.ls.core.internal.corext.util.JdtFlags;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
@@ -61,14 +69,64 @@ public class RefactorProposalUtility {
 	public static final String EXTRACT_FIELD_COMMAND = "extractField";
 	public static final String CONVERT_VARIABLE_TO_FIELD_COMMAND = "convertVariableToField";
 	public static final String MOVE_FILE_COMMAND = "moveFile";
+	public static final String MOVE_INSTANCE_METHOD_COMMAND = "moveInstanceMethod";
+	public static final String MOVE_STATIC_MEMBER_COMMAND = "moveStaticMember";
 
 	public static List<CUCorrectionProposal> getMoveRefactoringProposals(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation) {
 		String label = ActionMessages.MoveRefactoringAction_label;
 		int relevance = IProposalRelevance.MOVE_REFACTORING;
+		ASTNode node = context.getCoveredNode();
+		if (node == null) {
+			node = context.getCoveringNode();
+		}
+
+		while (node != null && !(node instanceof BodyDeclaration)) {
+			node = node.getParent();
+		}
+
 		ICompilationUnit cu = context.getCompilationUnit();
+		if (cu != null && node != null) {
+			if (node instanceof MethodDeclaration && !JdtFlags.isStatic((BodyDeclaration) node)) {
+				// move instance method.
+				return Collections.singletonList(new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_MOVE, cu, relevance, APPLY_REFACTORING_COMMAND_ID,
+						Arrays.asList(MOVE_INSTANCE_METHOD_COMMAND, params, new MoveInstanceMethodInfo(getDisplayName(node)))));
+			} else if ((node instanceof MethodDeclaration || node instanceof FieldDeclaration || node instanceof AbstractTypeDeclaration) && JdtFlags.isStatic((BodyDeclaration) node)) {
+				// move static member.
+				return Collections.singletonList(new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_MOVE, cu, relevance, APPLY_REFACTORING_COMMAND_ID,
+						Arrays.asList(MOVE_STATIC_MEMBER_COMMAND, params, new MoveStaticMemberInfo(getDisplayName(node), cu.getJavaProject().getProject().getName()))));
+			}
+		}
+
 		String uri = JDTUtils.toURI(cu);
-		return Collections
-				.singletonList(new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_MOVE, cu, relevance, RefactorProposalUtility.APPLY_REFACTORING_COMMAND_ID, Arrays.asList(MOVE_FILE_COMMAND, params, new MoveFileInfo(uri))));
+		return Collections.singletonList(
+				(new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_MOVE, cu, relevance, RefactorProposalUtility.APPLY_REFACTORING_COMMAND_ID, Arrays.asList(MOVE_FILE_COMMAND, params, new MoveFileInfo(uri)))));
+	}
+
+	private static String getDisplayName(ASTNode declaration) {
+		if (declaration instanceof MethodDeclaration) {
+			IMethodBinding method = ((MethodDeclaration) declaration).resolveBinding();
+			if (method != null) {
+				String name = method.getName();
+				String[] parameters = Stream.of(method.getParameterTypes()).map(type -> type.getName()).toArray(String[]::new);
+				return name + "(" + String.join(",", parameters) + ")";
+			}
+		} else if (declaration instanceof FieldDeclaration) {
+			List<String> fieldNames = new ArrayList<>();
+			for (Object fragment : ((FieldDeclaration) declaration).fragments()) {
+				IVariableBinding variable = ((VariableDeclarationFragment) fragment).resolveBinding();
+				if (variable != null) {
+					fieldNames.add(variable.getName());
+				}
+			}
+			return String.join(",", fieldNames);
+		} else if (declaration instanceof AbstractTypeDeclaration) {
+			ITypeBinding type = ((AbstractTypeDeclaration) declaration).resolveBinding();
+			if (type != null) {
+				return type.getName();
+			}
+		}
+
+		return null;
 	}
 
 	public static List<CUCorrectionProposal> getExtractVariableProposals(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation) throws CoreException {
@@ -513,6 +571,28 @@ public class RefactorProposalUtility {
 
 		public MoveFileInfo(String uri) {
 			this.uri = uri;
+		}
+	}
+
+	public static class MoveInstanceMethodInfo {
+		public String displayName;
+
+		public MoveInstanceMethodInfo(String displayName) {
+			this.displayName = displayName;
+		}
+	}
+
+	public static class MoveStaticMemberInfo {
+		public String displayName;
+		public String projectName;
+
+		public MoveStaticMemberInfo(String projectName) {
+			this.projectName = projectName;
+		}
+
+		public MoveStaticMemberInfo(String displayName, String projectName) {
+			this.displayName = displayName;
+			this.projectName = projectName;
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandlerTest.java
@@ -12,7 +12,9 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -25,16 +27,19 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.TextEditUtil;
 import org.eclipse.jdt.ls.core.internal.handlers.GetRefactorEditHandler.RefactorWorkspaceEdit;
+import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.LspVariableBinding;
 import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveDestinationsResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.MoveParams;
 import org.eclipse.jdt.ls.core.internal.handlers.MoveHandler.PackageNode;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
 import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.RenameFile;
 import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
@@ -72,6 +77,61 @@ public class MoveHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals("jdtls", ((PackageNode) response.destinations[1]).displayName);
 		assertEquals("jdtls.test1", ((PackageNode) response.destinations[2]).displayName);
 		assertTrue(((PackageNode) response.destinations[2]).isParentOfSelectedFile);
+	}
+
+	@Test
+	public void testGetInstanceMethodDestinations() throws Exception {
+		when(preferenceManager.getClientPreferences().isMoveRefactoringSupported()).thenReturn(true);
+
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		pack1.createCompilationUnit("Second.java", "package test1;\n"
+				+ "\n"
+				+ "public class Second {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		//@formatter:off
+		pack1.createCompilationUnit("Third.java", "package test1;\n"
+				+ "\n"
+				+ "public class Third {\n"
+				+ "    public void bar() {\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    Second s;\n"
+				+ "    String name;\n"
+				+ "    int id;\n"
+				+ "    public void print(Third t) {\n"
+				+ "        s.foo();\n"
+				+ "        t.bar();\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, "s.foo");
+		MoveParams moveParams = new MoveParams("moveInstanceMethod", new String[] { JDTUtils.toURI(cu) }, params);
+		MoveDestinationsResponse response = MoveHandler.getMoveDestinations(moveParams);
+		assertNotNull(response);
+		assertNull(response.errorMessage);
+		assertNotNull(response.destinations);
+		assertEquals(2, response.destinations.length);
+		assertEquals("t", ((LspVariableBinding) response.destinations[0]).name);
+		assertFalse(((LspVariableBinding) response.destinations[0]).isField);
+		assertEquals("Third", ((LspVariableBinding) response.destinations[0]).type);
+		assertEquals("s", ((LspVariableBinding) response.destinations[1]).name);
+		assertTrue(((LspVariableBinding) response.destinations[1]).isField);
+		assertEquals("Second", ((LspVariableBinding) response.destinations[1]).type);
 	}
 
 	@Test
@@ -198,5 +258,281 @@ public class MoveHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertNotNull(renameFileA);
 		assertEquals(JDTUtils.toURI(unitA), renameFileA.getOldUri());
 		assertEquals(ResourceUtils.fixURI(unitA.getResource().getRawLocationURI()).replace("test1", "test2"), renameFileA.getNewUri());
+	}
+
+	@Test
+	public void testMoveInstanceMethod() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		ICompilationUnit cuSecond = pack1.createCompilationUnit("Second.java", "package test1;\n"
+				+ "\n"
+				+ "public class Second {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		//@formatter:off
+		pack1.createCompilationUnit("Third.java", "package test1;\n"
+				+ "\n"
+				+ "public class Third {\n"
+				+ "    public void bar() {\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    Second s;\n"
+				+ "    String name;\n"
+				+ "    int id;\n"
+				+ "    public void print(Third t) {\n"
+				+ "        System.out.println(name);\n"
+				+ "        s.foo();\n"
+				+ "        t.bar();\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public void log(Third t) {\n"
+				+ "        print(t);\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, "s.foo");
+		MoveParams moveParams = new MoveParams("moveInstanceMethod", new String[] { JDTUtils.toURI(cu) }, params);
+		MoveDestinationsResponse response = MoveHandler.getMoveDestinations(moveParams);
+		assertNotNull(response);
+		assertNull(response.errorMessage);
+		assertNotNull(response.destinations);
+		assertEquals(2, response.destinations.length);
+
+		RefactorWorkspaceEdit refactorEdit = MoveHandler.move(new MoveParams("moveInstanceMethod", params, response.destinations[1], true), new NullProgressMonitor());
+		assertNotNull(refactorEdit);
+		assertNotNull(refactorEdit.edit);
+		List<Either<TextDocumentEdit, ResourceOperation>> changes = refactorEdit.edit.getDocumentChanges();
+		assertEquals(2, changes.size());
+
+		//@formatter:off
+		String expected = "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    Second s;\n"
+				+ "    String name;\n"
+				+ "    int id;\n"
+				+ "    public void log(Third t) {\n"
+				+ "        s.print(this, t);\n"
+				+ "    }\n"
+				+ "}";
+		//@formatter:on
+		TextDocumentEdit textEdit = changes.get(0).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(cu.getSource(), textEdit.getEdits()));
+
+		//@formatter:off
+		expected = "package test1;\n"
+				+ "\n"
+				+ "public class Second {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "\n"
+				+ "	public void print(E e, Third t) {\n"
+				+ "	    System.out.println(e.name);\n"
+				+ "	    foo();\n"
+				+ "	    t.bar();\n"
+				+ "	}\n"
+				+ "}";
+		//@formatter:on
+		textEdit = changes.get(1).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(cuSecond.getSource(), textEdit.getEdits()));
+	}
+
+	@Test
+	public void testMoveStaticMethod() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    public static void foo() {\n"
+				+ "        /*[*//*]*/\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public void bar() {\n"
+				+ "        foo();\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit unitFoo = pack1.createCompilationUnit("Foo.java", "package test1;\n"
+				+ "\n"
+				+ "public class Foo {\n"
+				+ "}", false, null);
+		//@formatter:on
+
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, "/*[*//*]*/");
+		RefactorWorkspaceEdit refactorEdit = MoveHandler.move(new MoveParams("moveStaticMember", params, "Foo", true), new NullProgressMonitor());
+		assertNotNull(refactorEdit);
+		assertNotNull(refactorEdit.edit);
+		List<Either<TextDocumentEdit, ResourceOperation>> changes = refactorEdit.edit.getDocumentChanges();
+		assertEquals(2, changes.size());
+
+		//@formatter:off
+		String expected = "package test1;\n"
+						+ "\n"
+						+ "public class E {\n"
+						+ "    public void bar() {\n"
+						+ "        Foo.foo();\n"
+						+ "    }\n"
+						+ "}";
+		//@formatter:on
+		TextDocumentEdit textEdit = changes.get(0).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(cu.getSource(), textEdit.getEdits()));
+
+		//@formatter:off
+		expected = "package test1;\n"
+				+ "\n"
+				+ "public class Foo {\n"
+				+ "\n"
+				+ "	public static void foo() {\n"
+				+ "	    /*[*//*]*/\n"
+				+ "	}\n"
+				+ "}";
+		//@formatter:on
+		textEdit = changes.get(1).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(unitFoo.getSource(), textEdit.getEdits()));
+	}
+
+	@Test
+	public void testMoveStaticField() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		pack1.createCompilationUnit("Foo.java", "package test1;\n"
+				+ "\n"
+				+ "public class Foo {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "}", false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit unitUtility = pack1.createCompilationUnit("Utility.java", "package test1;\n"
+				+ "\n"
+				+ "public class Utility {\n"
+				+ "}", false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    static Foo foo = new Foo();\n"
+				+ "    public void print() {\n"
+				+ "        foo.foo();\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, "new Foo()");
+		RefactorWorkspaceEdit refactorEdit = MoveHandler.move(new MoveParams("moveStaticMember", params, "Utility", true), new NullProgressMonitor());
+		assertNotNull(refactorEdit);
+		assertNotNull(refactorEdit.edit);
+		List<Either<TextDocumentEdit, ResourceOperation>> changes = refactorEdit.edit.getDocumentChanges();
+		assertEquals(2, changes.size());
+
+		//@formatter:off
+		String expected = "package test1;\n"
+						+ "\n"
+						+ "public class E {\n"
+						+ "    public void print() {\n"
+						+ "        Utility.foo.foo();\n"
+						+ "    }\n"
+						+ "}";
+		//@formatter:on
+		TextDocumentEdit textEdit = changes.get(0).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(cu.getSource(), textEdit.getEdits()));
+
+		//@formatter:off
+		expected = "package test1;\n"
+				+ "\n"
+				+ "public class Utility {\n"
+				+ "\n"
+				+ "	static Foo foo = new Foo();\n"
+				+ "}";
+		//@formatter:on
+		textEdit = changes.get(1).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(unitUtility.getSource(), textEdit.getEdits()));
+	}
+
+	@Test
+	public void testMoveStaticInnerType() throws Exception {
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		ICompilationUnit unitFoo = pack1.createCompilationUnit("Foo.java", "package test1;\n"
+				+ "\n"
+				+ "public class Foo {\n"
+				+ "}", false, null);
+		//@formatter:on
+
+		//@formatter:off
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", "package test1;\n"
+				+ "\n"
+				+ "public class E {\n"
+				+ "    public void print() {\n"
+				+ "        new Inner().run();\n"
+				+ "    }\n"
+				+ "    static class Inner {\n"
+				+ "        void run() {\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}", false, null);
+		//@formatter:on
+
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, "class Inner");
+		RefactorWorkspaceEdit refactorEdit = MoveHandler.move(new MoveParams("moveStaticMember", params, "Foo", true), new NullProgressMonitor());
+		assertNotNull(refactorEdit);
+		assertNotNull(refactorEdit.edit);
+		List<Either<TextDocumentEdit, ResourceOperation>> changes = refactorEdit.edit.getDocumentChanges();
+		assertEquals(2, changes.size());
+
+		//@formatter:off
+		String expected = "package test1;\n"
+						+ "\n"
+						+ "public class E {\n"
+						+ "    public void print() {\n"
+						+ "        new Foo.Inner().run();\n"
+						+ "    }\n"
+						+ "}";
+		//@formatter:on
+		TextDocumentEdit textEdit = changes.get(0).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(cu.getSource(), textEdit.getEdits()));
+
+		//@formatter:off
+		expected = "package test1;\n"
+				+ "\n"
+				+ "public class Foo {\n"
+				+ "\n"
+				+ "	static class Inner {\n"
+				+ "	    void run() {\n"
+				+ "	    }\n"
+				+ "	}\n"
+				+ "}";
+		//@formatter:on
+		textEdit = changes.get(1).getLeft();
+		assertNotNull(textEdit);
+		assertEquals(expected, TextEditUtil.apply(unitFoo.getSource(), textEdit.getEdits()));
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -37,7 +37,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	@Before
 	public void setup() throws Exception {
 		importProjects("eclipse/hello");//We need at least 1 project
-		handler = new WorkspaceSymbolHandler(preferenceManager);
+		handler = new WorkspaceSymbolHandler();
 	}
 
 	@Test
@@ -130,4 +130,22 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		assertTrue("Did not find "+className, foundClass);
 	}
 
+	@Test
+	public void testSearchSourceOnly() {
+		String query = "B*";
+		List<SymbolInformation> results = handler.search(query, "hello", true, monitor);
+		assertNotNull(results);
+		assertEquals("Found " + results.size() + "result", 5, results.size());
+		String className = "BaseTest";
+		boolean foundClass = results.stream().filter(s -> className.equals(s.getName())).findFirst().isPresent();
+		assertTrue("Did not find " + className, foundClass);
+	}
+
+	@Test
+	public void testSearchReturnTopOnly() {
+		String query = "B*";
+		List<SymbolInformation> results = handler.search(query, 2, "hello", true, monitor);
+		assertNotNull(results);
+		assertEquals("Found " + results.size() + "result", 2, results.size());
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -142,7 +142,7 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
-	public void testSearchReturnTopOnly() {
+	public void testSearchReturnMaxResults() {
 		String query = "B*";
 		List<SymbolInformation> results = handler.search(query, 2, "hello", true, monitor);
 		assertNotNull(results);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
@@ -170,4 +170,76 @@ public class AdvancedExtractTest extends AbstractSelectionTest {
 		Assert.assertTrue(moveCommand.getArguments().get(2) instanceof RefactorProposalUtility.MoveFileInfo);
 		Assert.assertEquals(JDTUtils.toURI(cu), ((RefactorProposalUtility.MoveFileInfo) moveCommand.getArguments().get(2)).uri);
 	}
+
+	@Test
+	public void testMoveInstanceMethod() throws Exception {
+		when(preferenceManager.getClientPreferences().isMoveRefactoringSupported()).thenReturn(true);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		//@formatter:off
+		pack1.createCompilationUnit("Second.java", "package test1;\n"
+				+ "\n"
+				+ "public class Second {\n"
+				+ "    public void bar() {\n"
+				+ "    }\n"
+				+ "}",
+				false, null);
+		//@formatter:on
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    Second s;\n");
+		buf.append("    public void print() {\n");
+		buf.append("        /*[*//*]*/s.bar();\n");
+		buf.append("    }\n");
+		buf.append("}");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, selection);
+		Assert.assertNotNull(codeActions);
+		Either<Command, CodeAction> moveAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.REFACTOR_MOVE);
+		Assert.assertNotNull(moveAction);
+		Command moveCommand = CodeActionHandlerTest.getCommand(moveAction);
+		Assert.assertNotNull(moveCommand);
+		Assert.assertEquals(RefactorProposalUtility.APPLY_REFACTORING_COMMAND_ID, moveCommand.getCommand());
+		Assert.assertNotNull(moveCommand.getArguments());
+		Assert.assertEquals(3, moveCommand.getArguments().size());
+		Assert.assertEquals(RefactorProposalUtility.MOVE_INSTANCE_METHOD_COMMAND, moveCommand.getArguments().get(0));
+		Assert.assertTrue(moveCommand.getArguments().get(2) instanceof RefactorProposalUtility.MoveInstanceMethodInfo);
+		Assert.assertEquals("print()", ((RefactorProposalUtility.MoveInstanceMethodInfo) moveCommand.getArguments().get(2)).displayName);
+	}
+
+	@Test
+	public void testMoveStaticMember() throws Exception {
+		when(preferenceManager.getClientPreferences().isMoveRefactoringSupported()).thenReturn(true);
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public static void print() {\n");
+		buf.append("        /*[*//*]*/\n");
+		buf.append("    }\n");
+		buf.append("}");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getRange(cu, null);
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, selection);
+		Assert.assertNotNull(codeActions);
+		Either<Command, CodeAction> moveAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.REFACTOR_MOVE);
+		Assert.assertNotNull(moveAction);
+		Command moveCommand = CodeActionHandlerTest.getCommand(moveAction);
+		Assert.assertNotNull(moveCommand);
+		Assert.assertEquals(RefactorProposalUtility.APPLY_REFACTORING_COMMAND_ID, moveCommand.getCommand());
+		Assert.assertNotNull(moveCommand.getArguments());
+		Assert.assertEquals(3, moveCommand.getArguments().size());
+		Assert.assertEquals(RefactorProposalUtility.MOVE_STATIC_MEMBER_COMMAND, moveCommand.getArguments().get(0));
+		Assert.assertTrue(moveCommand.getArguments().get(2) instanceof RefactorProposalUtility.MoveStaticMemberInfo);
+		Assert.assertEquals(fJProject1.getProject().getName(), ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).projectName);
+		Assert.assertEquals("print()", ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).displayName);
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AdvancedExtractTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.correction.AbstractSelectionTest;
@@ -241,5 +242,7 @@ public class AdvancedExtractTest extends AbstractSelectionTest {
 		Assert.assertTrue(moveCommand.getArguments().get(2) instanceof RefactorProposalUtility.MoveStaticMemberInfo);
 		Assert.assertEquals(fJProject1.getProject().getName(), ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).projectName);
 		Assert.assertEquals("print()", ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).displayName);
+		Assert.assertEquals(ASTNode.METHOD_DECLARATION, ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).memberType);
+		Assert.assertEquals("test1.E", ((RefactorProposalUtility.MoveStaticMemberInfo) moveCommand.getArguments().get(2)).enclosingTypeName);
 	}
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It covers two move scenarios mentioned in issue https://github.com/eclipse/eclipse.jdt.ls/issues/1089.
- Move Instance Method - The possible destinations are the object fields and method parameter objects which the instance method is able to access, and these objects must be source classes defined by your project.
- Move static member - The destination is probably any source class.