### PR TITLE
Can fetch indention settings from client side

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.jdt.ls.core.internal.lsp.ExecuteCommandProposedClient;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
@@ -220,6 +221,13 @@ public class JavaClientConnection {
 	 */
 	public void semanticHighlighting(SemanticHighlightingParams params) {
 		client.semanticHighlighting(params);
+	}
+
+	/**
+	 * @see {@link LanguageClient#configuration(ConfigurationParams)}
+	 */
+	public List<Object> configuration(ConfigurationParams configurationParams) {
+		return this.client.configuration(configurationParams).join();
 	}
 
 	public void disconnect() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+
+public class ConfigurationHandler {
+
+	private ConfigurationHandler() {}
+
+	/**
+	 * Query the format setting (insertSpace and tabSize) for the given uri.
+	 * Will return {@code null} if the 'workspace/configuration' request is not supported,
+	 * @param uri The target uri to query
+	 * @return 	a map stores the setting keys and their values, for any setting key which is not
+	 * 			available at the client side, a {@code null} value will be provided.
+	 */
+	public static Map<String, Object> getFormattingOptions(String uri) {
+		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isWorkspaceConfigurationSupported()) {
+			return null;
+		};
+
+		List<ConfigurationItem> configurationItems = new ArrayList<>();
+		// TODO: extract to const once it's available in Preferences.java
+		String[] settingKeys = {"java.format.tabSize", "java.format.insertSpaces"};
+		
+		ConfigurationItem tabSizeItem = new ConfigurationItem();
+		tabSizeItem.setScopeUri(uri);
+		tabSizeItem.setSection(settingKeys[0]);
+		configurationItems.add(tabSizeItem);
+		
+		ConfigurationItem insertSpacesItem = new ConfigurationItem();
+		insertSpacesItem.setScopeUri(uri);
+		insertSpacesItem.setSection(settingKeys[1]);
+		configurationItems.add(insertSpacesItem);
+	
+		ConfigurationParams configurationParams = new ConfigurationParams(configurationItems);
+		List<Object> response = JavaLanguageServerPlugin.getInstance().getClientConnection().configuration(configurationParams);
+
+		Map<String, Object> results = new HashMap<>();
+		int minLength = Math.min(settingKeys.length, response.size());
+		for (int i = 0; i < minLength; i++) {
+			results.put(settingKeys[i], response.get(i));
+		}
+		return results;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -119,6 +119,10 @@ public class ClientPreferences {
 		return v3supported && capabilities.getWorkspace() != null && isDynamicRegistrationSupported(capabilities.getWorkspace().getDidChangeWatchedFiles());
 	}
 
+	public boolean isWorkspaceConfigurationSupported() {
+		return v3supported && capabilities.getWorkspace() != null && isTrue(capabilities.getWorkspace().getConfiguration());
+	}
+
 	public boolean isDocumentSymbolDynamicRegistered() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getDocumentSymbol());
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandlerTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.junit.Test;
+
+public class ConfigurationHandlerTest extends AbstractProjectsManagerBasedTest {
+
+    @Test
+    public void testGetConfigurationWhenItIsNotSupported() {
+        ClientPreferences clientPreferences = mock(ClientPreferences.class);
+        when(clientPreferences.isWorkspaceConfigurationSupported()).thenReturn(false);
+        when(preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
+
+        assertNull(ConfigurationHandler.getFormattingOptions("fakeUri"));
+    }
+}


### PR DESCRIPTION
This PR is to make the Language Server be able to fetch the formatting options from the client side.

For issue #1157, we need more work because the formatting options need to be passed to the `CompilationUnitRewrite`. Some changes to the `jdt.ui` is needed: https://git.eclipse.org/r/#/c/150325/

Besides, the indention issue has to be fixed case by case, so far I cannot figure out a centralized way to address this issue. A list could be found here: https://github.com/eclipse/eclipse.jdt.ls/issues/1157#issuecomment-539350148. Feel free to add more items to it if anything is missing.

The client side change is here: https://github.com/redhat-developer/vscode-java/pull/1081

@fbricon @testforstephen @akaroml Please feel free to let me know if you have any thoughts on this.

Signed-off-by: Sheng Chen <sheche@microsoft.com>