### PR TITLE
move AddStaticImport quickfix to QuickFixProcessor

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -43,8 +43,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.proposals.TypeMismatchSubPro
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.UnresolvedElementsSubProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.ModifierCorrectionSubProcessor;
 
-/**
- */
+@SuppressWarnings("restriction")
 public class QuickFixProcessor {
 
 	private static int moveBack(int offset, int start, String ignoreCharacters, ICompilationUnit cu) {
@@ -108,6 +107,7 @@ public class QuickFixProcessor {
 
 			case IProblem.UndefinedMethod:
 				UnresolvedElementsSubProcessor.getMethodProposals(context, problem, false, proposals);
+				UnresolvedElementsSubProcessor.getAddStaticImportProposals(context, problem, proposals);
 				break;
 			case IProblem.UndefinedConstructor:
 				UnresolvedElementsSubProcessor.getConstructorProposals(context, problem, proposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -43,8 +43,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ASTVisitor;
-import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.ArrayCreation;
 import org.eclipse.jdt.core.dom.ArrayInitializer;
@@ -65,7 +63,6 @@ import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -75,7 +72,6 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.ParameterizedType;
-import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
@@ -101,9 +97,7 @@ import org.eclipse.jdt.core.manipulation.CleanUpOptionsCore;
 import org.eclipse.jdt.core.manipulation.CleanUpRequirementsCore;
 import org.eclipse.jdt.core.manipulation.CodeStyleConfiguration;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
-import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
-import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
@@ -227,7 +221,6 @@ public class QuickAssistProcessor {
 				//				getMissingCaseStatementProposals(context, coveringNode, resultingCollections);
 				getConvertVarTypeToResolvedTypeProposal(context, coveringNode, resultingCollections);
 				getConvertResolvedTypeToVarTypeProposal(context, coveringNode, resultingCollections);
-				getAddStaticImportProposals(context, coveringNode, resultingCollections);
 				getConvertForLoopProposal(context, coveringNode, resultingCollections);
 			}
 			return resultingCollections;
@@ -1369,203 +1362,5 @@ public class QuickAssistProcessor {
 			}
 		}
 		return true;
-	}
-
-	/**
-	 * Create static import proposal
-	 *
-	 * @param context
-	 *            the invocation context
-	 * @param node
-	 *            the node to work on
-	 * @param proposals
-	 *            the receiver of proposals, may be {@code null}
-	 * @return {@code true} if the operation could or has been performed,
-	 *         {@code false otherwise}
-	 */
-	private static boolean getAddStaticImportProposals(IInvocationContext context, ASTNode node, Collection<ChangeCorrectionProposal> proposals) {
-		if (!(node instanceof SimpleName)) {
-			return false;
-		}
-
-		final SimpleName name = (SimpleName) node;
-		final IBinding binding;
-		final ITypeBinding declaringClass;
-
-		// get bindings for method invocation or variable access
-
-		if (name.getParent() instanceof MethodInvocation) {
-			MethodInvocation mi = (MethodInvocation) name.getParent();
-
-			Expression expression = mi.getExpression();
-			if (expression == null || expression.equals(name)) {
-				return false;
-			}
-
-			binding = mi.resolveMethodBinding();
-			if (binding == null) {
-				return false;
-			}
-
-			declaringClass = ((IMethodBinding) binding).getDeclaringClass();
-		} else if (name.getParent() instanceof QualifiedName) {
-			QualifiedName qn = (QualifiedName) name.getParent();
-
-			if (name.equals(qn.getQualifier()) || qn.getParent() instanceof ImportDeclaration) {
-				return false;
-			}
-
-			binding = qn.resolveBinding();
-			if (!(binding instanceof IVariableBinding)) {
-				return false;
-			}
-			declaringClass = ((IVariableBinding) binding).getDeclaringClass();
-		} else {
-			return false;
-		}
-
-		// at this point binding cannot be null
-
-		if (!Modifier.isStatic(binding.getModifiers())) {
-			// only work with static bindings
-			return false;
-		}
-
-		boolean needImport = false;
-		if (!isDirectlyAccessible(name, declaringClass)) {
-			if (Modifier.isPrivate(declaringClass.getModifiers())) {
-				return false;
-			}
-			needImport = true;
-		}
-
-		if (proposals == null) {
-			return true; // return early, just testing if we could do it
-		}
-
-		try {
-			ImportRewrite importRewrite = StubUtility.createImportRewrite(context.getCompilationUnit(), true);
-			ImportRewrite importRewriteReplaceAllOccurences = StubUtility.createImportRewrite(context.getCompilationUnit(), true);
-			ASTRewrite astRewrite = ASTRewrite.create(node.getAST());
-			ASTRewrite astRewriteReplaceAllOccurrences = ASTRewrite.create(node.getAST());
-
-			int[] allReferencesToDeclaringClass = new int[1];
-			allReferencesToDeclaringClass[0] = 0;
-			int[] referencesFromOtherOccurences = new int[1];
-			referencesFromOtherOccurences[0] = 0;
-			MethodInvocation mi = null;
-			QualifiedName qn = null;
-			if (name.getParent() instanceof MethodInvocation) {
-				mi = (MethodInvocation) name.getParent();
-				// convert the method invocation
-				astRewrite.remove(mi.getExpression(), null);
-				mi.typeArguments().forEach(type -> astRewrite.remove((Type) type, null));
-			} else if (name.getParent() instanceof QualifiedName) {
-				qn = (QualifiedName) name.getParent();
-				// convert the field access
-				astRewrite.replace(qn, ASTNodeFactory.newName(node.getAST(), name.getFullyQualifiedName()), null);
-			} else {
-				return false;
-			}
-
-			MethodInvocation miFinal = mi;
-			name.getRoot().accept(new ASTVisitor() {
-				@Override
-				public boolean visit(MethodInvocation methodInvocation) {
-					Expression methodInvocationExpression = methodInvocation.getExpression();
-					if (methodInvocationExpression == null) {
-						return super.visit(methodInvocation);
-					}
-
-					if (methodInvocationExpression instanceof Name) {
-						String fullyQualifiedName = ((Name) methodInvocationExpression).getFullyQualifiedName();
-						if (miFinal != null && miFinal.getExpression() instanceof Name && ((Name) miFinal.getExpression()).getFullyQualifiedName().equals(fullyQualifiedName)
-								&& miFinal.getName().getIdentifier().equals(methodInvocation.getName().getIdentifier())) {
-							methodInvocation.typeArguments().forEach(type -> astRewriteReplaceAllOccurrences.remove((Type) type, null));
-							astRewriteReplaceAllOccurrences.remove(methodInvocationExpression, null);
-							allReferencesToDeclaringClass[0]++;
-						} else if (declaringClass.getName().equals(fullyQualifiedName)) {
-							allReferencesToDeclaringClass[0]++;
-							referencesFromOtherOccurences[0]++;
-						}
-					} else if (methodInvocationExpression instanceof ClassInstanceCreation) {
-						ClassInstanceCreation classInstanceCreation = (ClassInstanceCreation) methodInvocationExpression;
-						if (classInstanceCreation.getType() instanceof SimpleType) {
-							String typeName = ((SimpleType) classInstanceCreation.getType()).getName().getFullyQualifiedName();
-							if (typeName.equals(declaringClass.getName())) {
-								allReferencesToDeclaringClass[0]++;
-								referencesFromOtherOccurences[0]++;
-							}
-						}
-					}
-
-					return super.visit(methodInvocation);
-				}
-			});
-			QualifiedName qnFinal = qn;
-			name.getRoot().accept(new ASTVisitor() {
-				@Override
-				public boolean visit(QualifiedName qualifiedName) {
-					if (qnFinal != null && qualifiedName.getFullyQualifiedName().equals(qnFinal.getFullyQualifiedName())) {
-						astRewriteReplaceAllOccurrences.replace(qualifiedName, ASTNodeFactory.newName(node.getAST(), name.getFullyQualifiedName()), null);
-						allReferencesToDeclaringClass[0]++;
-					} else if (declaringClass.getName().equals(qualifiedName.getQualifier().getFullyQualifiedName())) {
-						allReferencesToDeclaringClass[0]++;
-						referencesFromOtherOccurences[0]++;
-					}
-					return super.visit(qualifiedName);
-				}
-			});
-
-			// add the static import
-			if (needImport) {
-				importRewrite.addStaticImport(binding);
-				if (allReferencesToDeclaringClass[0] == 1) { // If there are exactly 1 visits, the import can be removed
-					importRewrite.removeImport(declaringClass.getQualifiedName());
-				}
-				importRewriteReplaceAllOccurences.addStaticImport(binding);
-				if (referencesFromOtherOccurences[0] == 0) {
-					importRewriteReplaceAllOccurences.removeImport(declaringClass.getQualifiedName());
-				}
-			}
-
-			ASTRewriteCorrectionProposal proposal = new ASTRewriteCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import, CodeActionKind.QuickFix, context.getCompilationUnit(), astRewrite,
-					IProposalRelevance.ADD_STATIC_IMPORT);
-			proposal.setImportRewrite(importRewrite);
-			proposals.add(proposal);
-			ASTRewriteCorrectionProposal proposalReplaceAllOccurrences = new ASTRewriteCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import_replace_all, CodeActionKind.QuickFix, context.getCompilationUnit(),
-					astRewriteReplaceAllOccurrences, IProposalRelevance.ADD_STATIC_IMPORT);
-			proposalReplaceAllOccurrences.setImportRewrite(importRewriteReplaceAllOccurences);
-			proposals.add(proposalReplaceAllOccurrences);
-		} catch (IllegalArgumentException e) {
-			// Wrong use of ASTRewrite or ImportRewrite API, see bug 541586
-			JavaLanguageServerPlugin.logException("Failed to get static import proposal", e);
-			return false;
-		} catch (JavaModelException e) {
-			return false;
-		}
-
-		return true;
-	}
-
-	private static boolean isDirectlyAccessible(ASTNode nameNode, ITypeBinding declaringClass) {
-		ASTNode node = nameNode.getParent();
-		while (node != null) {
-
-			if (node instanceof AbstractTypeDeclaration) {
-				ITypeBinding binding = ((AbstractTypeDeclaration) node).resolveBinding();
-				if (binding != null && binding.isSubTypeCompatible(declaringClass)) {
-					return true;
-				}
-			} else if (node instanceof AnonymousClassDeclaration) {
-				ITypeBinding binding = ((AnonymousClassDeclaration) node).resolveBinding();
-				if (binding != null && binding.isSubTypeCompatible(declaringClass)) {
-					return true;
-				}
-			}
-
-			node = node.getParent();
-		}
-		return false;
 	}
 }


### PR DESCRIPTION
Part of #1136 

The code action "AddStaticImport" is of kind quickfix, should be calculated only when a method is unresolved.  Thus the corresponding proposal should be placed into `UnresolvedElementsSubProcessor`, and called by `QuickFixProcessor`. 