### PR TITLE
Add final modifier where possible

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -114,6 +114,7 @@ import org.eclipse.jdt.internal.corext.fix.ICleanUpCore;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.corext.fix.LambdaExpressionsFixCore;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
+import org.eclipse.jdt.internal.corext.fix.VariableDeclarationFixCore;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTesterCore;
 import org.eclipse.jdt.internal.corext.refactoring.code.ConvertAnonymousToNestedRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineConstantRefactoring;
@@ -222,7 +223,7 @@ public class QuickAssistProcessor {
 				//				}
 				//				getConvertEnhancedForLoopProposal(context, coveringNode, resultingCollections);
 				//				getRemoveBlockProposals(context, coveringNode, resultingCollections);
-				//				getMakeVariableDeclarationFinalProposals(context, resultingCollections);
+				getMakeVariableDeclarationFinalProposals(context, resultingCollections);
 				//				getConvertStringConcatenationProposals(context, resultingCollections);
 				//				getMissingCaseStatementProposals(context, coveringNode, resultingCollections);
 				getConvertVarTypeToResolvedTypeProposal(context, coveringNode, resultingCollections);
@@ -1372,6 +1373,19 @@ public class QuickAssistProcessor {
 				}
 			}
 		}
+		return true;
+	}
+
+	private static boolean getMakeVariableDeclarationFinalProposals(IInvocationContext context, Collection<ChangeCorrectionProposal> resultingCollections) {
+		IProposableFix fix = (IProposableFix) VariableDeclarationFixCore.createCleanUp(context.getASTRoot(), true, true, true);
+
+		if (fix == null) {
+			return false;
+		}
+
+		FixCorrectionProposal proposal = new FixCorrectionProposal(fix, null, IProposalRelevance.MAKE_VARIABLE_DECLARATION_FINAL, context);
+		proposal.setDisplayName("Change modifiers to final where possible");
+		resultingCollections.add(proposal);
 		return true;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
@@ -896,4 +896,28 @@ public class ModifierCorrectionsQuickFixTest extends AbstractQuickFixTest {
 
 		assertCodeActions(cu, e1);
 	}
+
+	@Test
+	public void testInsertFinalModifierWherePossible() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class A {\n");
+		buf.append("  public static void abc(int x){\n");
+		buf.append("    int b = 3;\n");
+		buf.append("  }\n");
+		buf.append("}");
+		ICompilationUnit cu = pack.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class A {\n");
+		buf.append("  public static void abc(final int x){\n");
+		buf.append("    final int b = 3;\n");
+		buf.append("  }\n");
+		buf.append("}");
+		Expected e1 = new Expected("Change modifiers to final where possible", buf.toString());
+
+		assertCodeActions(cu, e1);
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/774

One thing that can be improved is the message "Add final", but that relies on
a change from jdt code.

Signed-off-by: Nikolas Komonen <nikolaskomonen@gmail.com>