### PR TITLE
Updated Remark 1.0.0 -> 1.2.0 for Markdown Tables

### DIFF
--- a/org.eclipse.jdt.ls.core/.classpath
+++ b/org.eclipse.jdt.ls.core/.classpath
@@ -3,7 +3,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.9.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/remark-1.0.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/remark-1.2.0.jar"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -56,7 +56,7 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.preferences;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.text.correction;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-ClassPath: lib/jsoup-1.9.2.jar,
- lib/remark-1.0.0.jar,
+ lib/remark-1.2.0.jar,
  .
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.jdt.ls.core

--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -4,7 +4,7 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                lib/jsoup-1.9.2.jar,\
-               lib/remark-1.0.0.jar,\
+               lib/remark-1.2.0.jar,\
                lifecycle-mapping-metadata.xml,\
                plugin.properties
 src.includes = src/

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -20,7 +20,7 @@
 						<artifactItem>
 							<groupId>com.kotcrab.remark</groupId>
 							<artifactId>remark</artifactId>
-							<version>1.0.0</version>
+							<version>1.2.0</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>org.jsoup</groupId>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverter.java
@@ -32,7 +32,7 @@ public class JavaDoc2MarkdownConverter extends AbstractJavaDocConverter {
 
 	static {
 		Options options = new Options();
-		options.tables = Tables.CONVERT_TO_CODE_BLOCK;
+		options.tables = Tables.MULTI_MARKDOWN;
 		options.hardwraps = true;
 		options.inlineLinks = true;
 		options.autoLinks = true;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/AbstractJavadocConverterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/AbstractJavadocConverterTest.java
@@ -64,41 +64,78 @@ public abstract class AbstractJavadocConverterTest {
 	 * @unknown unknown tag
 	 * @unknown another unknown tag
 	 */
+	//@formatter:off
 	static final String RAW_JAVADOC_0 =
 			"This Javadoc  contains some <code> code </code>, a link to {@link IOException} and a table \n" +
+			"<table>\n" +
+			"  <thead><tr><th>header 1</th><th>header 2</th></tr></thead>\n" +
+			"  <tbody><tr><td>data 1</td><td>data 2</td></tr></tbody>\n" +
+			"  </table>\n"+
+			"<br> literally {@literal <b>literal</b>} and now a list:\n"+
+			"  <ul>"
+			+ "<li><b>Coffee</b>" +
+			"   <ul>" +
+			"    <li>Mocha</li>" +
+			"    <li>Latte</li>" +
+			"   </ul>" +
+			"  </li>" +
+			"  <li>Tea" +
+			"   <ul>" +
+			"    <li>Darjeeling</li>" +
+			"    <li>Early Grey</li>" +
+			"   </ul>" +
+			"  </li>" +
+			"</ul>"+
+			"\n"+
+			" @param param1 the first parameter\n" +
+			" @param param2 \n"+
+			" the 2nd parameter\n" +
+			" @param param3 \n"+
+			" @since 1.0\n" +
+			" @since .0\n" +
+			" @author <a href=\"mailto:foo@bar.com\">Ralf</a>\n" +
+			" @author <a href=\"mailto:bar@foo.com\">Andrew</a>\n" +
+			" @exception NastyException a\n nasty exception\n" +
+			" @throws \n"+
+			"IOException another nasty exception\n" +
+			" @return some kind of result\n"+
+			" @unknown unknown tag\n"+
+			" @unknown another unknown tag\n";
+
+	//Not using a THEAD tag
+		static final String RAW_JAVADOC_TABLE_0=
+				"<table>\n" +
+				"    <tr>\n" +
+				"        <th>Header 1</th>\n" +
+				"        <th>Header 2</th>\n" +
+				"    </tr>\n" +
+				"    <tr>\n" +
+				"        <td>Row 1A</td>\n" +
+				"        <td>Row 1B</td>\n" +
+				"    </tr>\n" +
+				"    <tr>\n" +
+				"        <td>Row 2A</td>\n" +
+				"        <td>Row 2B</td>\n" +
+				"    </tr>\n" +
+				"</table>";
+
+	//Not using a THEAD tag
+			static final String RAW_JAVADOC_TABLE_1=
 					"<table>\n" +
-					"  <thead><tr><th>header 1</th><th>header 2</th></tr></thead>\n" +
-					"  <tbody><tr><td>data 1</td><td>data 2</td></tr></tbody>\n" +
-					"  </table>\n"+
-					"<br> literally {@literal <b>literal</b>} and now a list:\n"+
-					"  <ul>"
-					+ "<li><b>Coffee</b>" +
-					"   <ul>" +
-					"    <li>Mocha</li>" +
-					"    <li>Latte</li>" +
-					"   </ul>" +
-					"  </li>" +
-					"  <li>Tea" +
-					"   <ul>" +
-					"    <li>Darjeeling</li>" +
-					"    <li>Early Grey</li>" +
-					"   </ul>" +
-					"  </li>" +
-					"</ul>"+
-					"\n"+
-					" @param param1 the first parameter\n" +
-					" @param param2 \n"+
-					" the 2nd parameter\n" +
-					" @param param3 \n"+
-					" @since 1.0\n" +
-					" @since .0\n" +
-					" @author <a href=\"mailto:foo@bar.com\">Ralf</a>\n" +
-					" @author <a href=\"mailto:bar@foo.com\">Andrew</a>\n" +
-					" @exception NastyException a\n nasty exception\n" +
-					" @throws \n"+
-					"IOException another nasty exception\n" +
-					" @return some kind of result\n"+
-					" @unknown unknown tag\n"+
-					" @unknown another unknown tag\n";
+					"    <tr>\n" +
+					"        <td>Row 0A</td>\n" +
+					"        <td>Row 0B</td>\n" +
+					"    </tr>\n" +
+					"    <tr>\n" +
+					"        <td>Row 1A</td>\n" +
+					"        <td>Row 1B</td>\n" +
+					"    </tr>\n" +
+					"    <tr>\n" +
+					"        <td>Row 2A</td>\n" +
+					"        <td>Row 2B</td>\n" +
+					"    </tr>\n" +
+					"</table>";
+
+	//@formatter:off
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverterTest.java
@@ -29,12 +29,13 @@ import org.junit.Test;
  * @author Fred Bricon
  */
 public class JavaDoc2MarkdownConverterTest extends AbstractJavadocConverterTest {
-
-	private static final String MARKDOWN_0 = "This Javadoc contains some `code`, a link to `IOException` and a table\n" +
+	//@formatter:off
+	private static final String MARKDOWN_0 =
+			"This Javadoc contains some `code`, a link to `IOException` and a table\n" +
 			"\n" +
-			"    | header 1 | header 2 |\n" +
-			"    | -------- | -------- |\n" +
-			"    | data 1   | data 2   |\n" +
+			"| header 1 | header 2 |\n" +
+			"| -------- | -------- |\n" +
+			"| data 1   | data 2   |\n" +
 			"\n" +
 			"\n" +
 			"literally <b>literal</b> and now a list:\n" +
@@ -75,6 +76,20 @@ public class JavaDoc2MarkdownConverterTest extends AbstractJavadocConverterTest 
 			"    \n" +
 			"     *  another unknown tag";
 
+	private static final String MARKDOWN_TABLE_0=
+			"| Header 1 | Header 2 |\n" +
+			"| -------- | -------- |\n" +
+			"| Row 1A   | Row 1B   |\n" +
+			"| Row 2A   | Row 2B   |";
+
+	private static final String MARKDOWN_TABLE_1=
+			"|        |        |\n" +
+			"| ------ | ------ |\n" +
+			"| Row 0A | Row 0B |\n" +
+			"| Row 1A | Row 1B |\n" +
+			"| Row 2A | Row 2B |";
+	//@formatter:on
+
 	static final String RAW_JAVADOC_HTML_1 = "<a href=\"file://some_location\">File</a>";
 	static final String RAW_JAVADOC_HTML_2 = "<a href=\"jdt://some_location\">JDT</a>";
 	static final String RAW_JAVADOC_HTML_SEE = "@see <a href=\"https://docs.oracle.com/javase/7/docs/api/\">Online docs for java</a>";
@@ -97,6 +112,18 @@ public class JavaDoc2MarkdownConverterTest extends AbstractJavadocConverterTest 
 	public void testGetAsString() throws IOException {
 		String result = new JavaDoc2MarkdownConverter(RAW_JAVADOC_0).getAsString();
 		assertEquals(Util.convertToIndependentLineDelimiter(MARKDOWN_0), Util.convertToIndependentLineDelimiter(result));
+	}
+
+	@Test
+	public void testMarkdownTableNoTHEAD() throws IOException {
+		String result = new JavaDoc2MarkdownConverter(RAW_JAVADOC_TABLE_0).getAsString();
+		assertEquals(Util.convertToIndependentLineDelimiter(MARKDOWN_TABLE_0), Util.convertToIndependentLineDelimiter(result));
+	}
+
+	@Test
+	public void testMarkdownTableInsertBlankHeader() throws IOException {
+		String result = new JavaDoc2MarkdownConverter(RAW_JAVADOC_TABLE_1).getAsString();
+		assertEquals(Util.convertToIndependentLineDelimiter(MARKDOWN_TABLE_1), Util.convertToIndependentLineDelimiter(result));
 	}
 
 	@Test


### PR DESCRIPTION
This PR uses the next version of Remark which fixes issues with tables converted to markdown.
Some issues this fixes are:

1) Tables without a header
2) Tables with an improperly defined header (no THEAD tag)
3) Some table indentation issues (fixed in JDT.ls)