### PR TITLE
Make PreferenceManager.initialize() non-static

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -83,7 +83,7 @@ public class PreferenceManager {
 	 * Initialize default preference values of used bundles to match server
 	 * functionality.
 	 */
-	public static void initialize() {
+	public void initialize() {
 		// Update JavaCore options
 		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
 		javaCoreOptions.put(JavaCore.CODEASSIST_VISIBILITY_CHECK, JavaCore.ENABLED);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -149,7 +149,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 	}
 
 	protected ClientPreferences initPreferenceManager(boolean supportClassFileContents) {
-		PreferenceManager.initialize();
+		preferenceManager.initialize();
 		when(preferenceManager.getPreferences()).thenReturn(preferences);
 		when(preferenceManager.getPreferences(any())).thenReturn(preferences);
 		when(preferenceManager.isClientSupportsClassFileContent()).thenReturn(supportClassFileContents);


### PR DESCRIPTION
I find there's inconsistency of definition and call. 

All the other references can be seen below:
![image](https://user-images.githubusercontent.com/2351748/67187551-082e6d00-f41d-11e9-9d37-4db3ffcc5174.png)
