### PR TITLE
Support semantic tokens

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -57,7 +57,8 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.managers;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
  org.eclipse.jdt.ls.core.internal.preferences;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
  org.eclipse.jdt.ls.core.internal.syntaxserver;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver",
- org.eclipse.jdt.ls.core.internal.text.correction;x-friends:="org.eclipse.jdt.ls.tests"
+ org.eclipse.jdt.ls.core.internal.text.correction;x-friends:="org.eclipse.jdt.ls.tests",
+ org.eclipse.jdt.ls.core.internal.semantictokens;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-ClassPath: lib/jsoup-1.9.2.jar,
  lib/remark-1.2.0.jar,
  .

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -81,6 +81,12 @@
             <command
                   id="java.project.refreshDiagnostics">
             </command>
+            <command
+                  id="java.project.provideSemanticTokens">
+            </command>
+            <command
+                  id="java.project.getSemanticTokensLegend">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension
@@ -89,7 +95,7 @@
          <importer
             id = "gradleProjectImporter"
             order ="300"
-            class = "org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter"/> 
+            class = "org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter"/>
          <importer
             id = "mavenProjectImporter"
             order = "400"

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
 import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
+import org.eclipse.jdt.ls.core.internal.commands.SemanticTokensCommand;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -68,6 +69,10 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return ProjectCommand.isTestFile((String) arguments.get(0));
 				case "java.project.refreshDiagnostics":
 					return DiagnosticsCommand.refreshDiagnostics((String) arguments.get(0), (String) arguments.get(1), (boolean) arguments.get(2));
+				case "java.project.provideSemanticTokens":
+					return SemanticTokensCommand.provide((String) arguments.get(0));
+				case "java.project.getSemanticTokensLegend":
+					return SemanticTokensCommand.getLegend();
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokenManager;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokens;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensLegend;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensVisitor;
+import org.eclipse.jface.text.IDocument;
+
+public class SemanticTokensCommand {
+
+    public static SemanticTokens provide(String uri) {
+
+        IDocument document = null;
+
+        ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
+        if (cu != null) {
+            try {
+                document = JsonRpcHelpers.toDocument(cu.getBuffer());
+            } catch (JavaModelException e) {
+                JavaLanguageServerPlugin.logException("Failed to provide semantic tokens for " + uri, e);
+            }
+        }
+
+        SemanticTokensVisitor collector = new SemanticTokensVisitor(document, SemanticTokenManager.getInstance());
+        CompilationUnit root = CoreASTProvider.getInstance().getAST(cu, CoreASTProvider.WAIT_YES, new NullProgressMonitor());
+        root.accept(collector);
+        return collector.getSemanticTokens();
+    }
+
+    public static SemanticTokensLegend getLegend() {
+        return SemanticTokenManager.getInstance().getLegend();
+    }
+
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jdt.ls.core.internal.commands;
 
+import java.util.Collections;
+
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
@@ -40,6 +42,9 @@ public class SemanticTokensCommand {
             } catch (JavaModelException e) {
                 JavaLanguageServerPlugin.logException("Failed to provide semantic tokens for " + uri, e);
             }
+        }
+        if (document == null) {
+            return new SemanticTokens(Collections.emptyList());
         }
 
         SemanticTokensVisitor collector = new SemanticTokensVisitor(document, SemanticTokenManager.getInstance());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/ITokenModifier.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/ITokenModifier.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import org.eclipse.jdt.core.dom.IBinding;
