### PR TITLE
Take advantage of CodeActionLiteral client capability

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -202,10 +202,13 @@ public class CodeActionHandler {
 		}
 
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(proposal.getKind())) {
-			// TODO: Should set WorkspaceEdit directly instead of Command
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(proposal.getKind());
-			codeAction.setCommand(command);
+			if (preferenceManager.getClientPreferences().isSupportedCodeActionLiteral()) {
+				codeAction.setEdit((WorkspaceEdit)command.getArguments().get(0));
+			} else {
+				codeAction.setCommand(command);
+			}
 			codeAction.setDiagnostics(context.getDiagnostics());
 			return Optional.of(Either.forRight(codeAction));
 		} else {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -261,8 +261,20 @@ public class ClientPreferences {
 
 	/**
 	 * {@code true} if the client has explicitly set the
-	 * {@code textDocument.documentSymbol.hierarchicalDocumentSymbolSupport} to
-	 * {@code true} when initializing the LS. Otherwise, {@code false}.
+	 * {@code textDocument.codeAction.codeActionLiteralSupport}
+	 * when initializing the LS. Otherwise, {@code false}.
+	 */
+	public boolean isSupportedCodeActionLiteral() {
+		//@formatter:off
+		return v3supported && capabilities.getTextDocument().getCodeAction() != null
+				&& capabilities.getTextDocument().getCodeAction().getCodeActionLiteralSupport() != null;
+		//@formatter:on
+	}
+
+	/**
+	 * {@code true} if the client has listed {@code kind} in
+	 * {@code textDocument.codeAction.codeActionLiteralSupport.codeActionKind.valueSet}
+	 * when initializing the LS. Otherwise, {@code false}.
 	 */
 	public boolean isSupportedCodeActionKind(String kind) {
 		//@formatter:off

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -352,7 +352,11 @@ public class SourceAssistProcessor {
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(kind)) {
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(kind);
-			codeAction.setCommand(command);
+			if (preferenceManager.getClientPreferences().isSupportedCodeActionLiteral()) {
+				codeAction.setEdit(workspaceEdit);
+			} else {
+				codeAction.setCommand(command);
+			}
 			codeAction.setDiagnostics(context.getDiagnostics());
 			return Optional.of(Either.forRight(codeAction));
 		} else {


### PR DESCRIPTION
If client advertises `CodeActionLiteralSupport`, using that for
`java.apply.workspaceEdit` would allow clients to use a generic
algorithm, instead of being forced to provide a special case for jdt.ls.

Fixes #376

This actually tries to revive #1059. Differences compared to #1059:

- Rebased onto latest master
- Checking `isSupportedCodeActionLiteral()` instead of `isWorkspaceApplyEditSupported()`.
  - This made me add `isSupportedCodeActionLiteral()` and I took the chance to fix the docstring from a previous faulty copy/paste.