### PR TITLE
Do not import the projects if they already in the workspace

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -105,6 +105,10 @@ public final class ProjectUtils {
 		return Stream.of(getAllProjects()).filter(ProjectUtils::isGradleProject).collect(Collectors.toList());
 	}
 
+	public static List<IProject> getMavenProjects() {
+		return Stream.of(getAllProjects()).filter(ProjectUtils::isMavenProject).collect(Collectors.toList());
+	}
+
 	public static IJavaProject[] getJavaProjects() {
 		//@formatter:off
 		return Stream.of(getAllProjects())

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -132,7 +132,7 @@ public final class ResourceUtils {
 			content = "";
 		}
 		try {
-			Files.write(content, toFile(fileURI), Charsets.UTF_8);
+			Files.asCharSink(toFile(fileURI), Charsets.UTF_8).write(content);
 		} catch (IOException e) {
 			throw new CoreException(StatusFactory.newErrorStatus("Can not write to " + fileURI, e));
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -101,9 +101,6 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 
 		Set<File> existingProjectFolders = new HashSet<>();
 		for (IProject project : ProjectUtils.getGradleProjects()) {
-			if (GradleBuildSupport.shouldSynchronize(project)) {
-				return true;
-			}
 			existingProjectFolders.add(new File(project.getLocationURI()));
 		}
 
@@ -114,7 +111,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 				return true;
 			}
 		}
-		
+
 		return false;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -18,35 +18,28 @@ import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.MavenModelManager;
-import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
 import org.eclipse.m2e.core.internal.preferences.ProblemSeverity;
 import org.eclipse.m2e.core.project.IMavenProjectImportResult;
@@ -83,13 +76,22 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 		if (preferencesManager != null && !preferencesManager.getPreferences().isImportMavenEnabled()) {
 			return false;
 		}
+
+		Set<File> existingProjectFolders = new HashSet<>();
+		for (IProject project : ProjectUtils.getMavenProjects()) {
+			existingProjectFolders.add(new File(project.getLocationURI()));
+		}
+
 		Set<MavenProjectInfo> files = getMavenProjectInfo(monitor);
 		if (files != null) {
 			Iterator<MavenProjectInfo> iter = files.iterator();
 			while (iter.hasNext()) {
 				MavenProjectInfo projectInfo = iter.next();
 				File dir = projectInfo.getPomFile() == null ? null : projectInfo.getPomFile().getParentFile();
-				if (dir != null && exclude(dir.toPath())) {
+				if (dir == null) {
+					continue;
+				}
+				if (exclude(dir.toPath()) || existingProjectFolders.contains(dir)) {
 					iter.remove();
 				}
 			}
@@ -143,9 +145,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 		subMonitor.setTaskName(IMPORTING_MAVEN_PROJECTS);
 		Set<MavenProjectInfo> files = getMavenProjectInfo(subMonitor.split(5));
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		Collection<IProject> projects = new LinkedHashSet<>();
 		Collection<MavenProjectInfo> toImport = new LinkedHashSet<>();
-		long lastWorkspaceStateSaved = getLastWorkspaceStateModified();
 		//Separate existing projects from new ones
 		for (MavenProjectInfo projectInfo : files) {
 			File pom = projectInfo.getPomFile();
@@ -166,10 +166,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				toImport.add(projectInfo);
 			} else {
 				IProject project = container.getProject();
-				boolean valid = !ProjectUtils.isJavaProject(project) || project.getFile(IJavaProject.CLASSPATH_FILE_NAME).exists();
-				if (ProjectUtils.isMavenProject(project) && valid) {
-					projects.add(container.getProject());
-				} else if (project != null) {
+				if (project != null) {
 					//Project doesn't have the Maven nature, so we (re)import it
 					digestStore.updateDigest(pom.toPath());
 					// need to delete project due to m2e failing to create if linked and not the same name
@@ -203,7 +200,6 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 					imported.add(result.getProject());
 				}
 				monitor2.setTaskName("Updating Maven project(s)");
-				updateProjects(imported, lastWorkspaceStateSaved, monitor2.split(projects.size()));
 				monitor2.done();
 			} else {
 				ProjectImportConfiguration importConfig = new ProjectImportConfiguration();
@@ -211,59 +207,11 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			}
 		}
 		subMonitor.setWorkRemaining(20);
-		updateProjects(projects, lastWorkspaceStateSaved, subMonitor.split(20));
 		subMonitor.done();
-	}
-
-	private long getLastWorkspaceStateModified() {
-		File workspaceStateFile = MavenPluginActivator.getDefault().getMavenProjectManager().getWorkspaceStateFile();
-		return workspaceStateFile.lastModified();
 	}
 
 	private File getProjectDirectory() {
 		return rootFolder;
-	}
-
-	private void updateProjects(Collection<IProject> projects, long lastWorkspaceStateSaved, IProgressMonitor monitor) throws CoreException {
-		if (projects.isEmpty()) {
-			return;
-		}
-		Iterator<IProject> iterator = projects.iterator();
-		while (iterator.hasNext()) {
-			IProject project = iterator.next();
-			project.open(monitor);
-			if (Platform.OS_WIN32.equals(Platform.getOS())) {
-				project.refreshLocal(IResource.DEPTH_ONE, monitor);
-				((Workspace) ResourcesPlugin.getWorkspace()).getRefreshManager().refresh(project);
-			} else {
-				project.refreshLocal(IResource.DEPTH_INFINITE, monitor);
-			}
-			if (!needsMavenUpdate(project, lastWorkspaceStateSaved)) {
-				iterator.remove();
-			}
-		}
-		if (projects.isEmpty()) {
-			return;
-		}
-
-		new WorkspaceJob("Update Maven project configuration") {
-			@Override
-			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
-				MavenBuildSupport mavenBuildSupport = new MavenBuildSupport();
-				mavenBuildSupport.setShouldCollectProjects(false);
-				for (IProject project : projects) {
-					if (monitor.isCanceled()) {
-						return Status.CANCEL_STATUS;
-					}
-					mavenBuildSupport.update(project, false, monitor);
-				}
-				return Status.OK_STATUS;
-			}
-		}.schedule();
-	}
-
-	private boolean needsMavenUpdate(IProject project, long lastWorkspaceStateSaved) {
-		return project.getFile(POM_FILE).getLocalTimeStamp() > lastWorkspaceStateSaved;
 	}
 
 	private Set<MavenProjectInfo> getMavenProjects(File directory, MavenModelManager modelManager, IProgressMonitor monitor) throws OperationCanceledException {
@@ -280,7 +228,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 	}
 
 	public boolean isMavenProject() {
-		return  isMavenProject(getProjectDirectory());
+		return isMavenProject(getProjectDirectory());
 	}
 
 	private boolean isMavenProject(File dir) {
@@ -311,5 +259,4 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			}
 		}.collectProjects(projects);
 	}
