### PR TITLE
Can get VM installation path through ProjectCommand.getProjectSettings()

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -67,7 +67,7 @@ public class ProjectCommand {
 	 *                        ["org.eclipse.jdt.core.compiler.compliance",
 	 *                        "org.eclipse.jdt.core.compiler.source"].
 	 *                        Besides the options defined in JavaCore, the following keys can also be used:
-	 *                        - "org.eclipse.jdt.ls.vm.location": Get the location of the VM assigned to build the given Java project
+	 *                        - "org.eclipse.jdt.ls.core.vm.location": Get the location of the VM assigned to build the given Java project
 	 * @return A <code>Map<string, string></code> with all the setting keys and
 	 *         their values.
 	 * @throws CoreException

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
@@ -63,10 +66,25 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
     }
 
     @Test
+    public void testGetProjectVMInstallation() throws Exception {
+        importProjects("maven/salut2");
+        IProject project = WorkspaceHelper.getProject("salut2");
+        String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList(ProjectCommand.VM_LOCATION);
+        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+
+        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(uriString);
+        IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
+        assertNotNull(vmInstall);
+        File location = vmInstall.getInstallLocation();
+        assertNotNull(location);
+        assertEquals(location.getAbsolutePath(), options.get(ProjectCommand.VM_LOCATION));
+    }
+
+    @Test
     public void testGetProjectFromUri() throws Exception {
         importProjects("maven/salut");
         IProject project = WorkspaceHelper.getProject("salut");
-
         String javaSource = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
         IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
         assertNotNull("Can get project from java file uri", javaProject);


### PR DESCRIPTION
See: https://github.com/redhat-developer/vscode-java/pull/1464

Added a customized key in ProjectCommand.getProjectSettings() to get the VM installation path.

Signed-off-by: Sheng Chen <sheche@microsoft.com>