### PR TITLE
BasicFileDetectorTest.testInclusions* fail randomly

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -18,6 +18,7 @@ import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getString;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -345,7 +346,7 @@ public class Preferences {
 
 	private List<String> javaCompletionFavoriteMembers;
 
-	private List<String> javaImportExclusions = new ArrayList<>();
+	private List<String> javaImportExclusions = new LinkedList<>();
 	private String javaHome;
 	private List<String> importOrder;
 	private List<String> filteredTypes;
@@ -357,7 +358,7 @@ public class Preferences {
 	private int parallelBuildsCount;
 
 	static {
-		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new ArrayList<>();
+		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/node_modules/**");
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/.metadata/**");
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT.add("**/archetype-resources/**");
@@ -561,8 +562,12 @@ public class Preferences {
 		prefs.setGenerateToStringLimitElements(generateToStringLimitElements);
 
 		List<String> javaImportExclusions = getList(configuration, JAVA_IMPORT_EXCLUSIONS_KEY, JAVA_IMPORT_EXCLUSIONS_DEFAULT);
-		prefs.setJavaImportExclusions(javaImportExclusions);
-
+		if (javaImportExclusions instanceof LinkedList) {
+			prefs.setJavaImportExclusions(javaImportExclusions);
+		} else {
+			List<String> copy = new LinkedList<>(javaImportExclusions);
+			prefs.setJavaImportExclusions(copy);
+		}
 		List<String> javaCompletionFavoriteMembers = getList(configuration, JAVA_COMPLETION_FAVORITE_MEMBERS_KEY, JAVA_COMPLETION_FAVORITE_MEMBERS_DEFAULT);
 		prefs.setJavaCompletionFavoriteMembers(javaCompletionFavoriteMembers);
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetUtilsTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,11 +30,18 @@ public class SnippetUtilsTest {
 
 	//	@Mock
 	protected PreferenceManager preferenceManager;
+	private PreferenceManager oldPreferenceManager;
 
 	@Before
 	public void initProjectManager() throws Exception {
 		preferenceManager = mock(PreferenceManager.class);
+		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
+	}
+
+	@After
+	public void cleanup() throws Exception {
+		JavaLanguageServerPlugin.setPreferencesManager(oldPreferenceManager);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ReorgQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ReorgQuickFixTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler;
 import org.eclipse.lsp4j.CodeAction;
@@ -51,10 +50,7 @@ public class ReorgQuickFixTest extends AbstractQuickFixTest {
 	public void setup() throws Exception {
 		fJProject1 = newEmptyProject();
 		fJProject1.setOptions(TestOptions.getDefaultOptions());
-
-		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
 		when(preferenceManager.getClientPreferences().isResourceOperationSupported()).thenReturn(true);
-
 		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -92,6 +92,8 @@ public abstract class AbstractProjectsManagerBasedTest {
 	@Mock
 	protected PreferenceManager preferenceManager;
 
+	private PreferenceManager oldPreferenceManager;
+
 	protected Preferences preferences;
 
 	protected SimpleLogListener logListener;
@@ -130,6 +132,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		}
 		initPreferenceManager(true);
 
+		oldPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
 		projectsManager = new ProjectsManager(preferenceManager);
 		ProgressReporterManager progressManager = new ProgressReporterManager(this.client, preferenceManager);
@@ -242,6 +245,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 
 	@After
 	public void cleanUp() throws Exception {
+		JavaLanguageServerPlugin.setPreferencesManager(oldPreferenceManager);
 		projectsManager = null;
 		Platform.removeLogListener(logListener);
 		logListener = null;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/BasicFileDetectorTest.java
@@ -87,7 +87,7 @@ public class BasicFileDetectorTest {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaImportExclusions(javaImportInclusions);
 			BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles/parent"), "buildfile").includeNested(false).maxDepth(3);
 			Collection<Path> dirs = detector.scan(null);
-			assertEquals("Found " + dirs, 2, dirs.size());
+			assertEquals("Found " + dirs + " ,exclusions=" + JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaImportExclusions(), 2, dirs.size());
 			List<String> missingDirs = separatorsToSystem(list("projects/buildfiles/parent/1_0/0_2_0", "projects/buildfiles/parent/1_0/0_2_1"));
 			dirs.stream().map(Path::toString).forEach(missingDirs::remove);
 			assertEquals("Directories were not detected" + missingDirs, 0, missingDirs.size());
@@ -113,7 +113,7 @@ public class BasicFileDetectorTest {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaImportExclusions(javaImportInclusions);
 			BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles/parent"), "buildfile").includeNested(false).maxDepth(3);
 			Collection<Path> dirs = detector.scan(null);
-			assertEquals("Found " + dirs, 1, dirs.size());
+			assertEquals("Found " + " ,exclusions=" + JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaImportExclusions() + dirs, 1, dirs.size());
 			List<String> missingDirs = separatorsToSystem(list("projects/buildfiles/parent/1_0/0_2_0"));
 			dirs.stream().map(Path::toString).forEach(missingDirs::remove);
 			assertEquals("Directories were not detected" + missingDirs, 0, missingDirs.size());
@@ -135,7 +135,7 @@ public class BasicFileDetectorTest {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaImportExclusions(javaImportInclusions);
 			BasicFileDetector detector = new BasicFileDetector(Paths.get("projects/buildfiles/parent"), "buildfile").includeNested(false).maxDepth(3);
 			Collection<Path> dirs = detector.scan(null);
-			assertEquals("Found " + dirs, 0, dirs.size());
+			assertEquals("Found " + " ,exclusions=" + JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaImportExclusions() + dirs, 0, dirs.size());
 		} finally {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setJavaImportExclusions(javaImportExclusions);
 		}


### PR DESCRIPTION
Fixes #1262 

The PR introduces the following changes:

- javaImportExclusions uses LinkedList
- the SnippetUtilsTest, ReorgQuickFixTest, AbstractProjectsManagerBasedTest tests restore the preferenceManager property

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>