### PR TITLE
Limit completion results

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SortTextHelper.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SortTextHelper.java
@@ -21,7 +21,7 @@ import org.eclipse.jdt.core.CompletionProposal;
  *
  */
 public final class SortTextHelper {
-	private static final int CEILING = 999_999_999;
+	public static final int CEILING = 999_999_999;
 
 	public static final int MAX_RELEVANCE_VALUE = 99_999_999;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -32,7 +32,6 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalReplacementProvider;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalRequestor;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2;
@@ -94,11 +93,6 @@ public class CompletionResolveHandler {
 		if (unit == null) {
 			throw new IllegalStateException(NLS.bind("Unable to match Compilation Unit from {0} ", uri));
 		}
-		CompletionProposalReplacementProvider proposalProvider = new CompletionProposalReplacementProvider(unit,
-				completionResponse.getContext(),
-				completionResponse.getOffset(),
-				this.manager.getClientPreferences());
-		proposalProvider.updateReplacement(completionResponse.getProposals().get(proposalId), param, '\0');
 		if (monitor.isCanceled()) {
 			param.setData(null);
 			return param;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -472,7 +472,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
 		logInfo(">> document/completion");
-		CompletionHandler handler = new CompletionHandler();
+		CompletionHandler handler = new CompletionHandler(preferenceManager);
 		final IProgressMonitor[] monitors = new IProgressMonitor[1];
 		CompletableFuture<Either<List<CompletionItem>, CompletionList>> result = computeAsync((monitor) -> {
 			monitors[0] = monitor;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -193,6 +193,13 @@ public class Preferences {
 	public static final List<String> JAVA_COMPLETION_FAVORITE_MEMBERS_DEFAULT;
 
 	/**
+	 * Preference key for maximum number of completion results to be returned.
+	 * Defaults to 50.
+	 */
+	public static final String JAVA_COMPLETION_MAX_RESULTS_KEY = "java.completion.maxResults";
+	public static final int JAVA_COMPLETION_MAX_RESULTS_DEFAULT = 50;
+
+	/**
 	 * A named preference that controls if the Java code assist only inserts
 	 * completions. When set to true, code completion overwrites the current text.
 	 * When set to false, code is simply added instead.
@@ -361,8 +368,8 @@ public class Preferences {
 	private String formatterProfileName;
 	private Collection<IPath> rootPaths;
 	private Collection<IPath> triggerFiles;
-
 	private int parallelBuildsCount;
+	private int maxCompletionResults;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -473,6 +480,7 @@ public class Preferences {
 		importOrder = JAVA_IMPORT_ORDER_DEFAULT;
 		filteredTypes = JAVA_COMPLETION_FILTERED_TYPES_DEFAULT;
 		parallelBuildsCount = PreferenceInitializer.PREF_MAX_CONCURRENT_BUILDS_DEFAULT;
+		maxCompletionResults = JAVA_COMPLETION_MAX_RESULTS_DEFAULT;
 	}
 
 	/**
@@ -611,6 +619,9 @@ public class Preferences {
 		int maxConcurrentBuilds = getInt(configuration, JAVA_MAX_CONCURRENT_BUILDS, PreferenceInitializer.PREF_MAX_CONCURRENT_BUILDS_DEFAULT);
 		maxConcurrentBuilds = maxConcurrentBuilds >= 1 ? maxConcurrentBuilds : 1;
 		prefs.setMaxBuildCount(maxConcurrentBuilds);
+
+		int maxCompletions = getInt(configuration, JAVA_COMPLETION_MAX_RESULTS_KEY, JAVA_COMPLETION_MAX_RESULTS_DEFAULT);
+		prefs.setMaxCompletionResults(maxCompletions);
 
 		return prefs;
 	}
@@ -1057,7 +1068,29 @@ public class Preferences {
 		return javaFormatOnTypeEnabled;
 	}
 
-	public void setJavaFormatOnTypeEnabled(boolean javaFormatOnTypeEnabled) {
+	public Preferences setJavaFormatOnTypeEnabled(boolean javaFormatOnTypeEnabled) {
 		this.javaFormatOnTypeEnabled = javaFormatOnTypeEnabled;
+		return this;
+	}
+
+	public int getMaxCompletionResults() {
+		return maxCompletionResults;
+	}
+
+	/**
+	 * Sets the maximum number of completion results (excluding snippets and Javadoc
+	 * proposals). If maxCompletions is set to 0 or lower, then the completion limit
+	 * is considered disabled, which could certainly severly impact performance in a
+	 * negative way.
+	 *
+	 * @param maxCompletions
+	 */
+	public Preferences setMaxCompletionResults(int maxCompletions) {
+		if (maxCompletions < 1) {
+			this.maxCompletionResults = Integer.MAX_VALUE;
+		} else {
+			this.maxCompletionResults = maxCompletions;
+		}
+		return this;
 	}
 }


### PR DESCRIPTION
TextEdits need to be computed during the `completion` call, but this can be extremely slow when a large number of results is returned. This PR tries to mitigate the issue by returning partial result lists and marking the results as incomplete. Smaller payload means computing Textedits is now more affordable. Hopefully the UX should be improved as well since completion queries will return faster too.
The number of completion results is configurable with the `java.completion.maxResults` preference (defaults to 50). Setting 0 will disable the limit and return all results. Be aware the performance will be very negatively impacted as textEdits for all results will be computed eagerly (can be thousands of results).

Fixes #465


Signed-off-by: Fred Bricon <fbricon@gmail.com>