### PR TITLE
Favorite static imports are ignored if server launched without advancedOrganizeImportsSupport:true

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/OrganizeImportsCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/OrganizeImportsCommand.java
@@ -44,6 +44,7 @@ import org.eclipse.jdt.ls.core.internal.TextEditConverter;
 import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
+import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -180,7 +181,11 @@ public class OrganizeImportsCommand {
 				protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
 					CompilationUnit astRoot = context.getASTRoot();
 					OrganizeImportsOperation op = new OrganizeImportsOperation(unit, astRoot, true, false, true, null);
-					editRoot.addChild(op.createTextEdit(null));
+					TextEdit edit = op.createTextEdit(null);
+					TextEdit staticEdit = OrganizeImportsHandler.wrapStaticImports(edit, astRoot, unit);
+					if (staticEdit.getChildrenSize() > 0) {
+						editRoot.addChild(staticEdit);
+					}
 				}
 			};
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OrganizeImportsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OrganizeImportsHandler.java
@@ -110,7 +110,7 @@ public final class OrganizeImportsHandler {
 		return null;
 	}
 
-	private static TextEdit wrapStaticImports(TextEdit edit, CompilationUnit root, ICompilationUnit unit) throws MalformedTreeException, CoreException {
+	public static TextEdit wrapStaticImports(TextEdit edit, CompilationUnit root, ICompilationUnit unit) throws MalformedTreeException, CoreException {
 		String[] favourites = PreferenceManager.getPrefs(unit.getResource()).getJavaCompletionFavoriteMembers();
 		if (favourites.length == 0) {
 			return edit;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -59,6 +59,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.GenerateConstructorsHandler.Che
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.LspVariableBinding;
+import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
@@ -199,7 +200,12 @@ public class SourceAssistProcessor {
 		CompilationUnit astRoot = context.getASTRoot();
 		OrganizeImportsOperation op = new OrganizeImportsOperation(unit, astRoot, true, false, true, null);
 		try {
-			return op.createTextEdit(null);
+			TextEdit edit = op.createTextEdit(null);
+			TextEdit staticEdit = OrganizeImportsHandler.wrapStaticImports(edit, astRoot, unit);
+			if (staticEdit.getChildrenSize() > 0) {
+				return staticEdit;
+			}
+			return edit;
 		} catch (OperationCanceledException | CoreException e) {
 			JavaLanguageServerPlugin.logException("Resolve organize imports source action", e);
 		}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo6.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Foo6.java
@@ -1,0 +1,7 @@
+package org.sample;
+
+public class Foo6 {
+    List list = List.of(1).stream().collect(toList());
+    double i = abs(-1);
+    double pi = PI;
+}


### PR DESCRIPTION
Fixes #1422 

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>