### PR TITLE
Adds quick fix for unnecessary cast

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -314,10 +314,9 @@ public class QuickFixProcessor {
 			// LocalCorrectionsSubProcessor.addSuperfluousSemicolonProposal(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.UnnecessaryCast:
-			// LocalCorrectionsSubProcessor.addUnnecessaryCastProposal(context,
-			// problem, proposals);
-			// break;
+			case IProblem.UnnecessaryCast:
+				LocalCorrectionsSubProcessor.addUnnecessaryCastProposal(context, problem, proposals);
+				break;
 			// case IProblem.UnnecessaryInstanceof:
 			// LocalCorrectionsSubProcessor.addUnnecessaryInstanceofProposal(context,
 			// problem, proposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -20,7 +20,9 @@ package org.eclipse.jdt.ls.core.internal.corrections.proposals;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -63,6 +65,7 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.core.manipulation.CleanUpOptionsCore;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
@@ -71,11 +74,13 @@ import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRe
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.Selection;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
 import org.eclipse.jdt.internal.corext.fix.UnusedCodeFixCore;
 import org.eclipse.jdt.internal.corext.refactoring.util.SurroundWithAnalyzer;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.ui.fix.UnnecessaryCodeCleanUpCore;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corext.dom.CodeScopeBuilder;
@@ -629,6 +634,16 @@ public class LocalCorrectionsSubProcessor {
 			if (curr.isConstructor() && !Modifier.isPrivate(curr.getModifiers())) {
 				proposals.add(new ConstructorFromSuperclassProposal(cu, typeDeclaration, curr, IProposalRelevance.ADD_CONSTRUCTOR_FROM_SUPER_CLASS));
 			}
+		}
+	}
+
+	public static void addUnnecessaryCastProposal(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) {
+		IProposableFix fix = UnusedCodeFixCore.createRemoveUnusedCastFix(context.getASTRoot(), problem);
+		if (fix != null) {
+			Map<String, String> options = new Hashtable<>();
+			options.put(CleanUpConstants.REMOVE_UNNECESSARY_CASTS, CleanUpOptionsCore.TRUE);
+			FixCorrectionProposal proposal = new FixCorrectionProposal(fix, new UnnecessaryCodeCleanUpCore(options), IProposalRelevance.REMOVE_UNUSED_CAST, context);
+			proposals.add(proposal);
 		}
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnnecessaryCastQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnnecessaryCastQuickFixTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.Map;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.lsp4j.Range;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author nikolas
+ *
+ */
+public class UnnecessaryCastQuickFixTest extends AbstractQuickFixTest {
+
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject = newEmptyProject();
+		fJProject.setOptions(TestOptions.getDefaultOptions());
+		fSourceFolder = fJProject.getPackageFragmentRoot(fJProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testUnnecessaryCast() throws Exception {
+		Map<String, String> testProjectOptions = fJProject.getOptions(false);
+		testProjectOptions.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.ERROR);
+
+		fJProject.setOptions(testProjectOptions);
+
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Driver {\n");
+		buf.append("}");
+		pack.createCompilationUnit("Driver.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class BusDriver extends Driver {\n");
+		buf.append("  public void drive() {\n");
+		buf.append("    Driver d = (Driver) this;\n");
+		buf.append("  }\n");
+		buf.append("}");
+		ICompilationUnit cu = pack.createCompilationUnit("BusDriver.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class BusDriver extends Driver {\n");
+		buf.append("  public void drive() {\n");
+		buf.append("    Driver d = this;\n");
+		buf.append("  }\n");
+		buf.append("}");
+		Expected e1 = new Expected("Remove cast", buf.toString());
+
+		Range selection = CodeActionUtil.getRange(cu, "FOO");
+		assertCodeActions(cu, selection, e1);
+	}
+}


### PR DESCRIPTION
Fixes issue #165

To test you need to add the preference "org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck=warning" to the org.eclipse.jdt.core.prefs settings file.
This will enable the warning to be shown in the ide.

And then refer to the test in this PR to use to re-create it.

Signed-off-by: Nikolas Komonen <nikolaskomonen@gmail.com>