### PR TITLE
Change var conversion actions to 'refactor' kind

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ChangeCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ChangeCorrectionProposal.java
@@ -25,6 +25,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 
 public class ChangeCorrectionProposal extends ChangeCorrectionProposalCore {
+	// LSP: Code Action Kind
 	private String fKind;
 
 	/**
@@ -94,5 +95,12 @@ public class ChangeCorrectionProposal extends ChangeCorrectionProposalCore {
 	 */
 	public String getKind() {
 		return fKind;
+	}
+
+	/**
+	 * @param codeActionKind the Code Action Kind to set
+	 */
+	public void setKind(String codeActionKind) {
+		this.fKind = codeActionKind;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -474,7 +474,9 @@ public class QuickAssistProcessor {
 			return false;
 		}
 
-		proposals.add(new TypeChangeCorrectionProposal(context.getCompilationUnit(), varBinding, astRoot, typeBinding, false, IProposalRelevance.CHANGE_VARIABLE));
+		TypeChangeCorrectionProposal proposal = new TypeChangeCorrectionProposal(context.getCompilationUnit(), varBinding, astRoot, typeBinding, false, IProposalRelevance.CHANGE_VARIABLE);
+		proposal.setKind(CodeActionKind.Refactor);
+		proposals.add(proposal);
 		return true;
 	}
 
@@ -577,7 +579,9 @@ public class QuickAssistProcessor {
 			return false;
 		}
 
-		proposals.add(new TypeChangeCorrectionProposal(context.getCompilationUnit(), varBinding, astRoot, typeBinding, IProposalRelevance.CHANGE_VARIABLE));
+		TypeChangeCorrectionProposal proposal = new TypeChangeCorrectionProposal(context.getCompilationUnit(), varBinding, astRoot, typeBinding, IProposalRelevance.CHANGE_VARIABLE);
+		proposal.setKind(CodeActionKind.Refactor);
+		proposals.add(proposal);
 		return true;
 	}
 	static ArrayList<ASTNode> getFullyCoveredNodes(IInvocationContext context, ASTNode coveringNode) {


### PR DESCRIPTION
Part of workitem #1136 

According to LSP, the conversion between resolved type and `var` should be of kind `refactor`, instead of `quickfix`. 
This PR 
* adds a setter for CodeActionKind in the base class.
* corrects the CodeActionKind of the action.