### PR TITLE
Correctly assign the queueLength in WrapperValidator

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
@@ -66,7 +66,7 @@ public class WrapperValidator {
 
 	public WrapperValidator(int queueLength) {
 		this.hashProvider = new HashProvider();
-		queueLength = queueLength;
+		this.queueLength = queueLength;
 	}
 
 	public WrapperValidator() {


### PR DESCRIPTION
Fix a typo here. The value of `queueLength` was not assigned actually.

Signed-off-by: Sheng Chen <sheche@microsoft.com>