### PR TITLE
Provide 'clean build' quickfix

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -641,7 +641,7 @@ public class QuickFixProcessor {
 		// ConfigureProblemSeveritySubProcessor.addConfigureProblemSeverityProposal(context,
 		// problem, proposals);
 
-		// Add proposals related with project steup, like: clean build, clean workspace, etc...
+		// Add proposals related with project setup, like: clean build, clean workspace, etc...
 		switch(id) {
 			case IProblem.ImportNotFound:
 				CleanBuildSubProcessor.cleanBuildForUnresolvedImportProposals(context, problem, proposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.CleanBuildSubProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.GetterSetterCorrectionSubProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.JavadocTagsSubProcessor;
@@ -639,5 +640,12 @@ public class QuickFixProcessor {
 		// }
 		// ConfigureProblemSeveritySubProcessor.addConfigureProblemSeverityProposal(context,
 		// problem, proposals);
+
+		// Add proposals related with project steup, like: clean build, clean workspace, etc...
+		switch(id) {
+			case IProblem.ImportNotFound:
+			CleanBuildSubProcessor.cleanBuildForUnresolvedImportProposals(context, problem, proposals);
+				break;
+		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -644,8 +644,8 @@ public class QuickFixProcessor {
 		// Add proposals related with project steup, like: clean build, clean workspace, etc...
 		switch(id) {
 			case IProblem.ImportNotFound:
-			CleanBuildSubProcessor.cleanBuildForUnresolvedImportProposals(context, problem, proposals);
-				break;
+				CleanBuildSubProcessor.cleanBuildForUnresolvedImportProposals(context, problem, proposals);
+					break;
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CleanBuildSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CleanBuildSubProcessor.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corrections.proposals;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
+import org.eclipse.lsp4j.CodeActionKind;
+
+public class CleanBuildSubProcessor {
+    public static void cleanBuildForUnresolvedImportProposals(IInvocationContext context, IProblemLocationCore problem,
+			Collection<ChangeCorrectionProposal> proposals) {
+		final ICompilationUnit cu= context.getCompilationUnit();
+		ASTNode coveringNode = problem.getCoveringNode(context.getASTRoot());
+		if (coveringNode instanceof Name) {
+			String fullyQualifiedName = ((Name) coveringNode).getFullyQualifiedName();
+			try {
+				IType type = cu.getJavaProject().findType(fullyQualifiedName);
+				if (type != null) {
+					ICompilationUnit compilationUnit = (ICompilationUnit) type.getAncestor(IJavaElement.COMPILATION_UNIT);
+					IClassFile cf = (IClassFile) type.getAncestor(IJavaElement.CLASS_FILE);
+					if (compilationUnit != null && cf == null) {
+						proposals.add(new CUCorrectionCommandProposal("Execute 'clean build'", CodeActionKind.QuickFix, cu, IProposalRelevance.NO_SUGGESSTIONS_AVAILABLE, "java.workspace.compile", Arrays.asList(Boolean.TRUE)));
+					}
+				}
+			} catch (JavaModelException e) {
+				// do nothing
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CleanBuildSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/CleanBuildSubProcessor.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
 import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -31,6 +32,10 @@ import org.eclipse.lsp4j.CodeActionKind;
 public class CleanBuildSubProcessor {
     public static void cleanBuildForUnresolvedImportProposals(IInvocationContext context, IProblemLocationCore problem,
 			Collection<ChangeCorrectionProposal> proposals) {
+		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isClientBuildCommandSupported()) {
+			return;
+		}
+		
 		final ICompilationUnit cu= context.getCompilationUnit();
 		ASTNode coveringNode = problem.getCoveringNode(context.getASTRoot());
 		if (coveringNode instanceof Name) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -221,6 +221,10 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("clientDocumentSymbolProvider", "false").toString());
 	}
 
+	public boolean isClientBuildCommandSupported() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("buildCommandSupport", "false").toString());
+	}
+
 	public boolean isSupportsCompletionDocumentationMarkdown() {
 		//@formatter:off
 		return v3supported && capabilities.getTextDocument().getCompletion() != null

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/java/Foo3.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/java/Foo3.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.sample.TestImport;
 
 public class Foo3 {
 
@@ -18,4 +19,9 @@ public class Foo3 {
 		System.out.println(this.properties);
 		System.out.println(util);
 	}
+
+	public void importTest() {
+		// TestImport testImport = new TestImport();
+	}
 }
+ 

--- a/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/TestImport.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/salut/src/main/java/org/sample/TestImport.java
@@ -1,0 +1,5 @@
+package org.sample;
+
+public class TestImport {
+    
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/CleanBuildQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/CleanBuildQuickFixTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Test;
+
+public class CleanBuildQuickFixTest extends AbstractQuickFixTest {
+
+	@Test
+	public void testCleanBuildForUnresolvedImport() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+
+		Path compilationUnitPath = Paths.get(project.getRawLocation().toOSString(), "src", "main", "java", "java", "Foo3.java");
+		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(compilationUnitPath.toUri().toString());
+		
+		Path classesPath = Paths.get(project.getRawLocation().toOSString(), "target", "classes");
+		File classDir = classesPath.toFile();
+		FileUtils.deleteDirectory(classDir);
+
+		IFile sourceFile = project.getFile("src/main/java/java/Foo3.java");
+		String content = ResourceUtils.getContent(sourceFile);
+		content = content.replace("// TestImport testImport = new TestImport();", "TestImport testImport = new TestImport();");
+		ResourceUtils.setContent(sourceFile, content);
+		cu.getUnderlyingResource().refreshLocal(IResource.DEPTH_ZERO, monitor);
+		waitForBackgroundJobs();
+
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActionsForIMarker(cu);
+		Expected e1 = new Expected("Execute 'clean build'", "");
+		for (Either<Command, CodeAction> c : codeActions) {
+			if (Objects.equals("Execute 'clean build'", getTitle(c))) {
+				Command commandInCodeAction = c.getRight().getCommand();
+				assertEquals("java.workspace.compile", commandInCodeAction.getCommand());
+
+				List<Object> argumentList = commandInCodeAction.getArguments();
+				assertEquals(1, argumentList.size());
+				assertEquals(true, argumentList.get(0));
+				return;
+			}
+		}
+		fail(e1.name + " not found");
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToTypeDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToTypeDefinitionHandlerTest.java
@@ -60,7 +60,7 @@ public class NavigateToTypeDefinitionHandlerTest extends AbstractProjectsManager
 
 	@Test
 	public void testLocalVariable() throws Exception {
-		testClass("java.Foo3", 18, 24);
+		testClass("java.Foo3", 19, 24);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -171,6 +171,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		when(clientPreferences.isAdvancedGenerateAccessorsSupported()).thenReturn(true);
 		when(clientPreferences.isGenerateConstructorsPromptSupported()).thenReturn(true);
 		when(clientPreferences.isGenerateDelegateMethodsPromptSupported()).thenReturn(true);
+		when(clientPreferences.isClientBuildCommandSupported()).thenReturn(true);
 		return clientPreferences;
 	}
 


### PR DESCRIPTION
Somehow mitigate https://github.com/redhat-developer/vscode-java/issues/314
We can leverage the quickfix to help user discover the command `clean build` in more scenarios.

### Step to validate

- New a Type in source, meanwhile add related import statement
- delete the imported class file
- Change the document and save, this will trigger `WorkspaceDiagnosticHnadler.resourceChanged()`
- trigger 'clean build' in quickfix to fix it.

![demo](https://user-images.githubusercontent.com/6193897/81783120-78bde800-952d-11ea-8ea3-25dd7601c5a4.gif)

client: https://github.com/redhat-developer/vscode-java/pull/1450

Signed-off-by: Sheng Chen <sheche@microsoft.com>