### PR TITLE
Use default JVM when importing gradle project

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
@@ -41,6 +41,7 @@ import org.eclipse.jdt.launching.PropertyChangeEvent;
 import org.eclipse.jdt.launching.VMStandin;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 
 /**
@@ -239,6 +240,10 @@ public class JVMConfigurator implements IVMInstallChangedListener {
 				IJavaProject javaProject = JavaCore.create(project);
 				configureJVMSettings(javaProject, current);
 			}
+			ProjectsManager projectsManager = JavaLanguageServerPlugin.getProjectsManager();
+			if (projectsManager != null) {
+				projectsManager.updateProject(project, true);
+			}
 		}
 	}
 
@@ -279,6 +284,7 @@ public class JVMConfigurator implements IVMInstallChangedListener {
 		} else {
 			javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.DISABLED);
 		}
+
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -13,8 +13,9 @@
 package org.eclipse.jdt.ls.core.internal.managers;
 
 import java.io.File;
-import java.util.Optional;
+import java.nio.file.Paths;
 
+import org.eclipse.buildship.core.BuildConfiguration;
 import org.eclipse.buildship.core.GradleBuild;
 import org.eclipse.buildship.core.GradleCore;
 import org.eclipse.buildship.core.internal.CorePlugin;
@@ -55,10 +56,10 @@ public class GradleBuildSupport implements IBuildSupport {
 			return;
 		}
 		JavaLanguageServerPlugin.logInfo("Starting Gradle update for " + project.getName());
-		Optional<GradleBuild> build = GradleCore.getWorkspace().getBuild(project);
-		if (build.isPresent()) {
-			build.get().synchronize(monitor);
-		}
+		String projectPath = project.getLocation().toFile().getAbsolutePath();
+		BuildConfiguration buildConfiguration = GradleProjectImporter.getBuildConfiguration(Paths.get(projectPath));
+		GradleBuild build = GradleCore.getWorkspace().createBuild(buildConfiguration);
+		build.synchronize(monitor);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -34,7 +34,10 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -187,8 +190,14 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 
 	public static BuildConfiguration getBuildConfiguration(Path rootFolder) {
 		GradleDistribution distribution = getGradleDistribution(rootFolder);
-		String javaHomeStr = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaHome();
-		File javaHome = javaHomeStr == null ? null : new File(javaHomeStr);
+		IVMInstall javaDefaultRuntime = JavaRuntime.getDefaultVMInstall();
+		File javaHome;
+		if (javaDefaultRuntime != null && javaDefaultRuntime.getVMRunner(ILaunchManager.RUN_MODE) != null) {
+			javaHome = javaDefaultRuntime.getInstallLocation();
+		} else {
+			String javaHomeStr = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaHome();
+			javaHome = javaHomeStr == null ? null : new File(javaHomeStr);
+		}
 		File gradleUserHome = getGradleUserHomeFile();
 		List<String> gradleArguments = JavaLanguageServerPlugin.getPreferencesManager() != null ? JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGradleArguments() : new ArrayList<>();
 		List<String> gradleJvmArguments = JavaLanguageServerPlugin.getPreferencesManager() != null ? JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGradleJvmArguments() : new ArrayList<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -86,6 +85,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		this.preferenceManager = preferenceManager;
 	}
 
+	@Override
 	public void initializeProjects(final Collection<IPath> rootPaths, IProgressMonitor monitor) throws CoreException, OperationCanceledException {
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
 		cleanInvalidProjects(rootPaths, subMonitor.split(20));
@@ -106,6 +106,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		}
 	}
 
+	@Override
 	public Job updateWorkspaceFolders(Collection<IPath> addedRootPaths, Collection<IPath> removedRootPaths) {
 		JavaLanguageServerPlugin.sendStatus(ServiceStatus.Message, "Updating workspace folders: Adding " + addedRootPaths.size() + " folder(s), removing " + removedRootPaths.size() + " folders.");
 		Job[] removedJobs = Job.getJobManager().find(removedRootPaths);
@@ -221,6 +222,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return url;
 	}
 
+	@Override
 	public boolean isBuildFile(IResource resource) {
 		return buildSupports().filter(bs -> bs.isBuildFile(resource)).findAny().isPresent();
 	}
@@ -313,6 +315,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return project;
 	}
 
+	@Override
 	public Job updateProject(IProject project, boolean force) {
 		if (project == null || (!ProjectUtils.isMavenProject(project) && !ProjectUtils.isGradleProject(project))) {
 			return null;
@@ -352,6 +355,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return job;
 	}
 
+	@Override
 	public Optional<IBuildSupport> getBuildSupport(IProject project) {
 		return buildSupports().filter(bs -> bs.applies(project)).findFirst();
 	}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/1426

You can test the following project: 
[gradle-test.zip](https://github.com/eclipse/eclipse.jdt.ls/files/4565942/gradle-test.zip)

VS Code settings: https://github.com/redhat-developer/vscode-java/issues/1426#issue-610003342

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>