### PR TITLE
Change lambda-anonymous class convertion code actions to 'refactor' kind

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/FixCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/FixCorrectionProposal.java
@@ -37,7 +37,11 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal {
 	private CompilationUnit fCompilationUnit;
 
 	public FixCorrectionProposal(IProposableFix fix, ICleanUpCore cleanUp, int relevance, IInvocationContext context) {
-		super(fix.getDisplayString(), CodeActionKind.QuickFix, context.getCompilationUnit(), null, relevance);
+		this(fix, cleanUp, relevance, context, CodeActionKind.QuickFix);
+	}
+
+	public FixCorrectionProposal(IProposableFix fix, ICleanUpCore cleanUp, int relevance, IInvocationContext context, String codeActionKind) {
+		super(fix.getDisplayString(), codeActionKind, context.getCompilationUnit(), null, relevance);
 		fFix = fix;
 		fCleanUp = cleanUp;
 		fCompilationUnit = context.getASTRoot();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -848,7 +848,7 @@ public class QuickAssistProcessor {
 		Map<String, String> options = new HashMap<>();
 		options.put(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES, CleanUpOptionsCore.TRUE);
 		options.put(CleanUpConstants.USE_LAMBDA, CleanUpOptionsCore.TRUE);
-		FixCorrectionProposal proposal = new FixCorrectionProposal(fix, new LambdaExpressionsCleanUpCore(options), IProposalRelevance.CONVERT_TO_LAMBDA_EXPRESSION, context);
+		FixCorrectionProposal proposal = new FixCorrectionProposal(fix, new LambdaExpressionsCleanUpCore(options), IProposalRelevance.CONVERT_TO_LAMBDA_EXPRESSION, context, CodeActionKind.Refactor);
 		resultingCollections.add(proposal);
 		return true;
 	}
@@ -876,7 +876,7 @@ public class QuickAssistProcessor {
 		Map<String, String> options = new HashMap<>();
 		options.put(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES, CleanUpOptionsCore.TRUE);
 		options.put(CleanUpConstants.USE_ANONYMOUS_CLASS_CREATION, CleanUpOptionsCore.TRUE);
-		FixCorrectionProposal proposal = new FixCorrectionProposal(fix, new LambdaExpressionsCleanUpCore(options), IProposalRelevance.CONVERT_TO_ANONYMOUS_CLASS_CREATION, context);
+		FixCorrectionProposal proposal = new FixCorrectionProposal(fix, new LambdaExpressionsCleanUpCore(options), IProposalRelevance.CONVERT_TO_ANONYMOUS_CLASS_CREATION, context, CodeActionKind.Refactor);
 		resultingCollections.add(proposal);
 		return true;
 	}


### PR DESCRIPTION
Part of workitem #1136 

Although it's implemented via `FixCorrectionProposal`, the conversion bewteen lambda and anonymous class should be of `refactor` kind, instead of `quickfix`.

This PR adds a constructor for `FixCorrectionProposal` allowing to specify CodeActionKind, and sets correct kind for the conversion actions.