### PR TITLE
Fix exception caused by misuse of java.util.stream.Stream

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -344,7 +344,7 @@ public final class ProjectUtils {
 	public static Set<Path> collectBinaries(IPath projectDir, Set<String> include, Set<String> exclude, IProgressMonitor monitor) throws CoreException {
 		Set<Path> binaries = new LinkedHashSet<>();
 		Map<IPath, Set<String>> includeByPrefix = groupGlobsByPrefix(projectDir, include);
-		Stream<IPath> excludeResolved = exclude.stream().map(glob -> resolveGlobPath(projectDir, glob));
+		Set<IPath> excludeResolved = exclude.stream().map(glob -> resolveGlobPath(projectDir, glob)).collect(Collectors.toSet());
 		for (IPath baseDir: includeByPrefix.keySet()) {
 			Path base = baseDir.toFile().toPath();
 			if (monitor.isCanceled()) {
@@ -360,7 +360,7 @@ public final class ProjectUtils {
 				continue; // base does not exist
 			}
 			Set<String> subInclude = includeByPrefix.get(baseDir);
-			Set<String> subExclude = excludeResolved.map(glob -> glob.makeRelativeTo(baseDir).toOSString()).collect(Collectors.toSet());
+			Set<String> subExclude = excludeResolved.stream().map(glob -> glob.makeRelativeTo(baseDir).toOSString()).collect(Collectors.toSet());
 			DirectoryScanner scanner = new DirectoryScanner();
 			try {
 				scanner.setIncludes(subInclude.toArray(new String[subInclude.size()]));


### PR DESCRIPTION
According to the Java 8 Stream specification:

> A Stream should be operated on (invoking an intermediate or terminal stream operation) only once. A Stream implementation may throw IllegalStateException if it detects that the Stream is being reused.

So multiple use of `excludeResolved` may cause following exception:

> IllegalStateException: stream has already been operated upon or closed.

Sorry for my fault of being not familiar with this Java feature...