### PR TITLE
Use stable lsp4j 0.9.0 release

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -202,7 +202,11 @@ public class CodeActionHandler {
 	private static int getProblemId(Diagnostic diagnostic) {
 		int $ = 0;
 		try {
-			$ = Integer.parseInt(diagnostic.getCode());
+			if (diagnostic.getCode().getLeft() != null) {
+				$ = Integer.parseInt(diagnostic.getCode().getLeft());
+			} else if (diagnostic.getCode().getRight() != null) {
+				$ = diagnostic.getCode().getRight().intValue();
+			}
 		} catch (NumberFormatException e) {
 			// return 0
 		}

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -42,7 +42,7 @@
             <repository location="https://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-apt/1.5.3-2019-11-08_11-04-22-H22/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/milestones/S202002202238/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.9.0/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
     </locations>


### PR DESCRIPTION
Uses https://download.eclipse.org/lsp4j/updates/releases/0.9.0/
Reapplies #1373

Fixes #1382

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>
Also-by: Fred Bricon <fbricon@gmail.com>