### PR TITLE
Ignore Unsupported SuppressWarning message

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -89,6 +89,7 @@ public class PreferenceManager {
 		javaCoreOptions.put(JavaCore.CODEASSIST_VISIBILITY_CHECK, JavaCore.ENABLED);
 		javaCoreOptions.put(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
 		javaCoreOptions.put(DefaultCodeFormatterConstants.FORMATTER_USE_ON_OFF_TAGS, DefaultCodeFormatterConstants.TRUE);
+		javaCoreOptions.put(JavaCore.COMPILER_PB_UNHANDLED_WARNING_TOKEN, JavaCore.IGNORE);
 		JavaCore.setOptions(javaCoreOptions);
 
 		// Initialize default preferences


### PR DESCRIPTION
Fixes #1062

Eclipse Preference: Window -> Preferences -> Java -> Compiler -> Errors/Warnings -> Annotations -> 'Unhandled token in @SuppressWarnings' = 'Ignore'

This PR simply sets the preference to 'Ignore', in the case that someone wants the option to
turn it back on another PR will be needed to create a preference