### PR TITLE
Implement referenced libraries support in language server

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -344,7 +344,7 @@ public final class ProjectUtils {
 	public static Set<Path> collectBinaries(IPath projectDir, Set<String> include, Set<String> exclude, IProgressMonitor monitor) throws CoreException {
 		Set<Path> binaries = new LinkedHashSet<>();
 		Map<Path, Set<String>> includeByPrefix = groupGlobsByPrefix(projectDir, include);
-		Map<Path, Set<String>> excludeByPrefix = groupGlobsByPrefix(projectDir, exclude);
+		Stream<Path> excludeResolved = exclude.stream().map(glob -> resolveGlobPath(projectDir, glob).toFile().toPath());
 		for (Path base: includeByPrefix.keySet()) {
 			if (monitor.isCanceled()) {
 				return binaries;
@@ -359,7 +359,7 @@ public final class ProjectUtils {
 				continue; // base does not exist
 			}
 			Set<String> subInclude = includeByPrefix.get(base);
-			Set<String> subExclude = excludeByPrefix.getOrDefault(base, new LinkedHashSet<>());
+			Set<String> subExclude = excludeResolved.map(glob -> base.relativize(glob).toString()).collect(Collectors.toSet());
 			DirectoryScanner scanner = new DirectoryScanner();
 			try {
 				scanner.setIncludes(subInclude.toArray(new String[0]));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -362,8 +362,8 @@ public final class ProjectUtils {
 			Set<String> subExclude = excludeResolved.map(glob -> base.relativize(glob).toString()).collect(Collectors.toSet());
 			DirectoryScanner scanner = new DirectoryScanner();
 			try {
-				scanner.setIncludes(subInclude.toArray(new String[0]));
-				scanner.setExcludes(subExclude.toArray(new String[0]));
+				scanner.setIncludes(subInclude.toArray(new String[subInclude.size()]));
+				scanner.setExcludes(subExclude.toArray(new String[subExclude.size()]));
 				scanner.addDefaultExcludes();
 				scanner.setBasedir(base.toString());
 				scanner.scan();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -124,9 +124,11 @@ final public class InitHandler {
 			Object settings = initializationOptions.get(SETTINGS_KEY);
 			@SuppressWarnings("unchecked")
 			Preferences prefs = Preferences.createFrom((Map<String, Object>) settings);
+			prefs.setRootPaths(rootPaths);
 			preferenceManager.update(prefs);
+		} else {
+			preferenceManager.getPreferences().setRootPaths(rootPaths);
 		}
-		preferenceManager.getPreferences().setRootPaths(rootPaths);
 
 		Collection<IPath> triggerPaths = new ArrayList<>();
 		Collection<String> triggerFiles = getInitializationOption(initializationOptions, "triggerFiles", Collection.class);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -411,8 +411,8 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 			Collection<IPath> rootPaths = preferenceManager.getPreferences().getRootPaths();
 			@SuppressWarnings("unchecked")
 			Preferences prefs = Preferences.createFrom((Map<String, Object>) settings);
+			prefs.setRootPaths(rootPaths);
 			preferenceManager.update(prefs);
-			preferenceManager.getPreferences().setRootPaths(rootPaths);
 		}
 		syncCapabilitiesToSettings();
 		boolean jvmChanged = false;
@@ -432,7 +432,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
 		FormatterManager.configureFormatter(preferenceManager, pm);
-		logInfo(">>New configuration: " + settings);
+		logInfo(">> New configuration: " + settings);
 	}
 
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -268,6 +268,7 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 					workspaceDiagnosticsHandler.publishDiagnostics(monitor);
 					workspaceDiagnosticsHandler.addResourceChangeListener();
 					pm.registerWatchers();
+					pm.registerListeners();
 					logInfo(">> watchers registered");
 				} catch (OperationCanceledException | CoreException e) {
 					logException(e.getMessage(), e);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
@@ -65,7 +65,12 @@ public class InvisibleProjectBuildSupport extends EclipseBuildSupport implements
 	}
 
 	public boolean matchPattern(IPath base, String pattern, String path) {
-		return SelectorUtils.matchPath(ProjectUtils.resolveGlobPath(base, pattern).toOSString(), path);
+		String glob = ProjectUtils.resolveGlobPath(base, pattern).toOSString();
+		if (base.getDevice() != null) {
+			return SelectorUtils.matchPath(glob, path, false); // Case insensitive match in Windows
+		} else {
+			return SelectorUtils.matchPath(glob, path); // Case sensitive match in *nix
+		}
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
@@ -65,7 +65,7 @@ public class InvisibleProjectBuildSupport extends EclipseBuildSupport implements
 	}
 
 	public boolean matchPattern(IPath base, String pattern, String path) {
-		return SelectorUtils.matchPath(ProjectUtils.resolveGlobPath(base, pattern).toString(), path);
+		return SelectorUtils.matchPath(ProjectUtils.resolveGlobPath(base, pattern).toOSString(), path);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
@@ -12,14 +12,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import org.codehaus.plexus.util.SelectorUtils;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.ReferencedLibraries;
 
 /**
  * @author Fred Bricon
@@ -43,15 +46,26 @@ public class InvisibleProjectBuildSupport extends EclipseBuildSupport implements
 			return false;
 		}
 		refresh(resource, changeType, monitor);
-		IProject invisibleProject = resource.getProject();
-		IPath realFolderPath = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK).getLocation();
-		if (realFolderPath != null) {
-			IPath libFolderPath = realFolderPath.append(LIB_FOLDER);
-			if (libFolderPath.isPrefixOf(resource.getLocation())) {
-				UpdateClasspathJob.getInstance().updateClasspath(JavaCore.create(invisibleProject), libFolderPath, monitor);
+		String resourcePath = resource.getLocation().toOSString();
+		IProject project = resource.getProject();
+		IPath projectFolder = ProjectUtils.getProjectRealFolder(project);
+		ReferencedLibraries libraries = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getReferencedLibraries();
+		for (String pattern: libraries.getExclude()) {
+			if (matchPattern(projectFolder, pattern, resourcePath)) {
+				return false; // skip if excluded
+			}
+		}
+		for (String pattern: libraries.getInclude()) {
+			if (matchPattern(projectFolder, pattern, resourcePath)) {
+				UpdateClasspathJob.getInstance().updateClasspath(JavaCore.create(project), libraries);
+				return false; // update if included in any pattern
 			}
 		}
 		return false;
+	}
+
+	public boolean matchPattern(IPath base, String pattern, String path) {
+		return SelectorUtils.matchPath(ProjectUtils.resolveGlobPath(base, pattern).toString(), path);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -105,13 +105,12 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 				IJavaProject javaProject = JavaCore.create(invisibleProject);
 				ProjectUtils.addSourcePath(sourcePath, subProjectPaths.toArray(new IPath[0]), javaProject);
 				JavaLanguageServerPlugin.logInfo("Successfully created a workspace invisible project " + invisibleProjectName);
+				UpdateClasspathJob.getInstance().updateClasspath(javaProject, preferencesManager.getPreferences().getReferencedLibraries());
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException("Failed to create the invisible project.", e);
 				return;
 			}
 		}
-		IJavaProject javaProject = JavaCore.create(invisibleProject);
-		UpdateClasspathJob.getInstance().updateClasspath(javaProject, rootPath.append(libFolder), monitor);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -105,12 +105,13 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 				IJavaProject javaProject = JavaCore.create(invisibleProject);
 				ProjectUtils.addSourcePath(sourcePath, subProjectPaths.toArray(new IPath[0]), javaProject);
 				JavaLanguageServerPlugin.logInfo("Successfully created a workspace invisible project " + invisibleProjectName);
-				UpdateClasspathJob.getInstance().updateClasspath(javaProject, preferencesManager.getPreferences().getReferencedLibraries());
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException("Failed to create the invisible project.", e);
 				return;
 			}
 		}
+		IJavaProject javaProject = JavaCore.create(invisibleProject);
+		UpdateClasspathJob.getInstance().updateClasspath(javaProject, preferencesManager.getPreferences().getReferencedLibraries());
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -130,19 +130,10 @@ public class ProjectsManager implements ISaveParticipant {
 
 	};
 
-	private IPreferencesChangeListener prefChangeListener = new IPreferencesChangeListener() {
-		@Override
-		public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
-			if (!oldPreferences.getReferencedLibraries().equals(newPreferences.getReferencedLibraries())) {
-				registerWatcherJob.schedule(1000L);
-				UpdateClasspathJob.getInstance().updateClasspath();
-			}
-		}
-	};
+	private IPreferencesChangeListener preferenceChangeListener = null;
 
 	public ProjectsManager(PreferenceManager preferenceManager) {
 		this.preferenceManager = preferenceManager;
-		this.preferenceManager.addPreferencesChangeListener(prefChangeListener);
 	}
 
 	public void initializeProjects(final Collection<IPath> rootPaths, IProgressMonitor monitor) throws CoreException, OperationCanceledException {
@@ -745,6 +736,21 @@ public class ProjectsManager implements ISaveParticipant {
 			return fileWatchers;
 		}
 		return Collections.emptyList();
+	}
+
+	public void registerListeners() {
+		if (this.preferenceChangeListener == null) {
+			this.preferenceChangeListener = new IPreferencesChangeListener() {
+				@Override
+				public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
+					if (!oldPreferences.getReferencedLibraries().equals(newPreferences.getReferencedLibraries())) {
+						registerWatcherJob.schedule(1000L);
+						UpdateClasspathJob.getInstance().updateClasspath();
+					}
+				}
+			};
+			this.preferenceManager.addPreferencesChangeListener(this.preferenceChangeListener);
+		}
 	}
 
 	public File findFile(String formatterUrl) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -692,7 +692,7 @@ public class ProjectsManager implements ISaveParticipant {
 								}
 							}
 						}
-						if (!ProjectUtils.isVisibleProject(project)) { // Invisible project will watch referenced libaraies' include pattern
+						if (!ProjectUtils.isVisibleProject(project)) { // Invisible project will watch referenced libraries' include patterns
 							IPath projectFolder = ProjectUtils.getProjectRealFolder(project);
 							Set<String> libraries = preferenceManager.getPreferences().getReferencedLibraries().getInclude();
 							for (String pattern: libraries) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -696,7 +696,12 @@ public class ProjectsManager implements ISaveParticipant {
 							IPath projectFolder = ProjectUtils.getProjectRealFolder(project);
 							Set<String> libraries = preferenceManager.getPreferences().getReferencedLibraries().getInclude();
 							for (String pattern: libraries) {
-								patterns.add(ProjectUtils.resolveGlobPath(projectFolder, pattern).toString());
+								IPath resolved = ProjectUtils.resolveGlobPath(projectFolder, pattern);
+								if (resolved.getDevice() != null) {
+									patterns.add(resolved.toPortableString().replace(resolved.getDevice(), "**"));
+								} else {
+									patterns.add(resolved.toPortableString());
+								}
 							}
 						}
 					}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -696,12 +696,7 @@ public class ProjectsManager implements ISaveParticipant {
 							IPath projectFolder = ProjectUtils.getProjectRealFolder(project);
 							Set<String> libraries = preferenceManager.getPreferences().getReferencedLibraries().getInclude();
 							for (String pattern: libraries) {
-								IPath resolved = ProjectUtils.resolveGlobPath(projectFolder, pattern);
-								if (resolved.getDevice() != null) {
-									patterns.add(resolved.toPortableString().replace(resolved.getDevice(), "**"));
-								} else {
-									patterns.add(resolved.toPortableString());
-								}
+								patterns.add(ProjectUtils.resolveGlobPath(projectFolder, pattern).toPortableString());
 							}
 						}
 					}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/UpdateClasspathJob.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/UpdateClasspathJob.java
@@ -101,12 +101,12 @@ public class UpdateClasspathJob extends WorkspaceJob {
 			final Path source = realFolderPath.resolve(entry.getValue());
 			expandedSources.put(binary, new org.eclipse.core.runtime.Path(source.toString()));
 		}
-		final Map<String, IPath> libraries = new HashMap<>();
+		final Map<Path, IPath> libraries = new HashMap<>();
 		for (final Path binary: binaries) {
 			if (expandedSources.containsKey(binary)) {
-				libraries.put(binary.toString(), expandedSources.get(binary));
+				libraries.put(binary, expandedSources.get(binary));
 			} else { // If not specified in source map, try to detect it
-				libraries.put(binary.toString(), ProjectUtils.detectSources(binary));
+				libraries.put(binary, ProjectUtils.detectSources(binary));
 			}
 		}
 		ProjectUtils.updateBinaries(javaProject, libraries, monitor);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -167,8 +167,9 @@ public class PreferenceManager {
 		if(preferences == null){
 			throw new IllegalArgumentException("Preferences can not be null");
 		}
-		preferencesChanged(this.preferences, preferences);
+		Preferences oldPreferences = this.preferences;
 		this.preferences = preferences;
+		preferencesChanged(oldPreferences, preferences); // listener will get latest preference from getPreferences()
 
 		String newMavenSettings = preferences.getMavenUserSettings();
 		String oldMavenSettings = getMavenConfiguration().getUserSettingsFile();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -455,15 +455,15 @@ public class Preferences {
 		private Set<String> exclude;
 		private Map<String, String> sources;
 
-		ReferencedLibraries() {
+		public ReferencedLibraries() {
 			this(new HashSet<>(), new HashSet<>(), new HashMap<>());
 		}
 
-		ReferencedLibraries(Set<String> include) {
+		public ReferencedLibraries(Set<String> include) {
 			this(include, new HashSet<>(), new HashMap<>());
 		}
 
-		ReferencedLibraries(Set<String> include, Set<String> exclude, Map<String, String> sources) {
+		public ReferencedLibraries(Set<String> include, Set<String> exclude, Map<String, String> sources) {
 			this.include = include;
 			this.exclude = exclude;
 			this.sources = sources;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.jobs.IJobChangeEvent;
 import org.eclipse.core.runtime.jobs.IJobChangeListener;
 import org.eclipse.core.runtime.jobs.Job;
@@ -159,14 +158,14 @@ public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBa
 
 		Set<String> include = new HashSet<>();
 		Set<String> exclude = new HashSet<>();
-		Map<String, IPath> sources = new HashMap<>();
+		Map<String, String> sources = new HashMap<>();
 
 		// Include following jars (by lib/** detection)
 		// - /lib/foo.jar
 		// - /lib/foo-sources.jar
 		File libFolder = Files.createDirectories(projectFolder.toPath().resolve(InvisibleProjectBuildSupport.LIB_FOLDER)).toFile();
 		File fooBinary = new File(libFolder, "foo.jar");
-		File fooSource = new File(libFolder, "foo-source.jar");
+		File fooSource = new File(libFolder, "foo-sources.jar");
 		FileUtils.copyFile(originBinary, fooBinary);
 		FileUtils.copyFile(originSource, fooSource);
 
@@ -179,7 +178,7 @@ public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBa
 		FileUtils.copyFile(originBinary, barBinary);
 		FileUtils.copyFile(originSource, barSource);
 		include.add(barBinary.toString());
-		sources.put(barBinary.toString(), new org.eclipse.core.runtime.Path(barSource.toString()));
+		sources.put(barBinary.toString(), barSource.toString());
 
 		// Exclude following jars (by manually add exclude)
 		// - /lib/foo.jar
@@ -199,7 +198,7 @@ public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBa
 
 		try { // Send two update request concurrently
 			Job.getJobManager().addJobChangeListener(listener);
-			projectsManager.fileChanged(fooBinary.toString(), CHANGE_TYPE.CREATED); // Request sent by jdt.ls's lib detection
+			projectsManager.fileChanged(fooBinary.toURI().toString(), CHANGE_TYPE.CREATED); // Request sent by jdt.ls's lib detection
 			UpdateClasspathJob.getInstance().updateClasspath(javaProject, include, exclude, sources); // Request sent by third-party client
 			waitForBackgroundJobs();
 			assertEquals("Update classpath job should have been invoked once", 1, jobInvocations[0]);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -76,11 +76,13 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 
 		List<FileSystemWatcher> watchers = projectsManager.registerWatchers();
 		watchers.sort((a, b) -> a.getGlobPattern().compareTo(b.getGlobPattern()));
-		assertEquals(9, watchers.size());
+		assertEquals(10, watchers.size()); // basic(8) + project(1) + library(1)
 		String srcGlobPattern = watchers.get(7).getGlobPattern();
 		assertTrue("Unexpected source glob pattern: " + srcGlobPattern, srcGlobPattern.equals("**/src/**"));
-		String libGlobPattern = watchers.get(8).getGlobPattern();
-		assertTrue("Unexpected project glob pattern: " + libGlobPattern, libGlobPattern.endsWith(projectFolder.getName() + "/**"));
+		String projGlobPattern = watchers.get(8).getGlobPattern();
+		assertTrue("Unexpected project glob pattern: " + projGlobPattern, projGlobPattern.endsWith(projectFolder.getName() + "/**"));
+		String libGlobPattern = watchers.get(9).getGlobPattern();
+		assertTrue("Unexpected library glob pattern: " + libGlobPattern, libGlobPattern.endsWith(projectFolder.getName() + "/lib/**"));
 	}
 
 	public void automaticJarDetection() throws Exception {


### PR DESCRIPTION
## Introduction

This PR implements the referenced libraries support in server side, as described in https://github.com/eclipse/eclipse.jdt.ls/issues/1257#issuecomment-552237461.

It contains following modifications:
* Add a preference `java.project.referencedLibraries`.
* Implement a glob-based binary searching with basic optimizations.
* UpdateClasspathJob now fully adopts `include-exclude-sources` pattern.
* Use `didChangeWorkspaceFiles` to watch include globs, along with watcher listening to preference change. 

Pitfalls of moving to the server:
* Java does not has a glob library that can rival `node-glob`. There's even not a library that supports searching based on either absolute or relative path. This PR implements basic optimizations from `node-glob`: group the globs by prefix, and use prefix base directory for searching (or just a regular file).
* VS Code will not report events of files outside of workspace. So referencing libraries via absolute path will often result in not being able to refresh lively. 

