### PR TITLE
Remove dup call of getRawLocationURI()

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -626,7 +626,8 @@ public final class JDTUtils {
 	 * @return
 	 */
 	public static String getFileURI(IResource resource) {
-		return ResourceUtils.fixURI(resource.getRawLocationURI() == null ? resource.getLocationURI() : resource.getRawLocationURI());
+		URI uri = resource.getRawLocationURI();
+		return ResourceUtils.fixURI(uri == null ? resource.getLocationURI() : uri);
 	}
 
 	public static IJavaElement findElementAtSelection(ITypeRoot unit, int line, int column, PreferenceManager preferenceManager, IProgressMonitor monitor) throws JavaModelException {


### PR DESCRIPTION
<img width="878" alt="Screen Shot 2019-12-06 at 12 44 25 PM" src="https://user-images.githubusercontent.com/2351748/70297599-bc4b5200-1829-11ea-87cc-68b8f04696b6.png">

Above is profiled by JProfiler when I complete for letter 'S'. According to the result, `getRawLocationURI()` is not cheap. This PR should improve the perf a little bit.