### PR TITLE
JSONUtility.toModel(): add support for parsing maps

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JSONUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JSONUtility.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 
@@ -60,6 +62,18 @@ public class JSONUtility {
 		}
 		if (object instanceof String) {
 			return gson.fromJson((String) object, clazz);
+		}
+		if (object instanceof Map) {
+			try {
+				Map<String, Object> map = (Map<String, Object>) object;
+				T result = clazz.newInstance();
+				for (Field field : clazz.getFields()) {
+					field.set(result, map.get(field.getName()));
+				}
+				return result;
+			} catch (InstantiationException | IllegalAccessException e) {
+				throw new RuntimeException(e);
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Since https://github.com/eclipse/eclipse.jdt.ls/pull/1312 was merged, I wanted to try using it as part of my project to get Java debugging working with [vim-lsp](https://github.com/prabirshrestha/vim-lsp/) and [java-debug](https://github.com/microsoft/java-debug). Unfortunately, my first attempt at using the API failed because the language server doesn't know how to handle map-type arguments natively.

For context, here is how I'm invoking the new API:

```viml
call lsp#send_request('java-language-server', {
      \ 'method': 'workspace/executeCommand',
      \ 'params': {
      \   'command': 'java.project.getClasspaths',
      \   'arguments': [
      \      'file://'.expand('%:p'),
      \      {'scope': 'runtime'},
      \   ],
      \ },
      \ 'sync': v:true,
      \ })
```

Initially, this resulted in a `NullPointerException` being raised [here](https://github.com/eclipse/eclipse.jdt.ls/blob/3ab2fdf3baceb8c9dde89a265f8a3596a851bce0/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java#L85) because `options` is null.

I tracked the error down to `JSONUtility.toModel()` returning null for the `classpathOptions` argument, and from there determined that it was actually an instance of `com.google.gson.internal.LinkedTreeMap`, causing `toModel()` to return null because it didn't match any of the expected types.

For simple cases such as this one, I think it would make sense for `JSONUtility.toModel()` to be smart enough to map the fields of a map into a model object, so that users of the API don't have to manually encode dictionaries into a JSON object.