### PR TITLE
Wait for jobs to complete when resolving the classpaths

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -117,6 +117,27 @@ public class ProjectCommandTest extends AbstractProjectsManagerBasedTest {
     }
 
     @Test
+    public void testGetClasspathsForMavenWhenUpdating() throws Exception {
+        importProjects("maven/classpathtest");
+        IProject project = WorkspaceHelper.getProject("classpathtest");
+        String uriString = project.getFile("src/main/java/main/App.java").getLocationURI().toString();
+        ClasspathOptions options = new ClasspathOptions();
+        options.scope = "test";
+
+        projectsManager.updateProject(project, true);
+
+        for (int i = 0; i < 10; i++) {
+            ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+            assertEquals(4, result.classpaths.length);
+            assertEquals(0, result.modulepaths.length);
+            boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {
+                return element.indexOf("junit") > -1;
+            });
+            assertTrue(containsJunit);
+        }
+    }
+
+    @Test
     public void testGetClasspathsForGradle() throws Exception {
         importProjects("gradle/simple-gradle");
         IProject project = WorkspaceHelper.getProject("simple-gradle");


### PR DESCRIPTION
When I'm working for this PR: https://github.com/redhat-developer/vscode-java/pull/1484, I found that the test case `getClasspath` will randomly fail, see: https://travis-ci.org/github/redhat-developer/vscode-java/jobs/697117335

It's because if we try to get the classpath when the m2e is updating the projects, the return results might only contain the source classes without dependency jars. so I add a wait here.

Signed-off-by: Sheng Chen <sheche@microsoft.com>