### PR TITLE
Add experimental support for Bazel (eclipse#543)

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.xtext.xbase.lib,
  org.eclipse.core.filesystem;bundle-version="1.7.0",
  org.eclipse.jdt.apt.pluggable.core;bundle-version="1.2.0";resolution:=optional,
- org.jboss.tools.maven.apt.core;bundle-version="1.3.0";resolution:=optional
+ org.jboss.tools.maven.apt.core;bundle-version="1.3.0";resolution:=optional,
+ com.salesforce.b2eclipse.jdt.ls;bundle-version="0.1.0"
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
  org.eclipse.jdt.ls.core.internal.codemanipulation;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.commands;x-friends:="org.eclipse.jdt.ls.tests",

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -89,11 +89,15 @@
          <importer
             id = "gradleProjectImporter"
             order ="300"
-            class = "org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter"/> 
+            class = "org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter"/>
          <importer
             id = "mavenProjectImporter"
             order = "400"
             class = "org.eclipse.jdt.ls.core.internal.managers.MavenProjectImporter"/>
+         <importer
+            id = "bazelProjectImporter"
+            order ="500"
+            class = "org.eclipse.jdt.ls.core.internal.managers.BazelProjectImporter"/>
          <importer
             id = "eclipseProjectImporter"
             order = "1000"

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BazelProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BazelProjectImporter.java
@@ -1,0 +1,69 @@
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+
+import com.salesforce.b2eclipse.abstractions.WorkProgressMonitor;
+import com.salesforce.b2eclipse.config.BazelEclipseProjectFactory;
+import com.salesforce.b2eclipse.importer.BazelProjectImportScanner;
+import com.salesforce.b2eclipse.model.BazelPackageInfo;
+import com.salesforce.b2eclipse.runtime.impl.EclipseWorkProgressMonitor;
+
+public final class BazelProjectImporter extends AbstractProjectImporter {
+
+    private static final String WORKSPACE_FILE_NAME = "WORKSPACE";
+
+    @Override
+    public boolean applies(IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+        PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
+        if (preferencesManager != null && !preferencesManager.getPreferences().isImportBazelEnabled()) {
+            return false;
+        }
+        if (!rootFolder.exists() || !rootFolder.isDirectory()) {
+            return false;
+        }
+		File workspaceFile = new File(rootFolder, WORKSPACE_FILE_NAME);
+		if (!workspaceFile.exists()) {
+            return false;
+        }
+        return true;
+
+    }
+
+    @Override
+    public void importToWorkspace(IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+        BazelProjectImportScanner scanner = new BazelProjectImportScanner();
+
+        BazelPackageInfo workspaceRootPackage = scanner.getProjects(rootFolder);
+
+        if (workspaceRootPackage == null) {
+            throw new IllegalArgumentException();
+        }
+        List<BazelPackageInfo> bazelPackagesToImport = workspaceRootPackage.getChildPackageInfos().stream()
+                .collect(Collectors.toList());
+
+        WorkProgressMonitor progressMonitor = new EclipseWorkProgressMonitor(null);
+
+        BazelEclipseProjectFactory.setImportBazelSRCPath(
+                JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getImportBazelSrcPath());
+        BazelEclipseProjectFactory.setImportBazelTestPath(
+                JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getImportBazelTestPath());
+
+        BazelEclipseProjectFactory.importWorkspace(workspaceRootPackage, bazelPackagesToImport, progressMonitor,
+                monitor);
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -209,6 +209,31 @@ public class Preferences {
 	public static final String SELECTIONRANGE_ENABLED_KEY = "java.selectionRange.enabled";
 
 	/**
+	 * Preference key to enable/disable bazel importer.
+	 */
+	public static final String IMPORT_BAZEL_ENABLED = "java.import.bazel.enabled";
+
+	/**
+	 * Preference key to change java classes src path for bazel importer.
+	 */
+	public static final String BAZEL_SRC_PATH = "java.import.bazel.src.path";
+
+	/**
+	 * Preference key to change java classes test path for bazel importer.
+	 */
+	public static final String BAZEL_TEST_PATH = "java.import.bazel.test.path";
+
+	/**
+	 * Default java class src path for bazel importer.
+	 */
+	public static final String BAZEL_DEFAULT_SRC_PATH = "/src/main/java";
+
+	/**
+	 * Default java class test path for bazel importer.
+	 */
+	public static final String BAZEL_DEFAULT_TEST_PATH = "/src/test/java";
+
+	/**
 	 * A named preference that holds the favorite static members.
 	 * <p>
 	 * Value is of type <code>String</code>: list of favorites.
@@ -383,6 +408,9 @@ public class Preferences {
 	private boolean generateToStringListArrayContents;
 	private int generateToStringLimitElements;
 	private List<String> preferredContentProviderIds;
+	private boolean importBazelEnabled;
+	private String importBazelSrcPath;
+	private String importBazelTestPath;
 
 	private String mavenUserSettings;
 
@@ -566,6 +594,10 @@ public class Preferences {
 		parallelBuildsCount = PreferenceInitializer.PREF_MAX_CONCURRENT_BUILDS_DEFAULT;
 		maxCompletionResults = JAVA_COMPLETION_MAX_RESULTS_DEFAULT;
 		referencedLibraries = JAVA_PROJECT_REFERENCED_LIBRARIES_DEFAULT;
+		importBazelEnabled = false;
+		importBazelSrcPath = BAZEL_DEFAULT_SRC_PATH;
+		importBazelTestPath = BAZEL_DEFAULT_TEST_PATH;
+
 	}
 
 	/**
@@ -612,6 +644,13 @@ public class Preferences {
 		prefs.setReferencesCodelensEnabled(referenceCodelensEnabled);
 		boolean implementationCodeLensEnabled = getBoolean(configuration, IMPLEMENTATIONS_CODE_LENS_ENABLED_KEY, false);
 		prefs.setImplementationCodelensEnabled(implementationCodeLensEnabled);
+
+		boolean importBazelEnabled = getBoolean(configuration, IMPORT_BAZEL_ENABLED, false);
+		prefs.setImportBazelEnabled(importBazelEnabled);
+		String importBazelSrcPath = getString(configuration, BAZEL_SRC_PATH, BAZEL_DEFAULT_SRC_PATH);
+		prefs.setImportBazelSrcPath(importBazelSrcPath);
+		String importBazelTestPath = getString(configuration, BAZEL_TEST_PATH, BAZEL_DEFAULT_TEST_PATH);
+		prefs.setImportBazelTestPath(importBazelTestPath);
 
 		boolean javaFormatEnabled = getBoolean(configuration, JAVA_FORMAT_ENABLED_KEY, true);
 		prefs.setJavaFormatEnabled(javaFormatEnabled);
@@ -896,6 +935,11 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setImportBazelEnabled(boolean enabled) {
+		this.importBazelEnabled = enabled;
+		return this;
+	}
+
 	public Preferences setMavenDownloadSources(boolean enabled) {
 		this.mavenDownloadSources = enabled;
 		return this;
@@ -1041,6 +1085,24 @@ public class Preferences {
 		return this;
 	}
 
+	public Preferences setImportBazelSrcPath(String importBazelSrcPath) {
+		this.importBazelSrcPath = importBazelSrcPath;
+		return this;
+	}
+
+	public Preferences setImportBazelTestPath(String importBazelTestPath) {
+		this.importBazelTestPath = importBazelTestPath;
+		return this;
+	}
+
+	public String getImportBazelSrcPath() {
+		return importBazelSrcPath;
+	}
+
+	public String getImportBazelTestPath() {
+		return importBazelTestPath;
+	}
+
 	public Severity getIncompleteClasspathSeverity() {
 		return incompleteClasspathSeverity;
 	}
@@ -1111,6 +1173,10 @@ public class Preferences {
 
 	public boolean isImportMavenEnabled() {
 		return importMavenEnabled;
+	}
+
+	public boolean isImportBazelEnabled() {
+		return importBazelEnabled;
 	}
 
 	public boolean isMavenDownloadSources() {

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -46,6 +46,10 @@
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        	<repository location="https://raw.githubusercontent.com/salesforce/bazel-eclipse-ls/gh-pages/p2/master/"/>
+            <unit id="com.salesforce.b2eclipse.jdt.ls" version="0.0.0"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <repository location="https://download.eclipse.org/eclipse/updates/4.15-P-builds/P20200318-0455/"/>
             <unit id="org.eclipse.jdt.java14patch.feature.group" version="0.0.0"/>
         </location>


### PR DESCRIPTION
Experimental support for Bazel (#543) 

Introduces integration with the following [plugin](https://github.com/salesforce/bazel-eclipse-ls/tree/master/com.salesforce.b2eclipse.jdt.ls). Since **it's in active development**, the importer is disabled by default and has the lowest priority. 

Currently the plugin does the following to provide rich development experience:
* Project importer
* Classpath container and its initializer

Signed-off-by: Pavel Mitrafanau <pavel_mitrafanau@epam.com>