### PR TITLE
Make syntax server support hovering over a type

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/HoverInfoProvider.java
@@ -116,8 +116,8 @@ public class HoverInfoProvider {
 			} else {
 				curr = elements[0];
 			}
-			boolean resolved = isResolved(curr, monitor);
-			if (resolved) {
+
+			if (JDTEnvironmentUtils.isSyntaxServer() || isResolved(curr, monitor)) {
 				IBuffer buffer = curr.getOpenable().getBuffer();
 				if (buffer == null && curr instanceof BinaryMember) {
 					IClassFile classFile = ((BinaryMember) curr).getClassFile();

--- a/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/java/Bar.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/java/Bar.java
@@ -1,5 +1,8 @@
 package java;
 
+/**
+ * This is Bar.
+ */
 public class Bar {
 
     public void print() {

--- a/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/java/Foo.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/java/Foo.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * This is foo
  */
-public class Foo {
+public class Foo implements IFoo {
 
     public static void main(String[] args) {
         System.out.println(StringUtils.capitalize("Hello world! from " + Foo.class));

--- a/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/pack/IFoo.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/projects/maven/salut4/src/main/java/pack/IFoo.java
@@ -1,0 +1,8 @@
+package pack;
+
+/**
+ * This is interface IFoo.
+ */
+public interface IFoo {
+
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Currently hovering at a type doesn't work at syntax server, see https://github.com/eclipse/eclipse.jdt.ls/pull/1386#issuecomment-600872477. The reason is the hover handler uses search engine to validate whether the type is resolved. However, the syntax server disabled search engine so that no result is returned. 

Given syntax server is for speeding up responsiveness, IMO, returning a non 100% accurate result is acceptable. I would prefer to skip the validation step for syntax server.

