### PR TITLE
wait for lifecycle jobs before calc semantic tokens

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
@@ -22,6 +22,8 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
+import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokenManager;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokens;
@@ -30,9 +32,12 @@ import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensVisitor;
 import org.eclipse.jface.text.IDocument;
 
 public class SemanticTokensCommand {
-
     public static SemanticTokens provide(String uri) {
+        JobHelpers.waitForJobs(DocumentLifeCycleHandler.DOCUMENT_LIFE_CYCLE_JOBS, null);
+        return doProvide(uri);
+    }
 
+    private static SemanticTokens doProvide(String uri) {
         IDocument document = null;
 
         ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode-java-dependency/issues/253

This PR ensures that the java model is up-to-date when calculation semantic tokens.