### PR TITLE
enable syntax mode when importing a partial folder of maven/gradle project

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -99,7 +99,8 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 
 		String packageName = getPackageName(javaFile, rootPath);
 		IPath sourceDirectory = inferSourceDirectory(javaFile.toFile().toPath(), packageName);
-		if (sourceDirectory == null || !rootPath.isPrefixOf(sourceDirectory)) {
+		if (sourceDirectory == null || !rootPath.isPrefixOf(sourceDirectory)
+			|| isPartOfMatureProject(sourceDirectory)) {
 			return false;
 		}
 
@@ -138,6 +139,20 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 		}
 
 		return true;
+	}
+
+	private static boolean isPartOfMatureProject(IPath sourcePath) {
+		sourcePath = sourcePath.removeTrailingSeparator();
+		List<String> segments = Arrays.asList(sourcePath.segments());
+		int index = segments.lastIndexOf("src");
+		if (index <= 0) {
+			return false;
+		}
+
+		IPath srcPath = sourcePath.removeLastSegments(segments.size() -1 - index);
+		IPath container = srcPath.removeLastSegments(1);
+		return container.append("pom.xml").toFile().exists()
+			|| container.append("build.gradle").toFile().exists();
 	}
 
 	private static String getPackageName(IPath javaFile, IPath workspaceRoot) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
@@ -88,6 +88,10 @@ public abstract class AbstractInvisibleProjectBasedTest extends AbstractProjects
 
 	protected IProject importRootFolder(File projectFolder, String triggerFile) throws Exception {
 		IPath rootPath = Path.fromOSString(projectFolder.getAbsolutePath());
+		return importRootFolder(rootPath, triggerFile);
+	}
+
+	protected IProject importRootFolder(IPath rootPath, String triggerFile) throws Exception {
 		if (StringUtils.isNotBlank(triggerFile)) {
 			IPath triggerFilePath = rootPath.append(triggerFile);
 			Preferences preferences = preferenceManager.getPreferences();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -58,6 +58,24 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 	}
 
 	@Test
+	public void importPartialMavenFolder() throws Exception {
+		File projectFolder = copyFiles("maven/salut-java11", true);
+		IPath projectFullPath = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath rootPath = projectFullPath.append("src");
+		IProject invisibleProject = importRootFolder(rootPath, "main/java/org/sample/Bar.java");
+		assertFalse(invisibleProject.exists());
+	}
+
+	@Test
+	public void importPartialGradleFolder() throws Exception {
+		File projectFolder = copyFiles("gradle/gradle-11", true);
+		IPath projectFullPath = Path.fromOSString(projectFolder.getAbsolutePath());
+		IPath rootPath = projectFullPath.append("src");
+		IProject invisibleProject = importRootFolder(rootPath, "main/java/foo/bar/Foo.java");
+		assertFalse(invisibleProject.exists());
+	}
+
+	@Test
 	public void automaticJarDetectionLibUnderSource() throws Exception {
 		ClientPreferences mockCapabilies = mock(ClientPreferences.class);
 		when(mockCapabilies.isWorkspaceChangeWatchedFilesDynamicRegistered()).thenReturn(Boolean.TRUE);


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix redhat-developer/vscode-java#1275

When opening a partial folder from a maven/gradle project, because the classpath is incomplete, will report syntax errors only.