-
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImportNewProjectsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ImportNewProjectsTest.java
@@ -113,7 +113,7 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
 		verify(client, times(1)).sendEventNotification(argument.capture());
 		assertEquals(EventType.ProjectsImported, argument.getValue().getType());
-		assertEquals(((List<URI>) argument.getValue().getData()).size(), projects.length);
+		assertEquals(projects.length, ((List<URI>) argument.getValue().getData()).size());
 	}
 
 	@Test
@@ -156,6 +156,6 @@ public class ImportNewProjectsTest extends AbstractProjectsManagerBasedTest {
 		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
 		verify(client, times(1)).sendEventNotification(argument.capture());
 		assertEquals(EventType.ProjectsImported, argument.getValue().getType());
-		assertEquals(((List<URI>) argument.getValue().getData()).size(), projects.length);
+		assertEquals(projects.length, ((List<URI>) argument.getValue().getData()).size());
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
@@ -128,7 +128,7 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertFalse(module2.exists());
 
 		List<PublishDiagnosticsParams> diags = getClientRequests("publishDiagnostics");
-		assertEquals(9L, diags.size());
+		assertEquals(7L, diags.size());
 		assertEndsWith(diags.get(0).getUri(), "/module2");
 		assertEndsWith(diags.get(1).getUri(), "/multimodule3");
 		assertEndsWith(diags.get(2).getUri(), "/multimodule3/pom.xml");
@@ -140,8 +140,6 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertEquals(0L, diags.get(5).getDiagnostics().size());
 		assertEndsWith(diags.get(6).getUri(), "/AppTest.java");
 		assertEquals(0L, diags.get(6).getDiagnostics().size());
-		assertEndsWith(diags.get(7).getUri(), "/multimodule3");
-		assertEndsWith(diags.get(8).getUri(), "/multimodule3/pom.xml");
 	}
 
 	private void assertEndsWith(String target, String suffix) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
@@ -50,7 +50,6 @@ public abstract class AbstractMavenBasedTest extends AbstractProjectsManagerBase
 		return project;
 	}
 
-
 	protected void assertIsMavenProject(IProject project) {
 		assertNotNull(project);
 		assertTrue(project.getName() +" is missing the Maven nature", ProjectUtils.isMavenProject(project));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporterTest.java
@@ -23,13 +23,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
@@ -215,6 +219,15 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 		assertFalse(ProjectUtils.isJavaProject(project));
 		IFile bin = project.getFile("bin");
 		assertFalse(bin.getRawLocation().toFile().exists());
+	}
+
+	@Test
+	public void testImportedProjectWontBeApplied() throws Exception {
+		importSimpleJavaProject();
+		for (IPath rootFolder : preferenceManager.getPreferences().getRootPaths()) {
+			importer.initialize(rootFolder.toFile());
+			assertFalse("Won't apply for imported Eclipse project", importer.applies(new NullProgressMonitor()));
+		}
 	}
 
 	@After

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -473,7 +473,6 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 	}
 
 	@Test
-	@Ignore
 	public void testImportedProjectWontBeApplied() throws Exception {
 		importGradleProject("multi-module");
 		for (IPath rootFolder : preferenceManager.getPreferences().getRootPaths()) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
@@ -234,6 +234,17 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 		assertTrue(ProjectUtils.isMavenProject(project));
 	}
 
+	@Test
+	public void testChangedProjectShouldBeUpdated() throws Exception {
+		String name = "salut";
+		IProject salut = importMavenProject(name);
+		MavenBuildSupport mavenBuildSupport = new MavenBuildSupport();
+		assertFalse("New Project should not be updated", mavenBuildSupport.needsMavenUpdate(salut));
+		File pom = salut.getFile(MavenProjectImporter.POM_FILE).getRawLocation().toFile();
+		pom.setLastModified(System.currentTimeMillis() + 1000);
+		assertTrue("Changed should not be updated", mavenBuildSupport.needsMavenUpdate(salut));
+	}
+
 	protected void testNonStandardCompilerId(String projectName) throws Exception {
 		IProject project = importMavenProject(projectName);
 		assertIsJavaProject(project);


### PR DESCRIPTION
  - Check if the project is already in ProjectUtils.getJavaProjects() in the IProjectImporter.apply()
  - Move all the update project operation from importer to build support
  - Move all the update project operation test from importer test to build support test
  - Add tests to check importer won't be applied if the project is already in workspace

Signed-off-by: Sheng Chen <sheche@microsoft.com>