### PR TITLE
Delete project root folder should clean up the project

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -257,18 +257,39 @@ public final class ResourceUtils {
 		if (path == null) {
 			return null;
 		}
+
+		String baseName = path.lastSegment();
+		return toGlobPattern(path, !baseName.endsWith(".jar") && !baseName.endsWith(".zip"));
+	}
+
+	/**
+	 * Convert an {@link IPath} to a glob pattern.
+	 *
+	 * @param path
+	 *            the path to convert
+	 * @param recursive
+	 *            whether to end the glob with "/**"
+	 * @return a glob pattern prefixed with the path
+	 */
+	public static String toGlobPattern(IPath path, boolean recursive) {
+		if (path == null) {
+			return null;
+		}
+
 		String globPattern = path.toPortableString();
 		if (path.getDevice() != null) {
 			//This seems pretty hack-ish: need to remove device as it seems to break
 			// file detection, at least on vscode
 			globPattern = globPattern.replace(path.getDevice(), "**");
 		}
-		if (!globPattern.endsWith(".jar") && !globPattern.endsWith(".zip")) {
+
+		if (recursive) {
 			if (!globPattern.endsWith("/")) {
 				globPattern += "/";
 			}
 			globPattern += "**";
 		}
+
 		return globPattern;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -34,6 +34,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
@@ -128,7 +129,7 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 			if (projectsManager.isBuildLikeFileName(resource.getName())) {
 				cleanUpDiagnostics(resource);
 				if(!resource.getParent().isAccessible()) { // Clean up the project folder diagnostics.
-					cleanUpDiagnostics(resource.getParent(), true);
+					cleanUpDiagnostics(resource.getParent(), Platform.OS_WIN32.equals(Platform.getOS()));
 				}
 			}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -79,6 +79,11 @@ public class GradleBuildSupport implements IBuildSupport {
 		return false;
 	}
 
+	@Override
+	public boolean isBuildLikeFileName(String fileName) {
+		return fileName.endsWith(GRADLE_SUFFIX) || fileName.equals(GRADLE_PROPERTIES);
+	}
+
 	/**
 	 * delete stale gradle project preferences
 	 *

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -32,6 +32,10 @@ public interface IBuildSupport {
 
 	boolean isBuildFile(IResource resource);
 
+	default boolean isBuildLikeFileName(String fileName) {
+		return false;
+	}
+
 	/**
 	 *
 	 * @param resource

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
@@ -53,6 +53,11 @@ public interface IProjectsManager {
 	boolean isBuildFile(IResource resource);
 
 	/**
+	 * Check whether the file name is like a build file.
+	 */
+	boolean isBuildLikeFileName(String fileName);
+
+	/**
 	 * Get the build support provided by the given project.
 	 */
 	Optional<IBuildSupport> getBuildSupport(IProject project);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -128,6 +128,11 @@ public class MavenBuildSupport implements IBuildSupport {
 				&& resource.getProject().equals(resource.getParent());
 	}
 
+	@Override
+	public boolean isBuildLikeFileName(String fileName) {
+		return fileName.equals("pom.xml");
+	}
+
 	public boolean shouldCollectProjects() {
 		return shouldCollectProjects;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -225,6 +225,10 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return buildSupports().filter(bs -> bs.isBuildFile(resource)).findAny().isPresent();
 	}
 
+	public boolean isBuildLikeFileName(String fileName) {
+		return buildSupports().filter(bs -> bs.isBuildLikeFileName(fileName)).findAny().isPresent();
+	}
+
 	private IProjectImporter getImporter(File rootFolder, IProgressMonitor monitor) throws OperationCanceledException, CoreException {
 		Collection<IProjectImporter> importers = importers();
 		SubMonitor subMonitor = SubMonitor.convert(monitor, importers.size());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -275,6 +275,11 @@ public class StandardProjectsManager extends ProjectsManager {
 	}
 
 	@Override
+	public boolean isBuildLikeFileName(String fileName) {
+		return buildSupports().filter(bs -> bs.isBuildLikeFileName(fileName)).findAny().isPresent();
+	}
+
+	@Override
 	public void prepareToSave(ISaveContext context) throws CoreException {
 		if (context.getKind() == ISaveContext.FULL_SAVE) {
 			GradleBuildSupport.saveModels();

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse</groupId>
+    <artifactId>multimodule3</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse</groupId>
+  <artifactId>module1</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>module1</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/src/main/java/org/eclipse/App.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/src/main/java/org/eclipse/App.java
@@ -1,0 +1,9 @@
+package org.eclipse;
+
+public class App {
+    public static final String GREETING = "Hello World!";
+
+    public static void main(String[] args) {
+        System.out.println(GREETING);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/src/test/java/org/eclipse/AppTest.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module1/src/test/java/org/eclipse/AppTest.java
@@ -1,0 +1,12 @@
+package org.eclipse;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AppTest {
+    @Test
+    public void testApp() {
+        assertTrue(true);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse</groupId>
+    <artifactId>multimodule3</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse</groupId>
+  <artifactId>module2</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>module1</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/src/main/java/org/eclipse/App.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/src/main/java/org/eclipse/App.java
@@ -1,0 +1,9 @@
+package org.eclipse;
+
+public class App {
+    public static final String GREETING = "Hello World!";
+
+    public static void main(String[] args) {
+        System.out.println(GREETING);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/src/test/java/org/eclipse/AppTest.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module2/src/test/java/org/eclipse/AppTest.java
@@ -1,0 +1,12 @@
+package org.eclipse;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AppTest {
+    @Test
+    public void testApp() {
+        assertTrue(true);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.eclipse</groupId>
+  <artifactId>multimodule3</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>multimodule3</name>
+  
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+  </modules>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -71,6 +71,7 @@ import org.eclipse.lsp4j.SynchronizationCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
+import org.eclipse.lsp4j.WatchKind;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEditCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -242,6 +243,15 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		importProjects(Arrays.asList("maven/salut", "gradle/simple-gradle"));
 		newEmptyProject();
 		List<FileSystemWatcher> watchers = projectsManager.registerWatchers();
+		// 8 basic + 3 project roots
+		assertEquals("Unexpected watchers:\n" + toString(watchers), 11, watchers.size());
+		List<FileSystemWatcher> projectWatchers = watchers.subList(8, 11);
+		assertTrue(projectWatchers.get(0).getGlobPattern().endsWith("/TestProject"));
+		assertTrue(WatchKind.Delete == projectWatchers.get(0).getKind());
+		assertTrue(projectWatchers.get(1).getGlobPattern().endsWith("/maven/salut"));
+		assertTrue(projectWatchers.get(2).getGlobPattern().endsWith("/gradle/simple-gradle"));
+
+		watchers = watchers.subList(0, 8);
 		Collections.sort(watchers, new Comparator<FileSystemWatcher>() {
 
 			@Override
@@ -249,7 +259,6 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 				return o1.getGlobPattern().compareTo(o2.getGlobPattern());
 			}
 		});
-		assertEquals("Unexpected watchers:\n" + toString(watchers), 8, watchers.size());
 		assertEquals("**/*.gradle", watchers.get(0).getGlobPattern());
 		assertEquals("**/*.java", watchers.get(1).getGlobPattern());
 		assertEquals("**/.classpath", watchers.get(2).getGlobPattern());
@@ -279,6 +288,13 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		verify(client, times(1)).registerCapability(any());
 		List<FileSystemWatcher> newWatchers = projectsManager.registerWatchers();
 		verify(client, times(1)).registerCapability(any());
+		assertEquals("Unexpected watchers:\n" + toString(watchers), 11, newWatchers.size());
+		projectWatchers = newWatchers.subList(8, 11);
+		assertTrue(projectWatchers.get(0).getGlobPattern().endsWith("/TestProject"));
+		assertTrue(projectWatchers.get(1).getGlobPattern().endsWith("/maven/salut"));
+		assertTrue(projectWatchers.get(2).getGlobPattern().endsWith("/gradle/simple-gradle"));
+
+		newWatchers = watchers.subList(0, 8);
 		Collections.sort(newWatchers, new Comparator<FileSystemWatcher>() {
 
 			@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
@@ -129,19 +129,27 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 
 		List<PublishDiagnosticsParams> diags = getClientRequests("publishDiagnostics");
 		assertEquals(9L, diags.size());
-		assertTrue(diags.get(0).getUri().endsWith("/module2/"));
-		assertTrue(diags.get(1).getUri().endsWith("/multimodule3/"));
-		assertTrue(diags.get(2).getUri().endsWith("/multimodule3/pom.xml"));
-		assertTrue(diags.get(3).getUri().endsWith("/module2/pom.xml"));
+		assertEndsWith(diags.get(0).getUri(), "/module2");
+		assertEndsWith(diags.get(1).getUri(), "/multimodule3");
+		assertEndsWith(diags.get(2).getUri(), "/multimodule3/pom.xml");
+		assertEndsWith(diags.get(3).getUri(), "/module2/pom.xml");
 		assertEquals(0L, diags.get(3).getDiagnostics().size());
-		assertTrue(diags.get(4).getUri().endsWith("/module2/"));
+		assertEndsWith(diags.get(4).getUri(), "/module2");
 		assertEquals(0L, diags.get(4).getDiagnostics().size());
-		assertTrue(diags.get(5).getUri().endsWith("/App.java"));
+		assertEndsWith(diags.get(5).getUri(), "/App.java");
 		assertEquals(0L, diags.get(5).getDiagnostics().size());
-		assertTrue(diags.get(6).getUri().endsWith("/AppTest.java"));
+		assertEndsWith(diags.get(6).getUri(), "/AppTest.java");
 		assertEquals(0L, diags.get(6).getDiagnostics().size());
-		assertTrue(diags.get(7).getUri().endsWith("/multimodule3/"));
-		assertTrue(diags.get(8).getUri().endsWith("/multimodule3/pom.xml"));
+		assertEndsWith(diags.get(7).getUri(), "/multimodule3");
+		assertEndsWith(diags.get(8).getUri(), "/multimodule3/pom.xml");
+	}
+
+	private void assertEndsWith(String target, String suffix) {
+		if (target.endsWith("/")) {
+			target = target.substring(0, target.length() - 1);
+		}
+
+		assertTrue(target.endsWith(suffix));
 	}
 
 	private void openDocument(ICompilationUnit cu, String content, int version) {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix redhat-developer/vscode-java#1446

Root Cause:
The language server didn't watch on the project root folder, so it never receives the delete notification. Reload window will restore the existing project.