### PR TITLE
vscode-java#249: long completion label not displayed completely

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -18,6 +18,7 @@ import java.io.Reader;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
@@ -36,6 +37,7 @@ import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.osgi.util.NLS;
@@ -43,6 +45,7 @@ import org.eclipse.osgi.util.NLS;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
+
 /**
  * Adds the completion string and documentation.
  * It checks the client capabilities.
@@ -191,6 +194,12 @@ public class CompletionResolveHandler {
 		if (monitor.isCanceled()) {
 			param.setData(null);
 		}
+
+		// Mitigate the bug https://github.com/redhat-developer/vscode-java/issues/249
+		// When the completion label is too long, some client cannot show the full label well. A workaround is displaying the full label in the detail.
+		// Then expand the Java doc and the user will see the full completion information.
+		String newDetail = String.format("%s - %s", StringUtils.isBlank(param.getDetail()) ? param.getKind().name() : param.getDetail(), param.getLabel());
+		param.setDetail(newDetail);
 		return param;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -2267,22 +2267,23 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
+			+	"import java.util.Collections;\n\n"
 			+	"public class Test {\n\n"
 			+	"	void test() {\n"
-			+	"		System.out.println\n"
+			+	"		Collections.emptyListIt\n"
 			+	"	}\n"
 			+	"}\n");
 		//@formatter:on
-		int[] loc = findCompletionLocation(unit, "System.out.println");
+		int[] loc = findCompletionLocation(unit, "Collections.emptyListIt");
 		CompletionList list = server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
 		assertNotNull(list);
 		assertTrue(list.getItems().size() > 0);
 		CompletionItem ci = list.getItems().get(0);
 		assertEquals(CompletionItemKind.Method, ci.getKind());
-		assertEquals("println(Object arg0) : void", ci.getLabel());
-		assertEquals("PrintStream", ci.getDetail());
+		assertEquals("emptyListIterator() : ListIterator<T>", ci.getLabel());
+		assertEquals("Collections", ci.getDetail());
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
-		assertEquals("PrintStream - println(Object arg0) : void", resolvedItem.getDetail());
+		assertEquals("Collections - emptyListIterator() : ListIterator<T>", resolvedItem.getDetail());
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Mitigate https://github.com/redhat-developer/vscode-java/issues/249

Before:
![image](https://user-images.githubusercontent.com/14052197/66728039-49e77280-ee75-11e9-9d4f-1b48f926371b.png)

![image](https://user-images.githubusercontent.com/14052197/66728126-9fbc1a80-ee75-11e9-9788-5dec764e3641.png)

After:
![image](https://user-images.githubusercontent.com/14052197/66728229-312b8c80-ee76-11e9-8ed4-d82837be9f36.png)

![image](https://user-images.githubusercontent.com/14052197/66728166-d8f48a80-ee75-11e9-9d06-bac28eb92848.png)
