### PR TITLE
Add text selection support in code snippet

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtils.java
@@ -20,12 +20,18 @@ public class SnippetUtils {
 
 	private static final String MARKDOWN_LANGUAGE = "java";
 
+	private static final String TM_SELECTED_TEXT = "\\$TM_SELECTED_TEXT";
+
 	private SnippetUtils() {
 	}
 
 	public static Either<String, MarkupContent> beautifyDocument(String raw) {
 		// remove the placeholder for the plain cursor like: ${0}, ${1:variable}
 		String escapedString = raw.replaceAll("\\$\\{\\d:?(.*?)\\}", "$1");
+
+		// Replace the reserved variable with empty string.
+		// See: https://github.com/eclipse/eclipse.jdt.ls/issues/1220
+		escapedString = escapedString.replaceAll(TM_SELECTED_TEXT, "");
 
 		if (JavaLanguageServerPlugin.getPreferencesManager() != null && JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences() != null
 				&& JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -68,7 +68,7 @@ class TemplatePreferences {
 	public static final String SYSOUT_CONTENT = "System.out.println($${0});";
 	public static final String SYSERR_CONTENT = "System.err.println($${0});";
 	public static final String SYSTRACE_CONTENT = "System.out.println(\"${enclosing_type}.${enclosing_method}()\");";
-	public static final String FOREACH_CONTENT = "for ($${1:${iterable_type}} $${2:${iterable_element}} : $${3:${iterable}}) {\n" + "\t$${0}\n" + "}";
+	public static final String FOREACH_CONTENT = "for ($${1:${iterable_type}} $${2:${iterable_element}} : $${3:${iterable}}) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
 	public static final String FORI_CONTENT = "for ($${1:int} $${2:${index}} = $${3:0}; $${2:${index}} < $${4:${array}.length}; $${2:${index}}++) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
 	public static final String WHILE_CONTENT = "while ($${1:${condition:var(boolean)}}) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
 	public static final String DOWHILE_CONTENT = "do {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "} while ($${1:${condition:var(boolean)}});";

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -69,13 +69,13 @@ class TemplatePreferences {
 	public static final String SYSERR_CONTENT = "System.err.println($${0});";
 	public static final String SYSTRACE_CONTENT = "System.out.println(\"${enclosing_type}.${enclosing_method}()\");";
 	public static final String FOREACH_CONTENT = "for ($${1:${iterable_type}} $${2:${iterable_element}} : $${3:${iterable}}) {\n" + "\t$${0}\n" + "}";
-	public static final String FORI_CONTENT = "for ($${1:int} $${2:${index}} = $${3:0}; $${2:${index}} < $${4:${array}.length}; $${2:${index}}++) {\n" + "\t$${0}\n" + "}";
-	public static final String WHILE_CONTENT = "while ($${1:${condition:var(boolean)}}) {\n" + "\t$${0}\n" + "}";
-	public static final String DOWHILE_CONTENT = "do {\n" + "\t$${0}\n" + "} while ($${1:${condition:var(boolean)}});";
-	public static final String IF_CONTENT = "if ($${1:${condition:var(boolean)}}) {\n" + "\t$${0}\n" + "}";
+	public static final String FORI_CONTENT = "for ($${1:int} $${2:${index}} = $${3:0}; $${2:${index}} < $${4:${array}.length}; $${2:${index}}++) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
+	public static final String WHILE_CONTENT = "while ($${1:${condition:var(boolean)}}) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
+	public static final String DOWHILE_CONTENT = "do {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "} while ($${1:${condition:var(boolean)}});";
+	public static final String IF_CONTENT = "if ($${1:${condition:var(boolean)}}) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
 	public static final String IFELSE_CONTENT = "if ($${1:${condition:var(boolean)}}) {\n" + "\t$${2}\n" + "} else {\n" + "\t$${0}\n" + "}";
-	public static final String IFNULL_CONTENT = "if ($${1:${name:var}} == null) {\n" + "\t$${0}\n" + "}";
-	public static final String IFNOTNULL_CONTENT = "if ($${1:${name:var}} != null) {\n" + "\t$${0}\n" + "}";
+	public static final String IFNULL_CONTENT = "if ($${1:${name:var}} == null) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
+	public static final String IFNOTNULL_CONTENT = "if ($${1:${name:var}} != null) {\n" + "\t$$TM_SELECTED_TEXT$${0}\n" + "}";
 
 	// Descriptions
 	public static final String SYSOUT_DESCRIPTION = "print to standard out";

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtilsTest.java
@@ -119,4 +119,26 @@ public class SnippetUtilsTest {
 
 		assertEquals(result.getLeft(), expected);
 	}
+
+	@Test
+	public void testSelectedTextPlaceholder() {
+		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
+		when(mockCapabilies.isSupportsCompletionDocumentationMarkdown()).thenReturn(Boolean.FALSE);
+		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+
+		//@formatter:off
+		String raw = "for (${1:int} ${2:i} = ${3:0}; ${2:i} < ${4:args.length}; ${2:i}++) {\n" +
+				"\t$TM_SELECTED_TEXT${0}\n" +
+				"}";
+		//@formatter:on
+		Either<String, MarkupContent> result = SnippetUtils.beautifyDocument(raw);
+
+		//@formatter:off
+		String expected = "for (int i = 0; i < args.length; i++) {\n" +
+				"\t\n" +
+				"}";
+		//@formatter:on
+
+		assertEquals(result.getLeft(), expected);
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -960,7 +960,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("foreach", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t${0}\n}", insertText);
+		assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test
@@ -986,7 +986,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("foreach", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t${0}\n}", insertText);
+		assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1011,7 +1011,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("fori", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("for (${1:int} ${2:i} = ${3:0}; ${2:i} < ${4:args.length}; ${2:i}++) {\n\t${0}\n}", insertText);
+		assertEquals("for (${1:int} ${2:i} = ${3:0}; ${2:i} < ${4:args.length}; ${2:i}++) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test
@@ -1036,7 +1036,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(1);
 		assertEquals("while", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("while (${1:con}) {\n\t${0}\n}", insertText);
+		assertEquals("while (${1:con}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test
@@ -1061,7 +1061,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("dowhile", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("do {\n\t${0}\n} while (${1:con});", insertText);
+		assertEquals("do {\n\t$TM_SELECTED_TEXT${0}\n} while (${1:con});", insertText);
 	}
 
 	@Test
@@ -1086,7 +1086,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(5);
 		assertEquals("if", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("if (${1:con}) {\n\t${0}\n}", insertText);
+		assertEquals("if (${1:con}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test
@@ -1136,7 +1136,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("ifnull", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("if (${1:obj} == null) {\n\t${0}\n}", insertText);
+		assertEquals("if (${1:obj} == null) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test
@@ -1161,7 +1161,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem item = items.get(0);
 		assertEquals("ifnotnull", item.getLabel());
 		String insertText = item.getInsertText();
-		assertEquals("if (${1:obj} != null) {\n\t${0}\n}", insertText);
+		assertEquals("if (${1:obj} != null) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
 	}
 
 	@Test


### PR DESCRIPTION
Mitigate #1220 

In [jdt.ui](https://github.com/eclipse/eclipse.jdt.ui/blob/master/org.eclipse.jdt.ui/templates/default-templates.xml), `for_array`, `while`, `do_while` and `if` have the `selection` placeholder.

Besides these snippets, I also add the `$TM_SELECTED_TEXT` into `ifnull` and `ifnotnull`

Signed-off-by: Sheng Chen <sheche@microsoft.com>