### PR TITLE
highlight QualifiedName together in packages

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
@@ -113,6 +114,16 @@ public class SemanticTokensVisitor extends ASTVisitor {
         int length = node.getLength();
         SemanticToken token = new SemanticToken(offset, length, tokenType, modifiers);
         tokens.add(token);
+    }
+
+    @Override
+    public boolean visit(QualifiedName node) {
+        IBinding binding = node.resolveBinding();
+        if (binding != null && binding.getKind() == IBinding.PACKAGE) {
+            addToken(node, TokenType.NAMESPACE, NO_MODIFIERS);
+            return false;
+        }
+        return super.visit(node);
     }
 
     @Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
@@ -151,6 +151,24 @@ public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest 
 		assertToken(decodedTokens, legend, 4, 11, 6, "type", Arrays.asList());
 	}
 
+	@Test
+	public void testSemanticTokens_packages() throws JavaModelException {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.util.List;\n");
+		buf.append("import java.nio.*;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		SemanticTokensLegend legend = SemanticTokensCommand.getLegend();
+		SemanticTokens tokens = SemanticTokensCommand.provide(JDTUtils.toURI(cu));
+		Map<Integer, Map<Integer, int[]>> decodedTokens = decode(tokens);
+		assertToken(decodedTokens, legend, 1, 7, 9, "namespace", Arrays.asList());
+		assertToken(decodedTokens, legend, 2, 7, 8, "namespace", Arrays.asList());
+	}
+
 	private void assertModifiers(List<String> tokenModifiers, int encodedModifiers, List<String> modifierStrings) {
 		int cnt = 0;
 		for (int i=0; i<tokenModifiers.size(); i++) {
@@ -178,7 +196,7 @@ public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest 
 		int total = data.size() / 5;
 		Map<Integer, Map<Integer, int[]>> decodedTokens = new HashMap<>();
 		int currentLine = 0;
-        int currentColumn = 0;
+		int currentColumn = 0;
 		for(int i = 0; i<total; i++) {
 			int offset = 5 * i;
 			int deltaLine = data.get(offset).intValue();


### PR DESCRIPTION
A fix for #1434 

Instead of highlighting each segment (SimpleName), the full qualified name of a package is highlighted together, e.g "java.util". 

### Behavior changes:
#### Previous
import **java**(namespace).**util**(namespace).**List**(type);

3 tokens. So the dot between "java" and "util" is not highlighted as namespace.

#### Now
import **java.util**(namespace).**List**(type);

2 tokens. dots within the full qualified name are also highlighted. 