### PR TITLE
Add default value to reference libraries' exclude and sources when importing

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -666,7 +666,7 @@ public class Preferences {
 		} else if (referencedLibraries instanceof Map) {
 			try {
 				Map<String, Object> config = (Map<String, Object>) referencedLibraries;
-				Set<String> include = new HashSet<>((List<String>) config.get("include"));
+				Set<String> include = new HashSet<>((List<String>) config.getOrDefault("include", new ArrayList<>()));
 				Set<String> exclude = new HashSet<>((List<String>) config.getOrDefault("exclude", new ArrayList<>()));
 				Map<String, String> sources = (Map<String, String>) config.getOrDefault("sources", new HashMap<>());
 				prefs.setReferencedLibraries(new ReferencedLibraries(include, exclude, sources));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -667,8 +667,8 @@ public class Preferences {
 			try {
 				Map<String, Object> config = (Map<String, Object>) referencedLibraries;
 				Set<String> include = new HashSet<>((List<String>) config.get("include"));
-				Set<String> exclude = new HashSet<>((List<String>) config.get("exclude"));
-				Map<String, String> sources = (Map<String, String>) config.get("sources");
+				Set<String> exclude = new HashSet<>((List<String>) config.getOrDefault("exclude", new ArrayList<>()));
+				Map<String, String> sources = (Map<String, String>) config.getOrDefault("sources", new HashMap<>());
 				prefs.setReferencedLibraries(new ReferencedLibraries(include, exclude, sources));
 			} catch (Exception e) {
 				prefs.setReferencedLibraries(JAVA_PROJECT_REFERENCED_LIBRARIES_DEFAULT);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupportTest.java
@@ -390,7 +390,7 @@ public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBa
 			assertEquals("Configuration with include, exclude and sources", libraries, preferences.getReferencedLibraries());
 		}
 
-		{ // Test import of referenced libraries without include (will fall back to default)
+		{ // Test import of referenced libraries with exclude and sources
 			List<String> exclude = Arrays.asList("libraries/sources/**");
 			Map<String, String> sources = new HashMap<String, String>() {{
 				put("libraries/foo.jar", "libraries/foo-src.jar");
@@ -401,8 +401,32 @@ public class InvisibleProjectBuildSupportTest extends AbstractInvisibleProjectBa
 				put("sources", sources);
 			}});
 			Preferences preferences = Preferences.createFrom(configuration);
-			ReferencedLibraries libraries = Preferences.JAVA_PROJECT_REFERENCED_LIBRARIES_DEFAULT;
-			assertEquals("Configuration with no include", libraries, preferences.getReferencedLibraries());
+			ReferencedLibraries libraries = new ReferencedLibraries(new HashSet<>(), new HashSet<>(exclude), sources);
+			assertEquals("Configuration with exclude and sources", libraries, preferences.getReferencedLibraries());
+		}
+
+		{ // Test import of referenced libraries with only exclude
+			List<String> exclude = Arrays.asList("libraries/sources/**");
+			Map<String, Object> configuration = new HashMap<>();
+			configuration.put(Preferences.JAVA_PROJECT_REFERENCED_LIBRARIES_KEY, new HashMap<String, Object>() {{
+				put("exclude", exclude);
+			}});
+			Preferences preferences = Preferences.createFrom(configuration);
+			ReferencedLibraries libraries = new ReferencedLibraries(new HashSet<>(), new HashSet<>(exclude), new HashMap<>());
+			assertEquals("Configuration with exclude", libraries, preferences.getReferencedLibraries());
+		}
+
+		{ // Test import of referenced libraries with only sources
+			Map<String, String> sources = new HashMap<String, String>() {{
+				put("libraries/foo.jar", "libraries/foo-src.jar");
+			}};
+			Map<String, Object> configuration = new HashMap<>();
+			configuration.put(Preferences.JAVA_PROJECT_REFERENCED_LIBRARIES_KEY, new HashMap<String, Object>() {{
+				put("sources", sources);
+			}});
+			Preferences preferences = Preferences.createFrom(configuration);
+			ReferencedLibraries libraries = new ReferencedLibraries(new HashSet<>(), new HashSet<>(), sources);
+			assertEquals("Configuration with sources", libraries, preferences.getReferencedLibraries());
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a bug reproduced by following setting:
```json
"java.project.referencedLibraries": {
    "include": [
        "....",
        "...."
    ]
}
```
where there's no `exclude` field set in the setting. This will cause the language server to use the fallback default setting (`lib/**`). This bug does not affect the shortcut array pattern (`"Libraries": [...]`).

The absence of `sources` field does not introduce bug since it won't raise NPE problem, but we also add a default value to it to make sure all the fields in `ReferencedLibraries` is initialized.

`include` field is not gotten with a default empty value, since `include` field is required, and if not provided, just use the default `lib/**`.