### PR TITLE
Add APIs to get classpaths and settings

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources,
  org.eclipse.core.net,
+ org.eclipse.debug.core,
  org.eclipse.jdt.core,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.text;bundle-version="3.6.0",

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -69,6 +69,12 @@
             <command
                   id="java.project.listSourcePaths">
             </command>
+            <command
+                  id="java.project.getSettings">
+            </command>
+            <command
+                  id="java.project.getClasspaths">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -75,6 +75,9 @@
             <command
                   id="java.project.getClasspaths">
             </command>
+            <command
+                  id="java.project.isTestFile">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Microsoft Corporation and others.
+ * Copyright (c) 2017,2019 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -12,13 +12,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.lsp4j.WorkspaceEdit;
 
 public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
@@ -56,6 +59,10 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return BuildPathCommand.removeFromSourcePath(sourceFolder1);
 				case "java.project.listSourcePaths":
 					return BuildPathCommand.listSourcePaths();
+				case "java.project.getSettings":
+					return ProjectCommand.getProjectSettings((String) arguments.get(0), (ArrayList<String>) arguments.get(1));
+				case "java.project.getClasspaths":
+					return ProjectCommand.getClasspaths((String) arguments.get(0), JSONUtility.toModel(arguments.get(1), ClasspathOptions.class));
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -63,6 +63,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return ProjectCommand.getProjectSettings((String) arguments.get(0), (ArrayList<String>) arguments.get(1));
 				case "java.project.getClasspaths":
 					return ProjectCommand.getClasspaths((String) arguments.get(0), JSONUtility.toModel(arguments.get(1), ClasspathOptions.class));
