### PR TITLE
Added MS Paint IDE to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ This repository only contains the server implementation. Here are some known cli
 * [Oni](https://github.com/onivim/oni/wiki/Language-Support#java) : modern modal editing - powered by Neovim.
 * [LSP Java](https://github.com/emacs-lsp/lsp-java) : a Java LSP client for Emacs
 * [Eclipse Theia](https://github.com/theia-ide/theia) : Theia is a cloud & desktop IDE framework implemented in TypeScript
-* [coc-java](https://github.com/neoclide/coc-java): an extension for [coc.nvim](https://github.com/neoclide/coc.nvim)
+* [coc-java](https://github.com/neoclide/coc-java) : an extension for [coc.nvim](https://github.com/neoclide/coc.nvim)
+* [MS Paint IDE](https://github.com/MSPaintIDE/MSPaintIDE) : an IDE for programming in MS Paint
 
 Continuous Integration Builds
 -----------------------------


### PR DESCRIPTION
MS Paint IDE is a less-than-conventional IDE that allows you to program in Paint via an OCR. The IDE has LSP support and uses Eclipse's Java language server for the Java language.