### PR TITLE
No need to publish diagnostics in BuildWorkspaceHandler

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -756,7 +756,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<BuildWorkspaceStatus> buildWorkspace(boolean forceReBuild) {
 		logInfo(">> java/buildWorkspace (" + (forceReBuild ? "full)" : "incremental)"));
-		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(client, pm);
+		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(pm);
 		return computeAsync((monitor) -> handler.buildWorkspace(forceReBuild, monitor));
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/BuildWorkspaceHandlerTest.java
@@ -12,7 +12,6 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -23,23 +22,18 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
-import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
-import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 public class BuildWorkspaceHandlerTest extends AbstractProjectsManagerBasedTest {
-	private JavaLanguageClient client = mock(JavaLanguageClient.class);
-	private JavaClientConnection javaClient = new JavaClientConnection(client);
-
 	private BuildWorkspaceHandler handler;
 	private IProject project;
 
 	@Before
 	public void setUp() throws Exception {
-		handler = new BuildWorkspaceHandler(javaClient, projectsManager);
+		handler = new BuildWorkspaceHandler(projectsManager);
 		importProjects("maven/salut2");
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut2");
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -321,7 +321,7 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 		// build workspace
 		reset(connection);
 		captor = ArgumentCaptor.forClass(PublishDiagnosticsParams.class);
-		BuildWorkspaceHandler bwh = new BuildWorkspaceHandler(connection, projectsManager);
+		BuildWorkspaceHandler bwh = new BuildWorkspaceHandler(projectsManager);
 		bwh.buildWorkspace(true, new NullProgressMonitor());
 		verify(connection, atLeastOnce()).publishDiagnostics(captor.capture());
 		allCalls = captor.getAllValues();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManagerTest.java
@@ -28,7 +28,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
-import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
@@ -47,7 +46,6 @@ import org.junit.Test;
 public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	private JavaLanguageClient client = mock(JavaLanguageClient.class);
-	private JavaClientConnection javaClient = new JavaClientConnection(client);
 	private JDTLanguageServer server;
 	private boolean autoBuild;
 
@@ -91,7 +89,7 @@ public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 		java.io.File physicalFile = new java.io.File(file.getLocationURI());
 		physicalFile.delete();
 
-		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(javaClient, projectsManager);
+		BuildWorkspaceHandler handler = new BuildWorkspaceHandler(projectsManager);
 		BuildWorkspaceStatus result = handler.buildWorkspace(true, monitor);
 
 		waitForBackgroundJobs();


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

**WorkspaceDiagnosticsHandler.java** is listening to resource change event, any time the build job changes (add or remove) the problem markers of the resources under the target project, the handler will sync diagnostics to the client. So it's unnecessary for the BuildWorkspaceHandler to clean up the project level diagnostics before building.