+				case "java.project.isTestFile":
+					return ProjectCommand.isTestFile((String) arguments.get(0));
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2019 Microsoft Corporation and others.
+ * Copyright (c) 2017,2020 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Corporation and others.
+ * Copyright (c) 2020 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.internal.core.LaunchConfiguration;
+import org.eclipse.debug.internal.core.LaunchConfigurationInfo;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+import org.eclipse.jdt.launching.JavaLaunchDelegate;
+import org.eclipse.jdt.ls.core.internal.IConstants;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class ProjectCommand {
+
+    /**
+     * Get the project settings.
+     * @param uri Uri of the source/class file needs to be queried.
+     * @param settingKeys the settings want to query, for example: ["org.eclipse.jdt.core.compiler.compliance"]
+     * @return A Map<string, string> with all the setting keys and their values.
+     * @throws CoreException
+     */
+    public static Map<String, String> getProjectSettings(String uri, List<String> settingKeys) throws CoreException {
+        IJavaProject javaProject = getJavaProjectFromUri(uri);
+        Map<String, String> settings = new HashMap<>();
+        for (String key : settingKeys) {
+            settings.putIfAbsent(key, javaProject.getOption(key, true));
+        }
+        return settings;
+    }
+
+    public static ClasspathResult getClasspaths(String uri, ClasspathOptions options) throws CoreException {
+        IJavaProject javaProject = getJavaProjectFromUri(uri);
+        ILaunchConfiguration launchConfig = new JavaApplicationLaunchConfiguration(javaProject.getProject(), options.excludingTests);
+        JavaLaunchDelegate delegate = new JavaLaunchDelegate();
+        String[][] paths = delegate.getClasspathAndModulepath(launchConfig);
+        return new ClasspathResult(paths[0], paths[1]);
+    }
+
+    private static IJavaProject getJavaProjectFromUri(String uri) throws CoreException {
+        ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(uri);
+        if (typeRoot == null) {
+            throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing TypeRoot"));
+        }
+        IJavaProject javaProject = typeRoot.getJavaProject();
+        if (javaProject == null) {
+            throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing Java project"));
+        }
+        return javaProject;
+    }
+    
+    private static class JavaApplicationLaunchConfiguration extends LaunchConfiguration {
+        public static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + "<launchConfiguration type=\"%s\">\n"
+                + "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
+                + "</listAttribute>\n"
+                + "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
+                + "</listAttribute>\n"
+                + "</launchConfiguration>";
+        private IProject project;
+        private boolean excludeTestCode;
+        private String classpathProvider;
+        private String sourcepathProvider;
+        private LaunchConfigurationInfo launchInfo;
+
+        protected JavaApplicationLaunchConfiguration(IProject project, boolean excludeTestCode) throws CoreException {
+            super(String.valueOf(new Date().getTime()), null, false);
+            this.project = project;
+            this.excludeTestCode = excludeTestCode;
+            if (ProjectUtils.isMavenProject(project)) {
+                classpathProvider = MavenRuntimeClasspathProvider.MAVEN_CLASSPATH_PROVIDER;
+                sourcepathProvider = MavenRuntimeClasspathProvider.MAVEN_SOURCEPATH_PROVIDER;
+            } else if (ProjectUtils.isGradleProject(project)) {
+                classpathProvider = GradleClasspathProvider.ID;
+            }
+            // Since MavenRuntimeClasspathProvider will only encluding test entries when:
+            // 1. Launch configuration is JUnit/TestNG type
+            // 2. Mapped resource is in test path.
+            // That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
+            // See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
+            this.launchInfo = new JavaLaunchConfigurationInfo(String.format(JAVA_APPLICATION_LAUNCH, excludeTestCode ? 
+                    MavenRuntimeClasspathProvider.JDT_JAVA_APPLICATION : MavenRuntimeClasspathProvider.JDT_JUNIT_TEST));
+        }
+
+        @Override
+        public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
+            if (IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE.equalsIgnoreCase(attributeName)) {
+                return excludeTestCode;
+            }
+
+            return super.getAttribute(attributeName, defaultValue);
+        }
+
+        @Override
+        public String getAttribute(String attributeName, String defaultValue) throws CoreException {
+            if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equalsIgnoreCase(attributeName)) {
+                return project.getName();
+            } else if (IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER.equalsIgnoreCase(attributeName)) {
+                return classpathProvider;
+            } else if (IJavaLaunchConfigurationConstants.ATTR_SOURCE_PATH_PROVIDER.equalsIgnoreCase(attributeName)) {
+                return sourcepathProvider;
+            }
+
+            return super.getAttribute(attributeName, defaultValue);
+        }
+
+        @Override
+        protected LaunchConfigurationInfo getInfo() throws CoreException {
+            return this.launchInfo;
+        }
+    }
+
+    private static class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
+        public JavaLaunchConfigurationInfo(String launchXml) {
+            super();
+            try {
+                DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+                parser.setErrorHandler(new DefaultHandler());
+                StringReader reader = new StringReader(launchXml);
+                InputSource source = new InputSource(reader);
+                Element root = parser.parse(source).getDocumentElement();
+                initializeFromXML(root);
+            } catch (ParserConfigurationException | SAXException | IOException | CoreException e) {
+                // do nothing
+            }
+        }
+    }
+
+    public static class ClasspathOptions {
+        public boolean excludingTests;
+    }
+
+    static class ClasspathResult {
+        String[] classpaths;
+        String[] modulepaths;
+
+        public ClasspathResult(String[] classpaths, String[] modulepaths) {
+            this.classpaths = classpaths;
+            this.modulepaths = modulepaths;
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -13,28 +13,18 @@
 
 package org.eclipse.jdt.ls.core.internal.commands;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunchConfiguration;
-import org.eclipse.debug.internal.core.LaunchConfiguration;
-import org.eclipse.debug.internal.core.LaunchConfigurationInfo;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -42,18 +32,13 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
-import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.JavaLaunchDelegate;
 import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.managers.IBuildSupport;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.m2e.jdt.IClasspathManager;
-import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
-import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 
 public class ProjectCommand {
 
@@ -96,7 +81,11 @@ public class ProjectCommand {
 	 */
 	public static ClasspathResult getClasspaths(String uri, ClasspathOptions options) throws CoreException {
 		IJavaProject javaProject = getJavaProjectFromUri(uri);
-		ILaunchConfiguration launchConfig = new JavaApplicationLaunchConfiguration(javaProject.getProject(), options.excludingTests);
+		Optional<IBuildSupport> bs = JavaLanguageServerPlugin.getProjectsManager().getBuildSupport(javaProject.getProject());
+		if (!bs.isPresent()) {
+			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "No BuildSupport for the project: " + javaProject.getElementName()));
+		}
+		ILaunchConfiguration launchConfig = bs.get().getLaunchConfiguration(javaProject, options.scope);
 		JavaLaunchDelegate delegate = new JavaLaunchDelegate();
 		String[][] paths = delegate.getClasspathAndModulepath(launchConfig);
 		return new ClasspathResult(javaProject.getProject().getLocationURI(), paths[0], paths[1]);
@@ -175,86 +164,9 @@ public class ProjectCommand {
 		}
 		return javaProject;
 	}
-	
-	private static class JavaApplicationLaunchConfiguration extends LaunchConfiguration {
-		public static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-				+ "<launchConfiguration type=\"%s\">\n"
-				+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
-				+ "</listAttribute>\n"
-				+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
-				+ "</listAttribute>\n"
-				+ "</launchConfiguration>";
-		private IProject project;
-		private boolean excludeTestCode;
-		private String classpathProvider;
-		private String sourcepathProvider;
-		private LaunchConfigurationInfo launchInfo;
-
-		protected JavaApplicationLaunchConfiguration(IProject project, boolean excludeTestCode) throws CoreException {
-			super(String.valueOf(new Date().getTime()), null, false);
-			this.project = project;
-			this.excludeTestCode = excludeTestCode;
-			if (ProjectUtils.isMavenProject(project)) {
-				classpathProvider = MavenRuntimeClasspathProvider.MAVEN_CLASSPATH_PROVIDER;
-				sourcepathProvider = MavenRuntimeClasspathProvider.MAVEN_SOURCEPATH_PROVIDER;
-			} else if (ProjectUtils.isGradleProject(project)) {
-				classpathProvider = GradleClasspathProvider.ID;
-			}
-			// Since MavenRuntimeClasspathProvider will only encluding test entries when:
-			// 1. Launch configuration is JUnit/TestNG type
-			// 2. Mapped resource is in test path.
-			// That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
-			// See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
-			this.launchInfo = new JavaLaunchConfigurationInfo(String.format(JAVA_APPLICATION_LAUNCH, excludeTestCode ? 
-					MavenRuntimeClasspathProvider.JDT_JAVA_APPLICATION : MavenRuntimeClasspathProvider.JDT_JUNIT_TEST));
-		}
-
-		@Override
-		public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
-			if (IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE.equalsIgnoreCase(attributeName)) {
-				return excludeTestCode;
-			}
-
-			return super.getAttribute(attributeName, defaultValue);
-		}
-
-		@Override
-		public String getAttribute(String attributeName, String defaultValue) throws CoreException {
-			if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equalsIgnoreCase(attributeName)) {
-				return project.getName();
-			} else if (IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER.equalsIgnoreCase(attributeName)) {
-				return classpathProvider;
-			} else if (IJavaLaunchConfigurationConstants.ATTR_SOURCE_PATH_PROVIDER.equalsIgnoreCase(attributeName)) {
-				return sourcepathProvider;
-			}
-
-			return super.getAttribute(attributeName, defaultValue);
-		}
-
-		@Override
-		protected LaunchConfigurationInfo getInfo() throws CoreException {
-			return this.launchInfo;
-		}
-	}
-
-	private static class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
-		public JavaLaunchConfigurationInfo(String launchXml) {
-			super();
-			try {
-				DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-				parser.setErrorHandler(new DefaultHandler());
-				StringReader reader = new StringReader(launchXml);
-				InputSource source = new InputSource(reader);
-				Element root = parser.parse(source).getDocumentElement();
-				initializeFromXML(root);
-			} catch (ParserConfigurationException | SAXException | IOException | CoreException e) {
-				// do nothing
-			}
-		}
-	}
 
 	public static class ClasspathOptions {
-		public boolean excludingTests;
+		public String scope;
 	}
 
 	public static class ClasspathResult {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -15,6 +15,8 @@ package org.eclipse.jdt.ls.core.internal.commands;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -27,18 +29,26 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.internal.core.LaunchConfiguration;
 import org.eclipse.debug.internal.core.LaunchConfigurationInfo;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 import org.eclipse.jdt.launching.JavaLaunchDelegate;
 import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.m2e.jdt.IClasspathManager;
 import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
@@ -47,130 +57,215 @@ import org.xml.sax.helpers.DefaultHandler;
 
 public class ProjectCommand {
 
-    /**
-     * Get the project settings.
-     * @param uri Uri of the source/class file needs to be queried.
-     * @param settingKeys the settings want to query, for example: ["org.eclipse.jdt.core.compiler.compliance"]
-     * @return A Map<string, string> with all the setting keys and their values.
-     * @throws CoreException
-     */
-    public static Map<String, String> getProjectSettings(String uri, List<String> settingKeys) throws CoreException {
-        IJavaProject javaProject = getJavaProjectFromUri(uri);
-        Map<String, String> settings = new HashMap<>();
-        for (String key : settingKeys) {
-            settings.putIfAbsent(key, javaProject.getOption(key, true));
-        }
-        return settings;
-    }
+	private static final String TEST_SCOPE_VALUE = "test";
+	private static final String GRADLE_SCOPE_ATTRIBUTE = "gradle_scope";
+	private static final String GRADLE_USED_BY_SCOPE_ATTRIBUTE = "gradle_used_by_scope";
 
-    public static ClasspathResult getClasspaths(String uri, ClasspathOptions options) throws CoreException {
-        IJavaProject javaProject = getJavaProjectFromUri(uri);
-        ILaunchConfiguration launchConfig = new JavaApplicationLaunchConfiguration(javaProject.getProject(), options.excludingTests);
-        JavaLaunchDelegate delegate = new JavaLaunchDelegate();
-        String[][] paths = delegate.getClasspathAndModulepath(launchConfig);
-        return new ClasspathResult(paths[0], paths[1]);
-    }
+	/**
+	 * Gets the project settings.
+	 * 
+	 * @param uri
+	 *                        Uri of the source/class file that needs to be queried.
+	 * @param settingKeys
+	 *                        the settings we want to query, for example:
+	 *                        ["org.eclipse.jdt.core.compiler.compliance",
+	 *                        "org.eclipse.jdt.core.compiler.source"]
+	 * @return A <code>Map<string, string></code> with all the setting keys and
+	 *         their values.
+	 * @throws CoreException
+	 */
+	public static Map<String, String> getProjectSettings(String uri, List<String> settingKeys) throws CoreException {
+		IJavaProject javaProject = getJavaProjectFromUri(uri);
+		Map<String, String> settings = new HashMap<>();
+		for (String key : settingKeys) {
+			settings.putIfAbsent(key, javaProject.getOption(key, true));
+		}
+		return settings;
+	}
 
-    private static IJavaProject getJavaProjectFromUri(String uri) throws CoreException {
-        ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(uri);
-        if (typeRoot == null) {
-            throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing TypeRoot"));
-        }
-        IJavaProject javaProject = typeRoot.getJavaProject();
-        if (javaProject == null) {
-            throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing Java project"));
-        }
-        return javaProject;
-    }
-    
-    private static class JavaApplicationLaunchConfiguration extends LaunchConfiguration {
-        public static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<launchConfiguration type=\"%s\">\n"
-                + "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
-                + "</listAttribute>\n"
-                + "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
-                + "</listAttribute>\n"
-                + "</launchConfiguration>";
-        private IProject project;
-        private boolean excludeTestCode;
-        private String classpathProvider;
-        private String sourcepathProvider;
-        private LaunchConfigurationInfo launchInfo;
+	/**
+	 * Gets the classpaths and modulepaths.
+	 * 
+	 * @param uri
+	 *                    Uri of the source/class file that needs to be queried.
+	 * @param options
+	 *                    Query options.
+	 * @return <code>ClasspathResult</code> containing both classpaths and
+	 *         modulepaths.
+	 * @throws CoreException
+	 */
+	public static ClasspathResult getClasspaths(String uri, ClasspathOptions options) throws CoreException {
+		IJavaProject javaProject = getJavaProjectFromUri(uri);
+		ILaunchConfiguration launchConfig = new JavaApplicationLaunchConfiguration(javaProject.getProject(), options.excludingTests);
+		JavaLaunchDelegate delegate = new JavaLaunchDelegate();
+		String[][] paths = delegate.getClasspathAndModulepath(launchConfig);
+		return new ClasspathResult(javaProject.getProject().getLocationURI(), paths[0], paths[1]);
+	}
 
-        protected JavaApplicationLaunchConfiguration(IProject project, boolean excludeTestCode) throws CoreException {
-            super(String.valueOf(new Date().getTime()), null, false);
-            this.project = project;
-            this.excludeTestCode = excludeTestCode;
-            if (ProjectUtils.isMavenProject(project)) {
-                classpathProvider = MavenRuntimeClasspathProvider.MAVEN_CLASSPATH_PROVIDER;
-                sourcepathProvider = MavenRuntimeClasspathProvider.MAVEN_SOURCEPATH_PROVIDER;
-            } else if (ProjectUtils.isGradleProject(project)) {
-                classpathProvider = GradleClasspathProvider.ID;
-            }
-            // Since MavenRuntimeClasspathProvider will only encluding test entries when:
-            // 1. Launch configuration is JUnit/TestNG type
-            // 2. Mapped resource is in test path.
-            // That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
-            // See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
-            this.launchInfo = new JavaLaunchConfigurationInfo(String.format(JAVA_APPLICATION_LAUNCH, excludeTestCode ? 
-                    MavenRuntimeClasspathProvider.JDT_JAVA_APPLICATION : MavenRuntimeClasspathProvider.JDT_JUNIT_TEST));
-        }
+	/**
+	 * Checks if the input uri is a test source file or not.
+	 * 
+	 * @param uri
+	 *                Uri of the source file that needs to be queried.
+	 * @return <code>true</code> if the input uri is a test file in its belonging
+	 *         project, otherwise returns <code>false</code>.
+	 * @throws CoreException
+	 */
+	public static boolean isTestFile(String uri) throws CoreException {
+		ICompilationUnit compilationUnit = JDTUtils.resolveCompilationUnit(uri);
+		if (compilationUnit == null) {
+			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing Java source file."));
+		}
+		IJavaProject javaProject = compilationUnit.getJavaProject();
+		if (javaProject == null) {
+			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing Java project."));
+		}
+		// Ignore default project
+		if (ProjectsManager.DEFAULT_PROJECT_NAME.equals(javaProject.getProject().getName())) {
+			return false;
+		}
+		final IPath compilationUnitPath = compilationUnit.getPath();
+		for (IPath testpath : listTestSourcePaths(javaProject)) {
+			if (testpath.isPrefixOf(compilationUnitPath)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-        @Override
-        public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
-            if (IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE.equalsIgnoreCase(attributeName)) {
-                return excludeTestCode;
-            }
+	private static IPath[] listTestSourcePaths(IJavaProject project) throws JavaModelException {
+		List<IPath> result = new ArrayList<>();
+		for (IClasspathEntry entry : project.getRawClasspath()) {
+			if (isTestClasspathEntry(entry)) {
+				result.add(entry.getPath());
+			}
+		}
+		return result.toArray(new IPath[0]);
+	}
 
-            return super.getAttribute(attributeName, defaultValue);
-        }
+	private static boolean isTestClasspathEntry(IClasspathEntry entry) {
+		if (entry.getEntryKind() != ClasspathEntry.CPE_SOURCE) {
+			return false;
+		}
 
-        @Override
-        public String getAttribute(String attributeName, String defaultValue) throws CoreException {
-            if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equalsIgnoreCase(attributeName)) {
-                return project.getName();
-            } else if (IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER.equalsIgnoreCase(attributeName)) {
-                return classpathProvider;
-            } else if (IJavaLaunchConfigurationConstants.ATTR_SOURCE_PATH_PROVIDER.equalsIgnoreCase(attributeName)) {
-                return sourcepathProvider;
-            }
+		if (entry.isTest()) {
+			return true;
+		}
 
-            return super.getAttribute(attributeName, defaultValue);
-        }
+		for (final IClasspathAttribute attribute : entry.getExtraAttributes()) {
+			String attributeName = attribute.getName();
+			if (IClasspathManager.SCOPE_ATTRIBUTE.equals(attributeName) ||
+					GRADLE_SCOPE_ATTRIBUTE.equals(attributeName) || GRADLE_USED_BY_SCOPE_ATTRIBUTE.equals(attributeName)) {
+				// the attribute value might be "test" or "integrationTest"
+				return attribute.getValue() != null && attribute.getValue().toLowerCase().contains(TEST_SCOPE_VALUE);
+			}
+		}
 
-        @Override
-        protected LaunchConfigurationInfo getInfo() throws CoreException {
-            return this.launchInfo;
-        }
-    }
+		return false;
+	}
 
-    private static class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
-        public JavaLaunchConfigurationInfo(String launchXml) {
-            super();
-            try {
-                DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-                parser.setErrorHandler(new DefaultHandler());
-                StringReader reader = new StringReader(launchXml);
-                InputSource source = new InputSource(reader);
-                Element root = parser.parse(source).getDocumentElement();
-                initializeFromXML(root);
-            } catch (ParserConfigurationException | SAXException | IOException | CoreException e) {
-                // do nothing
-            }
-        }
-    }
+	private static IJavaProject getJavaProjectFromUri(String uri) throws CoreException {
+		ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(uri);
+		if (typeRoot == null) {
+			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing TypeRoot."));
+		}
+		IJavaProject javaProject = typeRoot.getJavaProject();
+		if (javaProject == null) {
+			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "Given URI does not belong to an existing Java project."));
+		}
+		return javaProject;
+	}
+	
+	private static class JavaApplicationLaunchConfiguration extends LaunchConfiguration {
+		public static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+				+ "<launchConfiguration type=\"%s\">\n"
+				+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
+				+ "</listAttribute>\n"
+				+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
+				+ "</listAttribute>\n"
+				+ "</launchConfiguration>";
+		private IProject project;
+		private boolean excludeTestCode;
+		private String classpathProvider;
+		private String sourcepathProvider;
+		private LaunchConfigurationInfo launchInfo;
 
-    public static class ClasspathOptions {
-        public boolean excludingTests;
-    }
+		protected JavaApplicationLaunchConfiguration(IProject project, boolean excludeTestCode) throws CoreException {
+			super(String.valueOf(new Date().getTime()), null, false);
+			this.project = project;
+			this.excludeTestCode = excludeTestCode;
+			if (ProjectUtils.isMavenProject(project)) {
+				classpathProvider = MavenRuntimeClasspathProvider.MAVEN_CLASSPATH_PROVIDER;
+				sourcepathProvider = MavenRuntimeClasspathProvider.MAVEN_SOURCEPATH_PROVIDER;
+			} else if (ProjectUtils.isGradleProject(project)) {
+				classpathProvider = GradleClasspathProvider.ID;
+			}
+			// Since MavenRuntimeClasspathProvider will only encluding test entries when:
+			// 1. Launch configuration is JUnit/TestNG type
+			// 2. Mapped resource is in test path.
+			// That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
+			// See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
+			this.launchInfo = new JavaLaunchConfigurationInfo(String.format(JAVA_APPLICATION_LAUNCH, excludeTestCode ? 
+					MavenRuntimeClasspathProvider.JDT_JAVA_APPLICATION : MavenRuntimeClasspathProvider.JDT_JUNIT_TEST));
+		}
 
-    static class ClasspathResult {
-        String[] classpaths;
-        String[] modulepaths;
+		@Override
+		public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
+			if (IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE.equalsIgnoreCase(attributeName)) {
+				return excludeTestCode;
+			}
 
-        public ClasspathResult(String[] classpaths, String[] modulepaths) {
-            this.classpaths = classpaths;
-            this.modulepaths = modulepaths;
-        }
-    }
+			return super.getAttribute(attributeName, defaultValue);
+		}
+
+		@Override
+		public String getAttribute(String attributeName, String defaultValue) throws CoreException {
+			if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equalsIgnoreCase(attributeName)) {
+				return project.getName();
+			} else if (IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER.equalsIgnoreCase(attributeName)) {
+				return classpathProvider;
+			} else if (IJavaLaunchConfigurationConstants.ATTR_SOURCE_PATH_PROVIDER.equalsIgnoreCase(attributeName)) {
+				return sourcepathProvider;
+			}
+
+			return super.getAttribute(attributeName, defaultValue);
+		}
+
+		@Override
+		protected LaunchConfigurationInfo getInfo() throws CoreException {
+			return this.launchInfo;
+		}
+	}
+
+	private static class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
+		public JavaLaunchConfigurationInfo(String launchXml) {
+			super();
+			try {
+				DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				parser.setErrorHandler(new DefaultHandler());
+				StringReader reader = new StringReader(launchXml);
+				InputSource source = new InputSource(reader);
+				Element root = parser.parse(source).getDocumentElement();
+				initializeFromXML(root);
+			} catch (ParserConfigurationException | SAXException | IOException | CoreException e) {
+				// do nothing
+			}
+		}
+	}
+
+	public static class ClasspathOptions {
+		public boolean excludingTests;
+	}
+
+	static class ClasspathResult {
+		URI projectRoot;
+		String[] classpaths;
+		String[] modulepaths;
+
+		public ClasspathResult(URI projectRoot, String[] classpaths, String[] modulepaths) {
+			this.projectRoot = projectRoot;
+			this.classpaths = classpaths;
+			this.modulepaths = modulepaths;
+		}
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -257,10 +257,10 @@ public class ProjectCommand {
 		public boolean excludingTests;
 	}
 
-	static class ClasspathResult {
-		URI projectRoot;
-		String[] classpaths;
-		String[] modulepaths;
+	public static class ClasspathResult {
+		public URI projectRoot;
+		public String[] classpaths;
+		public String[] modulepaths;
 
 		public ClasspathResult(URI projectRoot, String[] classpaths, String[] modulepaths) {
 			this.projectRoot = projectRoot;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -38,13 +38,10 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.managers.IBuildSupport;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
-import org.eclipse.m2e.jdt.IClasspathManager;
 
 public class ProjectCommand {
 
 	private static final String TEST_SCOPE_VALUE = "test";
-	private static final String GRADLE_SCOPE_ATTRIBUTE = "gradle_scope";
-	private static final String GRADLE_USED_BY_SCOPE_ATTRIBUTE = "gradle_used_by_scope";
 
 	/**
 	 * Gets the project settings.
@@ -143,10 +140,10 @@ public class ProjectCommand {
 
 		for (final IClasspathAttribute attribute : entry.getExtraAttributes()) {
 			String attributeName = attribute.getName();
-			if (IClasspathManager.SCOPE_ATTRIBUTE.equals(attributeName) ||
-					GRADLE_SCOPE_ATTRIBUTE.equals(attributeName) || GRADLE_USED_BY_SCOPE_ATTRIBUTE.equals(attributeName)) {
-				// the attribute value might be "test" or "integrationTest"
-				return attribute.getValue() != null && attribute.getValue().toLowerCase().contains(TEST_SCOPE_VALUE);
+			// attribute name could be "maven.scope" for Maven, "gradle_scope" or "gradle_used_by_scope" for Gradle
+			if (attributeName.contains("scope")) {
+				// the attribute value could be "test" or "integrationTest"
+				return attribute.getValue() != null && attribute.getValue().toLowerCase().contains(TEST_SCOPE_VALUE); 
 			}
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandler.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.jdt.core.ElementChangedEvent;
+import org.eclipse.jdt.core.IElementChangedListener;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaElementDelta;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.ActionableNotification;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.lsp4j.MessageType;
+
+public class ClasspathUpdateHandler implements IElementChangedListener {
+
+	private static final String CLASSPATH_UPDATED_NOTIFICATION = "__CLASSPATH_UPDATED__";
+
+	private final JavaClientConnection connetction;
+	
+	public ClasspathUpdateHandler(JavaClientConnection client) {
+		this.connetction = client;
+	}
+
+	@Override
+	public void elementChanged(ElementChangedEvent event) {
+		// Collect project names which have classpath changed.
+		Set<String> uris = processDelta(event.getDelta(), null);
+		if (connetction != null && uris != null && !uris.isEmpty()) {
+			for (String uri : uris) {
+				ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Log).withMessage(CLASSPATH_UPDATED_NOTIFICATION).withData(uri);
+				this.connetction.sendActionableNotification(notification);
+			}
+		}
+	}
+
+	public void addElementChangeListener() {
+		JavaCore.addElementChangedListener(this);
+	}
+
+	public void removeElementChangeListener() {
+		JavaCore.removeElementChangedListener(this);
+	}
+
+	private Set<String> processDeltaChildren(IJavaElementDelta delta, Set<String> uris) {
+		for (IJavaElementDelta c : delta.getAffectedChildren()) {
+			uris = processDelta(c, uris);
+		}
+		return uris;
+	}
+
+	private Set<String> processDelta(IJavaElementDelta delta, Set<String> uris) {
+		IJavaElement element = delta.getElement();
+		switch (element.getElementType()) {
+		case IJavaElement.JAVA_MODEL:
+			uris = processDeltaChildren(delta, uris);
+			break;
+		case IJavaElement.JAVA_PROJECT:
+			if (isClasspathChanged(delta.getFlags())) {
+				if (uris == null) {
+					uris = new HashSet<String>();
+				}
+				IJavaProject javaProject = (IJavaProject) element;
+				uris.add(javaProject.getProject().getLocation().toOSString());
+			}
+			break;
+		default:
+			break;
+		}
+		return uris;
+	}
+
+	private boolean isClasspathChanged(int flags) {
+		return 0 != (flags & (IJavaElementDelta.F_CLASSPATH_CHANGED | IJavaElementDelta.F_RESOLVED_CLASSPATH_CHANGED
+				| IJavaElementDelta.F_CLOSED | IJavaElementDelta.F_OPENED));
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -216,11 +216,11 @@ public class JDTLanguageServer implements LanguageServer, TextDocumentService, W
 	@Override
 	public void initialized(InitializedParams params) {
 		logInfo(">> initialized");
-				try {
-					Job.getJobManager().join(InitHandler.JAVA_LS_INITIALIZATION_JOBS, null);
-				} catch (OperationCanceledException | InterruptedException e) {
-					logException(e.getMessage(), e);
-				}
+		try {
+			Job.getJobManager().join(InitHandler.JAVA_LS_INITIALIZATION_JOBS, null);
+		} catch (OperationCanceledException | InterruptedException e) {
+			logException(e.getMessage(), e);
+		}
 		logInfo(">> initialization job finished");
 		if (preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
 			registerCapability(Preferences.COMPLETION_ID, Preferences.COMPLETION, CompletionHandler.DEFAULT_COMPLETION_OPTIONS);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2019 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.eclipse.buildship.core.GradleBuild;
 import org.eclipse.buildship.core.GradleCore;
 import org.eclipse.buildship.core.internal.CorePlugin;
+import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
 import org.eclipse.buildship.core.internal.preferences.PersistentModel;
 import org.eclipse.buildship.core.internal.util.file.FileUtils;
 import org.eclipse.buildship.core.internal.workspace.WorkbenchShutdownEvent;
@@ -32,6 +33,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
@@ -129,5 +131,10 @@ public class GradleBuildSupport implements IBuildSupport {
 			}
 		}
 		return uriList.toArray(new URI[0]);
+	}
+
+	@Override
+	public ILaunchConfiguration getLaunchConfiguration(IJavaProject javaProject, String scope) throws CoreException {
+		return new JavaApplicationLaunchConfiguration(javaProject.getProject(), scope, GradleClasspathProvider.ID);
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -13,20 +13,14 @@
 package org.eclipse.jdt.ls.core.internal.managers;
 
 import java.io.File;
-import java.net.URI;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.buildship.core.GradleBuild;
 import org.eclipse.buildship.core.GradleCore;
 import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
-import org.eclipse.buildship.core.internal.preferences.PersistentModel;
 import org.eclipse.buildship.core.internal.util.file.FileUtils;
 import org.eclipse.buildship.core.internal.workspace.WorkbenchShutdownEvent;
-import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -117,20 +111,6 @@ public class GradleBuildSupport implements IBuildSupport {
 	 */
 	public static void saveModels() {
 		CorePlugin.listenerRegistry().dispatch(new WorkbenchShutdownEvent());
-	}
-
-	@Override
-	public URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
-		Set<URI> uriList = new LinkedHashSet<>();
-		uriList.add(project.getLocationURI());
-		PersistentModel model = CorePlugin.modelPersistence().loadModel(project);
-		if (model.isPresent()) {
-			Collection<IPath> subpaths = model.getSubprojectPaths();
-			for (IPath path : subpaths) {
-				uriList.add(URIUtil.toURI(project.getLocation().append(path)));
-			}
-		}
-		return uriList.toArray(new URI[0]);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2019 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -114,6 +115,10 @@ public interface IBuildSupport {
 	 */
 	default URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
 		return new URI[]{project.getLocationURI()};
+	}
+
+	default ILaunchConfiguration getLaunchConfiguration(IJavaProject javaProject, String scope) throws CoreException {
+		return new JavaApplicationLaunchConfiguration(javaProject.getProject(), scope, "");
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -118,7 +118,7 @@ public interface IBuildSupport {
 	}
 
 	default ILaunchConfiguration getLaunchConfiguration(IJavaProject javaProject, String scope) throws CoreException {
-		return new JavaApplicationLaunchConfiguration(javaProject.getProject(), scope, "");
+		return new JavaApplicationLaunchConfiguration(javaProject.getProject(), scope, null);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import java.net.URI;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -98,6 +100,20 @@ public interface IBuildSupport {
 	 * @throws CoreException
 	 */
 	default void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+	}
+
+	/**
+	 * Discover all the sub-projects of the input project and return them all.
+	 * 
+	 * @param project
+	 *                    - a parent project
+	 * 
+	 * @param monitor
+	 *                    - a progress monitor
+	 * @return array of the parent project and its sub-projects
+	 */
+	default URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
+		return new URI[]{project.getLocationURI()};
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
-import java.net.URI;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
@@ -101,20 +99,6 @@ public interface IBuildSupport {
 	 * @throws CoreException
 	 */
 	default void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
-	}
-
-	/**
-	 * Discover all the sub-projects of the input project and return them all.
-	 * 
-	 * @param project
-	 *                    - a parent project
-	 * 
-	 * @param monitor
-	 *                    - a progress monitor
-	 * @return array of the parent project and its sub-projects
-	 */
-	default URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
-		return new URI[]{project.getLocationURI()};
 	}
 
 	default ILaunchConfiguration getLaunchConfiguration(IJavaProject javaProject, String scope) throws CoreException {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaApplicationLaunchConfiguration.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaApplicationLaunchConfiguration.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.util.Date;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.internal.core.LaunchConfiguration;
+import org.eclipse.debug.internal.core.LaunchConfigurationInfo;
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+/**
+ * JavaApplicationLaunchConfiguration
+ */
+public class JavaApplicationLaunchConfiguration extends LaunchConfiguration {
+
+	private IProject project;
+	private String scope;
+	private String classpathProvider;
+	private LaunchConfigurationInfo launchInfo;
+
+	protected JavaApplicationLaunchConfiguration(IProject project, String scope, String classpathProvider) throws CoreException {
+		super(String.valueOf(new Date().getTime()), null, false);
+		this.project = project;
+		this.scope = scope;
+		this.classpathProvider = classpathProvider;
+		this.launchInfo = new JavaLaunchConfigurationInfo(scope);
+	}
+
+	@Override
+	public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
+		if (IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE.equalsIgnoreCase(attributeName)) {
+			return !"test".equals(this.scope);
+		}
+
+		return super.getAttribute(attributeName, defaultValue);
+	}
+
+	@Override
+	public String getAttribute(String attributeName, String defaultValue) throws CoreException {
+		if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equalsIgnoreCase(attributeName)) {
+			return project.getName();
+		} else if (IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER.equalsIgnoreCase(attributeName)) {
+			return this.classpathProvider;
+		}
+
+		return super.getAttribute(attributeName, defaultValue);
+	}
+
+	@Override
+	protected LaunchConfigurationInfo getInfo() throws CoreException {
+		return this.launchInfo;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaLaunchConfigurationInfo.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaLaunchConfigurationInfo.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.debug.internal.core.LaunchConfigurationInfo;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * JavaLaunchConfigurationInfo
+ */
+public class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
+
+	private static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+		+ "<launchConfiguration type=\"%s\">\n"
+		+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
+		+ "</listAttribute>\n"
+		+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
+		+ "</listAttribute>\n"
+		+ "</launchConfiguration>";
+			
+	public JavaLaunchConfigurationInfo(String scope) {
+		super();
+
+		// Since MavenRuntimeClasspathProvider will only encluding test entries when:
+		// 1. Launch configuration is JUnit/TestNG type
+		// 2. Mapped resource is in test path.
+		// That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
+		// See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
+		String launchXml = null;
+		if ("test".equals(scope)) {
+			launchXml = String.format(JAVA_APPLICATION_LAUNCH, "org.eclipse.jdt.junit.launchconfig");
+		} else {
+			launchXml = String.format(JAVA_APPLICATION_LAUNCH, "org.eclipse.jdt.launching.localJavaApplication");
+		}
+		try {
+			DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+			parser.setErrorHandler(new DefaultHandler());
+			StringReader reader = new StringReader(launchXml);
+			InputSource source = new InputSource(reader);
+			Element root = parser.parse(source).getDocumentElement();
+			initializeFromXML(root);
+		} catch (ParserConfigurationException | SAXException | IOException | CoreException e) {
+			// do nothing
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2019 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -175,19 +174,6 @@ public class MavenBuildSupport implements IBuildSupport {
 				}
 			}
 		}
-	}
-
-	@Override
-	public URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
-		Set<IProject> projectSet = new LinkedHashSet<>();
-		if (shouldCollectProjects()) {
-			collectProjects(projectSet, project, monitor);
-		} else {
-			projectSet.add(project);
-		}
-		return projectSet.stream().map((p) -> {
-			return p.getLocationURI();
-		}).toArray(URI[]::new);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -171,6 +172,19 @@ public class MavenBuildSupport implements IBuildSupport {
 				}
 			}
 		}
+	}
+
+	@Override
+	public URI[] getAllContainingProjects(IProject project, IProgressMonitor monitor) {
+		Set<IProject> projectSet = new LinkedHashSet<>();
+		if (shouldCollectProjects()) {
+			collectProjects(projectSet, project, monitor);
+		} else {
+			projectSet.add(project);
+		}
+		return projectSet.stream().map((p) -> {
+			return p.getLocationURI();
+		}).toArray(URI[]::new);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -27,8 +27,10 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
@@ -44,6 +46,7 @@ import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
 import org.eclipse.m2e.jdt.IClasspathManager;
 import org.eclipse.m2e.jdt.MavenJdtPlugin;
+import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -187,4 +190,8 @@ public class MavenBuildSupport implements IBuildSupport {
 		}).toArray(URI[]::new);
 	}
 
+	@Override
+	public ILaunchConfiguration getLaunchConfiguration(IJavaProject javaProject, String scope) throws CoreException {
+		return new JavaApplicationLaunchConfiguration(javaProject.getProject(), scope, MavenRuntimeClasspathProvider.MAVEN_CLASSPATH_PROVIDER);
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -769,4 +769,5 @@ public class ProjectsManager implements ISaveParticipant {
 		}
 		return null;
 	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -37,7 +37,6 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.buildship.core.internal.preferences.PersistentModel;
@@ -100,7 +99,6 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 public class ProjectsManager implements ISaveParticipant {
 
 	public static final String DEFAULT_PROJECT_NAME = "jdt.ls-java-project";
-	private static final String CLASSPATH_UPDATED_NOTIFICATION = "__CLASSPATH_UPDATED__";
 	private static final Set<String> watchers = new LinkedHashSet<>();
 	private PreferenceManager preferenceManager;
 	private JavaLanguageClient client;
@@ -534,21 +532,13 @@ public class ProjectsManager implements ISaveParticipant {
 				try {
 					long start = System.currentTimeMillis();
 					project.refreshLocal(IResource.DEPTH_INFINITE, progress.split(5));
-					URI[] impactedProjectsURIs = null;
 					Optional<IBuildSupport> buildSupport = getBuildSupport(project);
 					if (buildSupport.isPresent()) {
 						buildSupport.get().update(project, force, progress.split(95));
 						registerWatcherJob.schedule();
-						impactedProjectsURIs = buildSupport.get().getAllContainingProjects(project, monitor);
 					}
 					long elapsed = System.currentTimeMillis() - start;
 					JavaLanguageServerPlugin.logInfo("Updated " + projectName + " in " + elapsed + " ms");
-					if (client != null && ArrayUtils.isNotEmpty(impactedProjectsURIs)) {
-						for (URI uri : impactedProjectsURIs) {
-							ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Log).withMessage(CLASSPATH_UPDATED_NOTIFICATION).withData(uri.toString());
-							client.sendActionableNotification(notification);
-						}
-					}
 				} catch (CoreException e) {
 					String msg = "Error updating " + projectName;
 					JavaLanguageServerPlugin.logError(msg);
@@ -779,5 +769,4 @@ public class ProjectsManager implements ISaveParticipant {
 		}
 		return null;
 	}
-
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -99,6 +99,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 public class ProjectsManager implements ISaveParticipant {
 
 	public static final String DEFAULT_PROJECT_NAME = "jdt.ls-java-project";
+	private static final String CLASSPATH_UPDATED_NOTIFICATION = "__CLASSPATH_UPDATED__";
 	private static final Set<String> watchers = new LinkedHashSet<>();
 	private PreferenceManager preferenceManager;
 	private JavaLanguageClient client;
@@ -539,6 +540,10 @@ public class ProjectsManager implements ISaveParticipant {
 					}
 					long elapsed = System.currentTimeMillis() - start;
 					JavaLanguageServerPlugin.logInfo("Updated " + projectName + " in " + elapsed + " ms");
+					if (client != null) {
+						ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Log).withMessage(CLASSPATH_UPDATED_NOTIFICATION).withData(project.getLocationURI().toString());
+						client.sendActionableNotification(notification);
+					}
 				} catch (CoreException e) {
 					String msg = "Error updating " + projectName;
 					JavaLanguageServerPlugin.logError(msg);

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/build.gradle
@@ -1,0 +1,27 @@
+allprojects {
+	version = "1.0"
+}
+
+subprojects {
+	apply plugin: 'java'
+	apply plugin: 'maven'
+	
+	sourceCompatibility = 1.8 // java 8
+	targetCompatibility = 1.8
+	
+	task sourcesJar(type: Jar, dependsOn: classes) {
+	    classifier = 'sources'
+	    from sourceSets.main.allSource
+	}
+	
+	task javadocJar(type: Jar, dependsOn: javadoc) {
+	    classifier = 'javadoc'
+	    from javadoc.destinationDir
+	}
+	
+	artifacts {
+	    archives sourcesJar
+	    archives javadocJar
+	}
+}
+

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/build.gradle
@@ -9,19 +9,5 @@ subprojects {
 	sourceCompatibility = 1.8 // java 8
 	targetCompatibility = 1.8
 	
-	task sourcesJar(type: Jar, dependsOn: classes) {
-	    classifier = 'sources'
-	    from sourceSets.main.allSource
-	}
-	
-	task javadocJar(type: Jar, dependsOn: javadoc) {
-	    classifier = 'javadoc'
-	    from javadoc.destinationDir
-	}
-	
-	artifacts {
-	    archives sourcesJar
-	    archives javadocJar
-	}
 }
 

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/client/src/main/java/Client.java
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/client/src/main/java/Client.java
@@ -1,0 +1,7 @@
+
+public class Client {
+  
+  public static String GREETING = "Hello World";
+  
+}
+

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/server/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/server/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+  compile project(path: ':client')
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/server/src/main/java/Server.java
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/server/src/main/java/Server.java
@@ -1,0 +1,2 @@
+public class Server {
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/settings.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/multi-module/settings.gradle
@@ -1,0 +1,2 @@
+include 'client'
+include 'server'

--- a/org.eclipse.jdt.ls.tests/projects/maven/modular-project/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/modular-project/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.modular.test</groupId>
+    <artifactId>modular-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/modular-project/src/main/java/modular/Main.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/modular-project/src/main/java/modular/Main.java
@@ -1,0 +1,7 @@
+package modular;
+
+public class Main {
+
+    public static void main(String[] args) {
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/modular-project/src/main/java/module-info.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/modular-project/src/main/java/module-info.java
@@ -1,0 +1,2 @@
+module modular {
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -112,6 +112,23 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
     }
 
     @Test
+    public void testGetClasspathsForEclipse() throws Exception {
+        importProjects("eclipse/hello");
+        IProject project = WorkspaceHelper.getProject("hello");
+        String uriString = project.getFile("src/java/Bar.java").getLocationURI().toString();
+        ClasspathOptions options = new ClasspathOptions();
+        options.scope = "runtime";
+        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(1, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
+
+        options.scope = "test";
+        result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(2, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
+    }
+
+    @Test
     public void testIsTestFileForMaven() throws Exception {
         importProjects("maven/classpathtest");
         IProject project = WorkspaceHelper.getProject("classpathtest");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.Test;
+
+/**
+ * ProjectCommandTest
+ */
+public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
+
+    @Test
+    public void testGetProjectSettingsForMavenJava7() throws Exception {
+        importProjects("maven/salut");
+        IProject project = WorkspaceHelper.getProject("salut");
+        String uriString = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
+        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+
+        assertEquals(options.size(), settingKeys.size());
+        assertEquals(options.get("org.eclipse.jdt.core.compiler.compliance"), "1.7");
+        assertEquals(options.get("org.eclipse.jdt.core.compiler.source"), "1.7");
+    }
+
+    @Test
+    public void testGetProjectSettingsForMavenJava8() throws Exception {
+        importProjects("maven/salut2");
+        IProject project = WorkspaceHelper.getProject("salut2");
+        String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
+        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+
+        assertEquals(options.size(), settingKeys.size());
+        assertEquals(options.get("org.eclipse.jdt.core.compiler.compliance"), "1.8");
+        assertEquals(options.get("org.eclipse.jdt.core.compiler.source"), "1.8");
+    }
+
+    @Test
+    public void testGetClasspathsForMaven() throws Exception {
+        importProjects("maven/classpathtest");
+        IProject project = WorkspaceHelper.getProject("classpathtest");
+        String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+        ClasspathOptions options = new ClasspathOptions();
+        options.excludingTests = true;
+        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(result.classpaths.length, 1);
+        assertEquals(result.modulepaths.length, 0);
+        assertTrue(result.classpaths[0].indexOf("junit") == -1);
+
+        options.excludingTests = false;
+        result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(result.classpaths.length, 4);
+        assertEquals(result.modulepaths.length, 0);
+        boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+            return element.indexOf("junit") > -1;
+        });
+        assertTrue(containsJunit);
+    }
+
+    @Test
+    public void testGetClasspathsForGradle() throws Exception {
+        importProjects("gradle/simple-gradle");
+        IProject project = WorkspaceHelper.getProject("simple-gradle");
+        String uriString = project.getFile("src/main/java/Library.java").getLocationURI().toString();
+        ClasspathOptions options = new ClasspathOptions();
+        // Gradle project will always return classpath containing test dependencies.
+        // So we only test `excludingTests = false` scenario.
+        options.excludingTests = false;
+        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(result.classpaths.length, 5);
+        assertEquals(result.modulepaths.length, 0);
+        boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+            return element.indexOf("junit") > -1;
+        });
+        assertTrue(containsJunit);
+    }
+
+    @Test
+    public void testGetClasspathsForMavenModular() throws Exception {
+        importProjects("maven/modular-project");
+        IProject project = WorkspaceHelper.getProject("modular-project");
+        String uriString = project.getFile("src/main/java/modular/Main.java").getLocationURI().toString();
+        ClasspathOptions options = new ClasspathOptions();
+        options.excludingTests = false;
+        ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(result.classpaths.length, 0);
+        assertEquals(result.modulepaths.length, 1);
+    }
+
+    @Test
+    public void testIsTestFileForMaven() throws Exception {
+        importProjects("maven/classpathtest");
+        IProject project = WorkspaceHelper.getProject("classpathtest");
+        String srcUri = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+        String testUri = project.getFile("src/test/java/test/AppTest.java").getLocationURI().toString();
+        assertFalse(ProjectCommand.isTestFile(srcUri));
+        assertTrue(ProjectCommand.isTestFile(testUri));
+    }
+
+    @Test
+    public void testIsTestFileForGradle() throws Exception {
+        importProjects("gradle/simple-gradle");
+        IProject project = WorkspaceHelper.getProject("simple-gradle");
+        String srcUri = project.getFile("src/main/java/Library.java").getLocationURI().toString();
+        String testUri = project.getFile("src/test/java/LibraryTest.java").getLocationURI().toString();
+        assertFalse(ProjectCommand.isTestFile(srcUri));
+        assertTrue(ProjectCommand.isTestFile(testUri));
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -41,9 +41,9 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
         List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
         Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
-        assertEquals(options.size(), settingKeys.size());
-        assertEquals(options.get("org.eclipse.jdt.core.compiler.compliance"), "1.7");
-        assertEquals(options.get("org.eclipse.jdt.core.compiler.source"), "1.7");
+        assertEquals(settingKeys.size(), options.size());
+        assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.compliance"));
+        assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.source"));
     }
 
     @Test
@@ -54,9 +54,9 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
         List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
         Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
-        assertEquals(options.size(), settingKeys.size());
-        assertEquals(options.get("org.eclipse.jdt.core.compiler.compliance"), "1.8");
-        assertEquals(options.get("org.eclipse.jdt.core.compiler.source"), "1.8");
+        assertEquals(settingKeys.size(), options.size());
+        assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
+        assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.source"));
     }
 
     @Test
@@ -65,16 +65,16 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
         IProject project = WorkspaceHelper.getProject("classpathtest");
         String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
         ClasspathOptions options = new ClasspathOptions();
-        options.excludingTests = true;
+        options.scope = "runtime";
         ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(result.classpaths.length, 1);
-        assertEquals(result.modulepaths.length, 0);
+        assertEquals(1, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
         assertTrue(result.classpaths[0].indexOf("junit") == -1);
 
-        options.excludingTests = false;
+        options.scope = "test";
         result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(result.classpaths.length, 4);
-        assertEquals(result.modulepaths.length, 0);
+        assertEquals(4, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
         boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
             return element.indexOf("junit") > -1;
         });
@@ -88,11 +88,11 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
         String uriString = project.getFile("src/main/java/Library.java").getLocationURI().toString();
         ClasspathOptions options = new ClasspathOptions();
         // Gradle project will always return classpath containing test dependencies.
-        // So we only test `excludingTests = false` scenario.
-        options.excludingTests = false;
+        // So we only test `scope = "test"` scenario.
+        options.scope = "test";
         ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(result.classpaths.length, 5);
-        assertEquals(result.modulepaths.length, 0);
+        assertEquals(5, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
         boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
             return element.indexOf("junit") > -1;
         });
@@ -105,10 +105,10 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
         IProject project = WorkspaceHelper.getProject("modular-project");
         String uriString = project.getFile("src/main/java/modular/Main.java").getLocationURI().toString();
         ClasspathOptions options = new ClasspathOptions();
-        options.excludingTests = false;
+        options.scope = "test";
         ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
-        assertEquals(result.classpaths.length, 0);
-        assertEquals(result.modulepaths.length, 1);
+        assertEquals(0, result.classpaths.length);
+        assertEquals(1, result.modulepaths.length);
     }
 
     @Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandlerTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.ls.core.internal.ActionableNotification;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClasspathUpdateHandlerTest extends AbstractProjectsManagerBasedTest {
+	@Mock
+	private JavaClientConnection connection;
+
+	private ClasspathUpdateHandler handler;
+
+	@Before
+	public void setup() throws Exception {
+		handler = new ClasspathUpdateHandler(connection);
+		handler.addElementChangeListener();;
+	}
+
+	@After
+	@Override
+	public void cleanUp() throws Exception {
+		super.cleanUp();
+		handler.removeElementChangeListener();
+	}
+
+	@Test
+	public void testProjectConfigurationIsNotUpToDate() throws Exception {
+		//import project
+		importProjects("maven/salut");
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut");
+		IFile pom = project.getFile("/pom.xml");
+		assertTrue(pom.exists());
+		ResourceUtils.setContent(pom, ResourceUtils.getContent(pom).replaceAll("<version>3.5</version>", "<version>3.6</version>"));
+
+		ResourcesPlugin.getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, monitor);
+
+		verify(connection, times(1)).sendActionableNotification(any(ActionableNotification.class));
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandlerTest.java
@@ -54,7 +54,7 @@ public class ClasspathUpdateHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
-	public void testProjectConfigurationIsNotUpToDate() throws Exception {
+	public void testClasspathUpdate() throws Exception {
 		//import project
 		importProjects("maven/salut");
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
@@ -20,7 +20,6 @@ import java.net.URI;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.junit.Test;
 
@@ -62,13 +61,4 @@ public class GradleBuildSupportTest extends AbstractGradleBasedTest {
 		assertNoErrors(project);
 		assertEquals("1.7", ProjectUtils.getJavaSourceLevel(project));
 	}
-
-	@Test
-	public void testGetAllContainingProjects() throws Exception {
-		IProject project = importGradleProject("multi-module");
-		GradleBuildSupport gradleBuildSupport = new GradleBuildSupport();
-		URI[] result = gradleBuildSupport.getAllContainingProjects(project, new NullProgressMonitor());
-		assertEquals(result.length, 3);
-	}
-
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.junit.Test;
 
@@ -60,6 +61,14 @@ public class GradleBuildSupportTest extends AbstractGradleBasedTest {
 		waitForBackgroundJobs();
 		assertNoErrors(project);
 		assertEquals("1.7", ProjectUtils.getJavaSourceLevel(project));
+	}
+
+	@Test
+	public void testGetAllContainingProjects() throws Exception {
+		IProject project = importGradleProject("multi-module");
+		GradleBuildSupport gradleBuildSupport = new GradleBuildSupport();
+		URI[] result = gradleBuildSupport.getAllContainingProjects(project, new NullProgressMonitor());
+		assertEquals(result.length, 3);
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupportTest.java
@@ -61,4 +61,5 @@ public class GradleBuildSupportTest extends AbstractGradleBasedTest {
 		assertNoErrors(project);
 		assertEquals("1.7", ProjectUtils.getJavaSourceLevel(project));
 	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
@@ -234,6 +234,14 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 		assertTrue(ProjectUtils.isMavenProject(project));
 	}
 
+	@Test
+	public void testGetAllContainingProjects() throws Exception {
+		IProject project = importMavenProject("multimodule");
+		MavenBuildSupport mavenBuildSupport = new MavenBuildSupport();
+		URI[] result = mavenBuildSupport.getAllContainingProjects(project, new NullProgressMonitor());
+		assertEquals(result.length, 4);
+	}
+
 	protected void testNonStandardCompilerId(String projectName) throws Exception {
 		IProject project = importMavenProject(projectName);
 		assertIsJavaProject(project);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
@@ -234,14 +234,6 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 		assertTrue(ProjectUtils.isMavenProject(project));
 	}
 
-	@Test
-	public void testGetAllContainingProjects() throws Exception {
-		IProject project = importMavenProject("multimodule");
-		MavenBuildSupport mavenBuildSupport = new MavenBuildSupport();
-		URI[] result = mavenBuildSupport.getAllContainingProjects(project, new NullProgressMonitor());
-		assertEquals(result.length, 4);
-	}
-
 	protected void testNonStandardCompilerId(String projectName) throws Exception {
 		IProject project = importMavenProject(projectName);
 		assertIsJavaProject(project);


### PR DESCRIPTION
This PR is to enable the SonarLint Java support in VS Code.

The context background can be found here: https://github.com/SonarSource/sonarlint-vscode/pull/28

Related PR for VS Code client: https://github.com/redhat-developer/vscode-java/pull/1212

There is one issue that the classpath resolved for Gradle project will always contains test entries no matter the `excludingTests` is set to `true` or `false`. 🤔

> Note: Please do not merge it until the design is tested and verified. The discussion is [here](https://github.com/SonarSource/sonarlint-vscode/pull/28).

Signed-off-by: Sheng Chen <sheche@microsoft.com>