### PR TITLE
Take advantage of CodeActionLiteral client capability - Second attempt

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -155,6 +155,7 @@ public class CodeActionHandler {
 		}
 
 		Command command;
+		WorkspaceEdit edit = null;
 		if (proposal instanceof CUCorrectionCommandProposal) {
 			CUCorrectionCommandProposal commandProposal = (CUCorrectionCommandProposal) proposal;
 			command = new Command(name, commandProposal.getCommand(), commandProposal.getCommandArguments());
@@ -162,7 +163,7 @@ public class CodeActionHandler {
 			RefactoringCorrectionCommandProposal commandProposal = (RefactoringCorrectionCommandProposal) proposal;
 			command = new Command(name, commandProposal.getCommand(), commandProposal.getCommandArguments());
 		} else {
-			WorkspaceEdit edit = ChangeUtil.convertToWorkspaceEdit(proposal.getChange());
+			edit = ChangeUtil.convertToWorkspaceEdit(proposal.getChange());
 			if (!ChangeUtil.hasChanges(edit)) {
 				return Optional.empty();
 			}
@@ -170,10 +171,13 @@ public class CodeActionHandler {
 		}
 
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(proposal.getKind())) {
-			// TODO: Should set WorkspaceEdit directly instead of Command
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(proposal.getKind());
-			codeAction.setCommand(command);
+			if (edit != null) {
+				codeAction.setEdit(edit);
+			} else {
+				codeAction.setCommand(command);
+			}
 			codeAction.setDiagnostics(context.getDiagnostics());
 			return Optional.of(Either.forRight(codeAction));
 		} else {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -260,9 +260,9 @@ public class ClientPreferences {
 	}
 
 	/**
-	 * {@code true} if the client has explicitly set the
-	 * {@code textDocument.documentSymbol.hierarchicalDocumentSymbolSupport} to
-	 * {@code true} when initializing the LS. Otherwise, {@code false}.
+	 * {@code true} if the client has listed {@code kind} in
+	 * {@code textDocument.codeAction.codeActionLiteralSupport.codeActionKind.valueSet}
+	 * when initializing the LS. Otherwise, {@code false}.
 	 */
 	public boolean isSupportedCodeActionKind(String kind) {
 		//@formatter:off

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -352,7 +352,7 @@ public class SourceAssistProcessor {
 		if (preferenceManager.getClientPreferences().isSupportedCodeActionKind(kind)) {
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(kind);
-			codeAction.setCommand(command);
+			codeAction.setEdit(workspaceEdit);
 			codeAction.setDiagnostics(context.getDiagnostics());
 			return Optional.of(Either.forRight(codeAction));
 		} else {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
@@ -294,14 +294,22 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 			throws BadLocationException, JavaModelException {
 
 		Command c = codeAction.isLeft() ? codeAction.getLeft() : codeAction.getRight().getCommand();
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
-		Assert.assertNotNull(c.getArguments());
-		Assert.assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
-		WorkspaceEdit we = (WorkspaceEdit) c.getArguments().get(0);
-		if (we.getDocumentChanges() != null) {
-			return evaluateChanges(we.getDocumentChanges());
+		if (c != null) {
+			Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
+			Assert.assertNotNull(c.getArguments());
+			Assert.assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
+			WorkspaceEdit we = (WorkspaceEdit) c.getArguments().get(0);
+			if (we.getDocumentChanges() != null) {
+				return evaluateChanges(we.getDocumentChanges());
+			}
+			return evaluateChanges(we.getChanges());
+		} else {
+			WorkspaceEdit we = (WorkspaceEdit) codeAction.getRight().getEdit();
+			if (we.getDocumentChanges() != null) {
+				return evaluateChanges(we.getDocumentChanges());
+			}
+			return evaluateChanges(we.getChanges());
 		}
-		return evaluateChanges(we.getChanges());
 	}
 
 	private String evaluateChanges(List<Either<TextDocumentEdit, ResourceOperation>> documentChanges) throws BadLocationException, JavaModelException {
@@ -338,7 +346,7 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 	}
 
 	public String getTitle(Either<Command, CodeAction> codeAction) {
-		return getCommand(codeAction).getTitle();
+		return codeAction.isLeft() ? codeAction.getLeft().getTitle() : codeAction.getRight().getTitle();
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ReorgQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ReorgQuickFixTest.java
@@ -197,10 +197,16 @@ public class ReorgQuickFixTest extends AbstractQuickFixTest {
 
 	private WorkspaceEdit getWorkspaceEdit(Either<Command, CodeAction> codeAction) {
 		Command c = codeAction.isLeft() ? codeAction.getLeft() : codeAction.getRight().getCommand();
-		assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
-		assertNotNull(c.getArguments());
-		assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
-		return (WorkspaceEdit) c.getArguments().get(0);
+		if (c != null) {
+			assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
+			assertNotNull(c.getArguments());
+			assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
+			return (WorkspaceEdit) c.getArguments().get(0);
+		} else {
+			WorkspaceEdit e = (WorkspaceEdit) codeAction.getRight().getEdit();
+			assertNotNull(e);
+			return e;
+		}
 	}
 
 	private void assertRenameFileOperation(Either<Command, CodeAction> codeAction, String newUri) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gorkem Ercan
@@ -93,8 +94,34 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
 		Assert.assertEquals(codeActions.get(1).getRight().getKind(), CodeActionKind.QuickFix);
 		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
-		Command c = codeActions.get(0).getRight().getCommand();
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
+		WorkspaceEdit e = (WorkspaceEdit) codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(e);
+	}
+
+	@Test
+	public void testCodeActionLiteral_removeUnusedImport() throws Exception{
+		when(preferenceManager.getClientPreferences().isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"import java.sql.*; \n" +
+						"public class Foo {\n"+
+						"	void foo() {\n"+
+						"	}\n"+
+				"}\n");
+
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, "java.sql");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnusedImport), range))));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertTrue(codeActions.size() >= 3);
+		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
+		Assert.assertEquals(codeActions.get(1).getRight().getKind(), CodeActionKind.QuickFix);
+		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
+		WorkspaceEdit w = codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(w);
 	}
 
 	@Test
@@ -252,8 +279,32 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertNotNull(codeActions);
 		Assert.assertFalse(codeActions.isEmpty());
 		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
-		Command c = codeActions.get(0).getRight().getCommand();
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
+		WorkspaceEdit e = (WorkspaceEdit) codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(e);
+	}
+
+	@Test
+	public void testCodeActionLiteral_removeUnterminatedString() throws Exception{
+		when(preferenceManager.getClientPreferences().isSupportedCodeActionKind(CodeActionKind.QuickFix)).thenReturn(true);
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						"String s = \"some str\n" +
+						"	}\n"+
+				"}\n");
+
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(JDTUtils.toURI(unit)));
+		final Range range = CodeActionUtil.getRange(unit, "some str");
+		params.setRange(range);
+		params.setContext(new CodeActionContext(Arrays.asList(getDiagnostic(Integer.toString(IProblem.UnterminatedString), range))));
+		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
+		Assert.assertNotNull(codeActions);
+		Assert.assertFalse(codeActions.isEmpty());
+		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
+		WorkspaceEdit w = codeActions.get(0).getRight().getEdit();
+		Assert.assertNotNull(w);
 	}
 
 	@Test