+
+public interface ITokenModifier {
+    public boolean applies(IBinding binding);
+    public String toString();
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/ITokenModifier.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/ITokenModifier.java
@@ -16,6 +16,16 @@ package org.eclipse.jdt.ls.core.internal.semantictokens;
 import org.eclipse.jdt.core.dom.IBinding;
 
 public interface ITokenModifier {
+    /**
+     * Determine whether this modifier applies to a named entity.
+     * @param binding corresponding binding of the named entity.
+     * @return <code>true</code> if this modifier applies to the binding and
+	 *    <code>false</code> otherwise
+     */
     public boolean applies(IBinding binding);
+
+    /**
+     * identifier of the modifier
+     */
     public String toString();
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokenManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokenManager.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SemanticTokenManager {
+    private TokenModifiers tokenModifiers;
+    private List<TokenType> tokenTypes;
+    private SemanticTokensLegend legend;
+
+    private SemanticTokenManager() {
+        this.tokenModifiers = new TokenModifiers();
+        this.tokenTypes = Arrays.asList(TokenType.values());
+        List<String> modifiers = tokenModifiers.list().stream().map(mod -> mod.toString()).collect(Collectors.toList());
+        List<String> types = tokenTypes.stream().map(TokenType::toString).collect(Collectors.toList());
+        this.legend = new SemanticTokensLegend(types, modifiers);
+    }
+
+    private static class SingletonHelper{
+        private static final SemanticTokenManager INSTANCE = new SemanticTokenManager();
+    }
+
+    public static SemanticTokenManager getInstance(){
+        return SingletonHelper.INSTANCE;
+    }
+
+    public SemanticTokensLegend getLegend() {
+        return this.legend;
+    }
+
+    public TokenModifiers getTokenModifiers() {
+        return tokenModifiers;
+    }
+
+    public List<TokenType> getTokenTypes() {
+        return tokenTypes;
+    }
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokens.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokens.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.util.Preconditions;
+
+public class SemanticTokens {
+
+    /**
+     * Tokens in a file are represented as an array of integers. The position of each token is expressed relative to
+     * the token before it, because most tokens remain stable relative to each other when edits are made in a file.
+     *
+     * ---
+     * In short, each token takes 5 integers to represent, so a specific token `i` in the file consists of the following array indices:
+     *  - at index `5*i`   - `deltaLine`: token line number, relative to the previous token
+     *  - at index `5*i+1` - `deltaStart`: token start character, relative to the previous token (relative to 0 or the previous token's start if they are on the same line)
+     *  - at index `5*i+2` - `length`: the length of the token. A token cannot be multiline.
+     *  - at index `5*i+3` - `tokenType`: will be looked up in `SemanticTokensLegend.tokenTypes`. We currently ask that `tokenType` < 65536.
+     *  - at index `5*i+4` - `tokenModifiers`: each set bit will be looked up in `SemanticTokensLegend.tokenModifiers`
+     *
+     * ---
+     * ### How to encode tokens
+     *
+     * Here is an example for encoding a file with 3 tokens in a uint32 array:
+     * ```
+     *    { line: 2, startChar:  5, length: 3, tokenType: "property",  tokenModifiers: ["private", "static"] },
+     *    { line: 2, startChar: 10, length: 4, tokenType: "type",      tokenModifiers: [] },
+     *    { line: 5, startChar:  2, length: 7, tokenType: "class",     tokenModifiers: [] }
+     * ```
+     *
+     * 1. First of all, a legend must be devised. This legend must be provided up-front and capture all possible token types.
+     * For this example, we will choose the following legend which must be passed in when registering the provider:
+     * ```
+     *    tokenTypes: ['property', 'type', 'class'],
+     *    tokenModifiers: ['private', 'static']
+     * ```
+     *
+     * 2. The first transformation step is to encode `tokenType` and `tokenModifiers` as integers using the legend. Token types are looked
+     * up by index, so a `tokenType` value of `1` means `tokenTypes[1]`. Multiple token modifiers can be set by using bit flags,
+     * so a `tokenModifier` value of `3` is first viewed as binary `0b00000011`, which means `[tokenModifiers[0], tokenModifiers[1]]` because
+     * bits 0 and 1 are set. Using this legend, the tokens now are:
+     * ```
+     *    { line: 2, startChar:  5, length: 3, tokenType: 0, tokenModifiers: 3 },
+     *    { line: 2, startChar: 10, length: 4, tokenType: 1, tokenModifiers: 0 },
+     *    { line: 5, startChar:  2, length: 7, tokenType: 2, tokenModifiers: 0 }
+     * ```
+     *
+     * 3. The next step is to represent each token relative to the previous token in the file. In this case, the second token
+     * is on the same line as the first token, so the `startChar` of the second token is made relative to the `startChar`
+     * of the first token, so it will be `10 - 5`. The third token is on a different line than the second token, so the
+     * `startChar` of the third token will not be altered:
+     * ```
+     *    { deltaLine: 2, deltaStartChar: 5, length: 3, tokenType: 0, tokenModifiers: 3 },
+     *    { deltaLine: 0, deltaStartChar: 5, length: 4, tokenType: 1, tokenModifiers: 0 },
+     *    { deltaLine: 3, deltaStartChar: 2, length: 7, tokenType: 2, tokenModifiers: 0 }
+     * ```
+     *
+     * 4. Finally, the last step is to inline each of the 5 fields for a token in a single array, which is a memory friendly representation:
+     * ```
+     *    // 1st token,  2nd token,  3rd token
+     *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+     * ```
+     */
+    private final List<Integer> data;
+
+    /**
+     * The result id of the tokens (optional).
+     *
+     * This is the id that will be passed to incrementally calculate semantic tokens.
+     */
+    private final String resultId;
+
+    public SemanticTokens(List<Integer> data) {
+        this(data, null);
+    }
+
+    public SemanticTokens(List<Integer> data, String resultId) {
+        this.data = Preconditions.<List<Integer>>checkNotNull(data, "data");
+        this.resultId = resultId;
+    }
+
+    public String getResultId() {
+        return resultId;
+    }
+
+    public List<Integer> getData() {
+        return data;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensLegend.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensLegend.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import java.util.List;
+
+public class SemanticTokensLegend {
+    private final List<String> tokenTypes;
+    private final List<String> tokenModifiers;
+
+    public SemanticTokensLegend(List<String> tokenTypes, List<String> tokenModifiers){
+        this.tokenTypes = tokenTypes;
+        this.tokenModifiers = tokenModifiers;
+    };
+
+    public List<String> getTokenTypes() {
+        return this.tokenTypes;
+    }
+
+    public List<String> getTokenModifiers() {
+        return this.tokenModifiers;
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
+import org.eclipse.jface.text.IDocument;
+
+public class SemanticTokensVisitor extends ASTVisitor {
+    private IDocument document;
+    private SemanticTokenManager manager;
+    private List<SemanticToken> tokens;
+
+    public SemanticTokensVisitor(IDocument document, SemanticTokenManager manager) {
+        this.manager = manager;
+        this.document = document;
+        this.tokens = new ArrayList<>();
+    }
+
+    private class SemanticToken {
+        private final TokenType tokenType;
+        private final ITokenModifier[] tokenModifiers;
+        private final int offset;
+        private final int length;
+
+        public SemanticToken(int offset, int length, TokenType tokenType, ITokenModifier[] tokenModifiers) {
+            this.offset = offset;
+            this.length = length;
+            this.tokenType = tokenType;
+            this.tokenModifiers = tokenModifiers;
+        }
+
+        public TokenType getTokenType() {
+            return tokenType;
+        }
+
+        public ITokenModifier[] getTokenModifiers() {
+            return tokenModifiers;
+        }
+
+        public int getOffset() {
+            return offset;
+        }
+
+        public int getLength() {
+            return length;
+        }
+    }
+
+    public SemanticTokens getSemanticTokens() {
+        List<Integer> data = encoded();
+        return new SemanticTokens(data);
+    }
+
+    private List<Integer> encoded() {
+        List<Integer> data = new ArrayList<>();
+        int currentLine = 0;
+        int currentColumn = 0;
+        for (SemanticToken token : this.tokens) {
+            int[] lineAndColumn = JsonRpcHelpers.toLine(this.document, token.getOffset());
+            int line = lineAndColumn[0];
+            int column = lineAndColumn[1];
+            int deltaLine = line - currentLine;
+            if (deltaLine != 0) {
+                currentLine = line;
+                currentColumn = 0;
+            }
+            int deltaColumn = column - currentColumn;
+            int tokenTypeIndex = manager.getTokenTypes().indexOf(token.getTokenType());
+            ITokenModifier[] modifiers = token.getTokenModifiers();
+            int encodedModifiers = 0;
+            for (ITokenModifier modifier : modifiers) {
+                int bit = manager.getTokenModifiers().indexOf(modifier);
+                if (bit >= 0) {
+                    encodedModifiers = encodedModifiers | (0b00000001 << bit);
+                }
+            }
+            data.add(deltaLine);
+            data.add(deltaColumn);
+            data.add(token.getLength());
+            data.add(tokenTypeIndex);
+            data.add(encodedModifiers);
+        }
+        return data;
+    }
+
+    private void addToken(ASTNode node, TokenType tokenType, ITokenModifier[] modifiers) {
+        int offset = node.getStartPosition();
+        int length = node.getLength();
+        SemanticToken token = new SemanticToken(offset, length, tokenType, modifiers);
+        tokens.add(token);
+    }
+
+    @Override
+    public boolean visit(SimpleName node) {
+        IBinding binding = node.resolveBinding();
+        if (binding == null) {
+            return super.visit(node);
+        }
+
+        TokenType tokenType = null;
+        switch (binding.getKind()) {
+            case IBinding.VARIABLE: {
+                if (((IVariableBinding) binding).isField()) {
+                    tokenType = TokenType.VARIABLE;
+                }
+                break;
+            }
+            case IBinding.METHOD: {
+                tokenType = TokenType.METHOD;
+                break;
+            }
+            default:
+                break;
+        }
+
+        if (tokenType != null) {
+            List<ITokenModifier> modifierList = new ArrayList<>();
+            for (ITokenModifier tokenModifier : manager.getTokenModifiers().values()) {
+                if (tokenModifier.applies(binding)) {
+                    modifierList.add(tokenModifier);
+                }
+            }
+            ITokenModifier[] modifiers = new ITokenModifier[modifierList.size()];
+            modifierList.toArray(modifiers);
+            addToken(node, tokenType, modifiers);
+        }
+
+        return super.visit(node);
+    }
+
+    @Override
+    public boolean visit(MethodInvocation node) {
+        return super.visit(node);
+    }
+
+
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -134,7 +134,7 @@ public class SemanticTokensVisitor extends ASTVisitor {
         }
 
         if (tokenType != null) {
-            List<ITokenModifier> modifierList = new ArrayList<>();
+            List<ITokenModifier> modifierList = new ArrayList<>(manager.getTokenModifiers().values().size());
             for (ITokenModifier tokenModifier : manager.getTokenModifiers().values()) {
                 if (tokenModifier.applies(binding)) {
                     modifierList.add(tokenModifier);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenModifiers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenModifiers.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.Modifier;
+
+public class TokenModifiers {
+    private ITokenModifier[] modifiers;
+    private Map<ITokenModifier, Integer> modifierIndices;
+
+    public TokenModifiers() {
+        modifiers = new ITokenModifier[] {
+            new StaticModifier(),
+            new FinalModifier(),
+            new DeprecatedModifier(),
+            new PublicModifier(),
+            new PrivateModifier(),
+            new ProtectedModifier(),
+            new AbstractModifier()
+        };
+        modifierIndices = new HashMap<>();
+        for (int i = 0; i < modifiers.length; i++) {
+            modifierIndices.putIfAbsent(modifiers[i], i);
+        }
+    }
+
+    public Set<ITokenModifier> values() {
+        return modifierIndices.keySet();
+    }
+
+    public List<ITokenModifier> list() {
+        return Arrays.asList(modifiers);
+    }
+
+    public int indexOf(ITokenModifier modifier) {
+        return modifierIndices.getOrDefault(modifier, -1);
+    }
+
+    class StaticModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.STATIC) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "static";
+        }
+    }
+
+    class FinalModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.FINAL) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "final";
+        }
+    }
+
+    class DeprecatedModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            if (binding != null) {
+                return binding.isDeprecated();
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "deprecated";
+        }
+    }
+
+    class PublicModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.PUBLIC) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "public";
+        }
+    }
+
+    class PrivateModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.PRIVATE) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "private";
+        }
+    }
+
+    class ProtectedModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.PROTECTED) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "protected";
+        }
+    }
+
+    class AbstractModifier implements ITokenModifier {
+        @Override
+        public boolean applies(IBinding binding) {
+            int flags = binding.getModifiers();
+            if ((flags & Modifier.ABSTRACT) != 0) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "abstract";
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.semantictokens;
+
+public enum TokenType {
+    VARIABLE("variable"),
+    METHOD("method"),
+    ;
+
+    private String literalString;
+    TokenType(String tokenTypeString) {
+        this.literalString = tokenTypeString;
+    }
+
+    public String toString() {
+        return this.literalString;
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokens;
+import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensLegend;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest {
+	private IJavaProject fJProject1;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testSemanticTokens_methods() throws JavaModelException {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public void foo1() {}\n");
+		buf.append("    private void foo2() {}\n");
+		buf.append("    protected void foo3() {}\n");
+		buf.append("    static void foo4() {}\n");
+		buf.append("    @Deprecated\n");
+		buf.append("    void foo5() {}\n");
+		buf.append("    public static void main(String args[]) {}\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		SemanticTokensLegend legend = SemanticTokensCommand.getLegend();
+		SemanticTokens tokens = SemanticTokensCommand.provide(JDTUtils.toURI(cu));
+		assertToken(tokens, 0, legend, 4, 16, 4, "method", Arrays.asList("public"));
+		assertToken(tokens, 1, legend, 1, 17, 4, "method", Arrays.asList("private"));
+		assertToken(tokens, 2, legend, 1, 19, 4, "method", Arrays.asList("protected"));
+		assertToken(tokens, 3, legend, 1, 16, 4, "method", Arrays.asList("static"));
+		assertToken(tokens, 4, legend, 2, 9, 4, "method", Arrays.asList("deprecated"));
+		assertToken(tokens, 5, legend, 1, 23, 4, "method", Arrays.asList("public", "static"));
+	}
+
+
+	@Test
+	public void testSemanticTokens_variables() throws JavaModelException {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("\n");
+		buf.append("    public String bar1;\n");
+		buf.append("    private int bar2;\n");
+		buf.append("    protected boolean bar3;\n");
+		buf.append("    final String bar4;\n");
+		buf.append("    static int bar5;\n");
+		buf.append("    public final static int bar6 = 1;\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		SemanticTokensLegend legend = SemanticTokensCommand.getLegend();
+		SemanticTokens tokens = SemanticTokensCommand.provide(JDTUtils.toURI(cu));
+		assertToken(tokens, 0, legend, 4, 18, 4, "variable", Arrays.asList("public"));
+		assertToken(tokens, 1, legend, 1, 16, 4, "variable", Arrays.asList("private"));
+		assertToken(tokens, 2, legend, 1, 22, 4, "variable", Arrays.asList("protected"));
+		assertToken(tokens, 3, legend, 1, 17, 4, "variable", Arrays.asList("final"));
+		assertToken(tokens, 4, legend, 1, 15, 4, "variable", Arrays.asList("static"));
+		assertToken(tokens, 5, legend, 1, 28, 4, "variable", Arrays.asList("static", "public", "final"));
+	}
+
+	private void assertToken(SemanticTokens tokens, int tokenIndex, SemanticTokensLegend legend, int deltaLine, int deltaCol, int length, String tokenTypeString, List<String> modifierStrings) {
+		List<Integer> data = tokens.getData();
+
+		int offset = 5 * tokenIndex;
+		assertEquals(deltaLine, data.get(offset + 0).intValue());
+		assertEquals(deltaCol, data.get(offset + 1).intValue());
+		assertEquals(length, data.get(offset + 2).intValue());
+
+		List<String> tokenTypes = legend.getTokenTypes();
+		int tokenTypeIndex = data.get(offset + 3).intValue();
+		assertEquals(tokenTypes.get(tokenTypeIndex), tokenTypeString);
+
+		List<String> tokenModifiers = legend.getTokenModifiers();
+		int encodedModifiers = data.get(offset + 4).intValue();
+		assertModifiers(tokenModifiers, encodedModifiers, modifierStrings);
+	}
+
+	private void assertModifiers(List<String> tokenModifiers, int encodedModifiers, List<String> modifierStrings) {
+		int cnt = 0;
+		for (int i=0; i<tokenModifiers.size(); i++) {
+			if((encodedModifiers & (0b00000001 << i)) != 0) {
+				String current = tokenModifiers.get(i);
+				assertTrue(modifierStrings.contains(current));
+				cnt += 1;
+			}
+		}
+		assertEquals(cnt, modifierStrings.size());
+	}
+}


### PR DESCRIPTION
This PR is about [Semantic Highlighting](https://github.com/microsoft/vscode/wiki/Semantic-Highlighting-Overview). VS Code has already support to register providers via its APIs, LSP proposal is in progress, but it's not yet part of LSP for the moment. 
In this PR, a delegate command to respond to the semantic token request, before it's merged into LSP in the coming version. 

Basically the LS tells clients a list of encoded tokens and the legend, and then client is reponsible for  applying the tokens with proper textmate scopes and related styles. 

Two token types `variable` and `method` are supported.
Token modifiers include `public`, `private`, `protected`, `abstract`, `final`, `static`, `deprecated`


Below is how it looks in vscode after applying styles for some modifiers:
* **static**: italic
* **final**: bold underline
* **deprecated**: rgb(#838080)  
<img width="1208" alt="Screen Shot 2020-04-15 at 2 15 45 AM" src="https://user-images.githubusercontent.com/2351748/79259323-1d152600-7ebf-11ea-91a7-2fa4511df98e.png">
