### PR TITLE
Find implementation intelligently fall back to find definition

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandler.java
@@ -51,22 +51,29 @@ public class NavigateToDefinitionHandler {
 	private Location computeDefinitionNavigation(ITypeRoot unit, int line, int column, IProgressMonitor monitor) {
 		try {
 			IJavaElement element = JDTUtils.findElementAtSelection(unit, line, column, this.preferenceManager, monitor);
-			if (element == null) {
-				return null;
-			}
-
-
-			ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
-			IClassFile cf = (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
-			if (compilationUnit != null || (cf != null && cf.getSourceRange() != null)  ) {
-				return fixLocation(element, JDTUtils.toLocation(element), unit.getJavaProject());
-			}
-			if (element instanceof IMember && ((IMember) element).getClassFile() != null) {
-				return fixLocation(element, JDTUtils.toLocation(((IMember) element).getClassFile()), unit.getJavaProject());
-			}
+			return computeDefinitionNavigation(element, unit.getJavaProject());
 		} catch (JavaModelException e) {
-			JavaLanguageServerPlugin.logException("Problem computing definition for" +  unit.getElementName(), e);
+			JavaLanguageServerPlugin.logException("Problem computing definition for" + unit.getElementName(), e);
 		}
+
+		return null;
+	}
+
+	public static Location computeDefinitionNavigation(IJavaElement element, IJavaProject javaProject) throws JavaModelException {
+		if (element == null) {
+			return null;
+		}
+
+		ICompilationUnit compilationUnit = (ICompilationUnit) element.getAncestor(IJavaElement.COMPILATION_UNIT);
+		IClassFile cf = (IClassFile) element.getAncestor(IJavaElement.CLASS_FILE);
+		if (compilationUnit != null || (cf != null && cf.getSourceRange() != null)) {
+			return fixLocation(element, JDTUtils.toLocation(element), javaProject);
+		}
+
+		if (element instanceof IMember && ((IMember) element).getClassFile() != null) {
+			return fixLocation(element, JDTUtils.toLocation(((IMember) element).getClassFile()), javaProject);
+		}
+
 		return null;
 	}
 

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/AbstractFoo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/AbstractFoo.java
@@ -1,0 +1,7 @@
+package org.sample;
+
+public abstract class AbstractFoo {
+	
+	abstract void someMethod();
+
+}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/FooService.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/FooService.java
@@ -6,4 +6,13 @@ public class FooService {
 	void bar() {
 		foo.someMethod();
 	}
+
+	void bar1() {
+		Foo newFoo = new Foo();
+		newFoo.someMethod();
+	}
+
+	void bar2(AbstractFoo newFoo) {
+		newFoo.someMethod();
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImplementationsHandlerTest.java
@@ -151,6 +151,88 @@ public class ImplementationsHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
+	public void testClassImplementation_includeDefinition() {
+		URI uri = project.getFile("src/org/sample/FooService.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(10, 20)); //Position over new Foo()
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 2, implementations.size());
+		Location foo = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/Foo.java"));
+		//check range points to Foo class declaration position
+		assertEquals(new Position(2, 13), foo.getRange().getStart());
+		assertEquals(new Position(2, 16), foo.getRange().getEnd());
+		foo = implementations.get(1);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/FooChild.java"));
+		//check range points to FooChild class declaration position
+		assertEquals(new Position(2, 13), foo.getRange().getStart());
+		assertEquals(new Position(2, 21), foo.getRange().getEnd());
+	}
+
+	@Test
+	public void testMethodImplementation_includeDefinition() {
+		URI uri = project.getFile("src/org/sample/FooService.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(11, 13)); //Position over someMethod()
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 2, implementations.size());
+		Location foo = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/Foo.java"));
+		//check range points to someMethod() position
+		assertEquals(new Position(8, 13), foo.getRange().getStart());
+		assertEquals(new Position(8, 23), foo.getRange().getEnd());
+		foo = implementations.get(1);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/FooChild.java"));
+		//check range points to someMethod() position
+		assertEquals(new Position(4, 13), foo.getRange().getStart());
+		assertEquals(new Position(4, 23), foo.getRange().getEnd());
+	}
+
+	@Test
+	public void testUnimplementedClassImplementation_includeDefinition() {
+		URI uri = project.getFile("src/org/sample/FooService.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(14, 13)); //Position over AbstractFoo.
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 1, implementations.size());
+		Location foo = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/AbstractFoo.java"));
+		//check range points to AbstractFoo class declaration position
+		assertEquals(new Position(2, 22), foo.getRange().getStart());
+		assertEquals(new Position(2, 33), foo.getRange().getEnd());
+	}
+
+	@Test
+	public void testUnimplementedMethodImplementation_includeDefinition() {
+		URI uri = project.getFile("src/org/sample/FooService.java").getRawLocationURI();
+		String fileURI = ResourceUtils.fixURI(uri);
+
+		TextDocumentPositionParams param = new TextDocumentPositionParams();
+		param.setPosition(new Position(15, 13)); //Position over someMethod()
+		param.setTextDocument(new TextDocumentIdentifier(fileURI));
+		List<? extends Location> implementations = handler.findImplementations(param, monitor);
+		assertNotNull("findImplementations should not return null", implementations);
+		assertEquals(implementations.toString(), 1, implementations.size());
+		Location foo = implementations.get(0);
+		assertTrue("Unexpected implementation : " + foo.getUri(), foo.getUri().contains("org/sample/AbstractFoo.java"));
+		//check range points to someMethod() position
+		assertEquals(new Position(4, 15), foo.getRange().getStart());
+		assertEquals(new Position(4, 25), foo.getRange().getEnd());
+	}
+
+	@Test
 	public void testImplementationFromBinaryTypeWithoutClassContentSupport() {
 		//Only workspace implementation returned
 		List<? extends Location> implementations = getRunnableImplementations();


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #1098

If the find implementation happens at the position of method or type declaration, keeps old behavior.

If it happens at the position of method/type invocation, then follows the rules below to determine whether to include the definition to the result.
- If the hovered element is an unimplemented member (abstract or interface) and no implementations are found in the workspace, then include the element definition to the result. 
- If the hovered element is non abstract or interface, then always include the element definition as the first result.