@@ -375,6 +426,12 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	public static Command getCommand(Either<Command, CodeAction> codeAction) {
 		return codeAction.isLeft() ? codeAction.getLeft() : codeAction.getRight().getCommand();
+	}
+
+	public static WorkspaceEdit getEdit(Either<Command, CodeAction> codeAction) {
+		assertTrue(codeAction.isRight());
+		assertNotNull(codeAction.getRight().getEdit());
+		return (WorkspaceEdit) codeAction.getRight().getEdit();
 	}
 
 	private Diagnostic getDiagnostic(String code, Range range){

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsActionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,9 +70,8 @@ public class GenerateAccessorsActionTest extends AbstractCompilationUnitBasedTes
 		Assert.assertNotNull(codeActions);
 		Either<Command, CodeAction> generateAccessorsAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.SOURCE_GENERATE_ACCESSORS);
 		Assert.assertNotNull(generateAccessorsAction);
-		Command generateAccessorsCommand = CodeActionHandlerTest.getCommand(generateAccessorsAction);
-		Assert.assertNotNull(generateAccessorsCommand);
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, generateAccessorsCommand.getCommand());
+		WorkspaceEdit generateAccessorsEdit = CodeActionHandlerTest.getEdit(generateAccessorsAction);
+		Assert.assertNotNull(generateAccessorsEdit);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Assert;
 import org.junit.Before;
@@ -88,9 +89,8 @@ public class GenerateConstructorsActionTest extends AbstractCompilationUnitBased
 		Assert.assertNotNull(codeActions);
 		Either<Command, CodeAction> constructorAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.SOURCE_GENERATE_CONSTRUCTORS);
 		Assert.assertNotNull(constructorAction);
-		Command constructorCommand = CodeActionHandlerTest.getCommand(constructorAction);
-		Assert.assertNotNull(constructorCommand);
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, constructorCommand.getCommand());
+		WorkspaceEdit constructorEdit = CodeActionHandlerTest.getEdit(constructorAction);
+		Assert.assertNotNull(constructorEdit);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Assert;
 import org.junit.Before;
@@ -89,9 +90,8 @@ public class GenerateToStringActionTest extends AbstractCompilationUnitBasedTest
 		Assert.assertNotNull(codeActions);
 		Either<Command, CodeAction> toStringAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.SOURCE_GENERATE_TO_STRING);
 		Assert.assertNotNull(toStringAction);
-		Command toStringCommand = CodeActionHandlerTest.getCommand(toStringAction);
-		Assert.assertNotNull(toStringCommand);
-		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, toStringCommand.getCommand());
+		WorkspaceEdit toStringEdit = CodeActionHandlerTest.getEdit(toStringAction);
+		Assert.assertNotNull(toStringEdit);
 	}
 
 	@Test


### PR DESCRIPTION
Another attempt at solving #376. Github seems confused about the state of #1256, so I decided to open a new one.

Changes compared to #1256:

- The error reported by @fbricon should be fixed now.
- There's no more `isSupportedCodeActionLiteral()` because we should always be checking the code action kind.
  - In both places where `isSupportedCodeActionLiteral()` was used in #1256, the `isSupportedCodeActionKind(kind)` was checked a few lines above, so the actual functional changes of the PR could be slightly simplified (compared to #1256).
- Correctly handling code action literals meant that there's a lot of places where the code basically does:
  - Pull `Command` out of `Either<Command, CodeAction>`.
  - If that `Command` is not `null` to thing A.
  - Else do thing B.

Fixes #376