### PR TITLE
Update to Eclipse 4.16

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractConstantRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractConstantRefactoring.java
@@ -293,7 +293,7 @@ public class ExtractConstantRefactoring extends Refactoring {
 		try {
 			pm.beginTask("", 7); //$NON-NLS-1$
 
-			RefactoringStatus result = Checks.validateEdit(fCu, getValidationContext());
+			RefactoringStatus result = Checks.validateEdit(fCu, getValidationContext(), pm);
 			if (result.hasFatalError()) {
 				return result;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractFieldRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractFieldRefactoring.java
@@ -246,7 +246,7 @@ public class ExtractFieldRefactoring extends Refactoring {
 		try {
 			pm.beginTask("", 16); //$NON-NLS-1$
 
-			RefactoringStatus result = Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCu }), getValidationContext());
+			RefactoringStatus result = Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCu }), getValidationContext(), pm);
 			if (result.hasFatalError()) {
 				return result;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -338,7 +338,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 		}
 
 		IFile[] changedFiles = ResourceUtil.getFiles(new ICompilationUnit[] { fCUnit });
-		result.merge(Checks.validateModifiesFiles(changedFiles, getValidationContext()));
+		result.merge(Checks.validateModifiesFiles(changedFiles, getValidationContext(), pm));
 		if (result.hasFatalError()) {
 			return result;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -622,7 +622,7 @@ public class ExtractTempRefactoring extends Refactoring {
 		try {
 			pm.beginTask("", 6); //$NON-NLS-1$
 
-			RefactoringStatus result = Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCu }), getValidationContext());
+			RefactoringStatus result = Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCu }), getValidationContext(), pm);
 			if (result.hasFatalError()) {
 				return result;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -1493,8 +1493,13 @@ public final class ReorgPolicyFactory {
 				if (fChangeManager == null) {
 					fChangeManager= createChangeManager(new SubProgressMonitor(pm, 1), new RefactoringStatus());
 					// TODO: non-CU matches silently dropped
-					RefactoringStatus status= Checks.validateModifiesFiles(getAllModifiedFiles(), null);
-					if (status.hasFatalError()) {
+					RefactoringStatus status;
+					try {
+						status = Checks.validateModifiesFiles(getAllModifiedFiles(), null, pm);
+						if (status.hasFatalError()) {
+							fChangeManager = new TextChangeManager();
+						}
+					} catch (CoreException e) {
 						fChangeManager= new TextChangeManager();
 					}
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
@@ -417,7 +417,7 @@ public class SelfEncapsulateFieldRefactoring extends Refactoring {
 
 		sub.done();
 		IFile[] filesToBeModified = ResourceUtil.getFiles(fChangeManager.getAllCompilationUnits());
-		result.merge(Checks.validateModifiesFiles(filesToBeModified, getValidationContext()));
+		result.merge(Checks.validateModifiesFiles(filesToBeModified, getValidationContext(), pm));
 		if (result.hasFatalError()) {
 			return result;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
@@ -185,7 +185,7 @@ public class SurroundWithTryCatchRefactoring extends Refactoring {
 	 */
 	@Override
 	public RefactoringStatus checkFinalConditions(IProgressMonitor pm) throws CoreException {
-		return Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCUnit }), getValidationContext());
+		return Checks.validateModifiesFiles(ResourceUtil.getFiles(new ICompilationUnit[] { fCUnit }), getValidationContext(), pm);
 	}
 
 	/* non Java-doc

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -894,8 +894,9 @@ public class RefactorProcessor {
 					return null;
 				}
 				boolean convertForLoops = isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+				boolean checkIfLoopVarUsed = isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_ONLY_IF_LOOP_VAR_USED);
 				return ConvertLoopFixCore.createCleanUp(compilationUnit, convertForLoops, convertForLoops,
-						isEnabled(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL) && isEnabled(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_LOCAL_VARIABLES));
+						isEnabled(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL) && isEnabled(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_LOCAL_VARIABLES), checkIfLoopVarUsed);
 			}
 
 			@Override
@@ -903,6 +904,9 @@ public class RefactorProcessor {
 				List<String> result = new ArrayList<>();
 				if (isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_TO_ENHANCED)) {
 					result.add(MultiFixMessages.Java50CleanUp_ConvertToEnhancedForLoop_description);
+					if (isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_ONLY_IF_LOOP_VAR_USED)) {
+						result.add(MultiFixMessages.Java50CleanUp_ConvertLoopOnlyIfLoopVarUsed_description);
+					}
 				}
 				return result.toArray(new String[result.size()]);
 			}
@@ -919,6 +923,15 @@ public class RefactorProcessor {
 					buf.append("for (int i = 0; i < ids.length; i++) {\n"); //$NON-NLS-1$
 					buf.append("    double value= ids[i] / 2; \n"); //$NON-NLS-1$
 					buf.append("    System.out.println(value);\n"); //$NON-NLS-1$
+					buf.append("}\n"); //$NON-NLS-1$
+				}
+				if (isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_TO_ENHANCED) && !isEnabled(CleanUpConstants.CONTROL_STATMENTS_CONVERT_FOR_LOOP_ONLY_IF_LOOP_VAR_USED)) {
+					buf.append("for (int id : ids) {\n"); //$NON-NLS-1$
+					buf.append("    System.out.println(\"here\");\n"); //$NON-NLS-1$
+					buf.append("}\n"); //$NON-NLS-1$
+				} else {
+					buf.append("for (int i = 0; i < ids.length; i++) {\n"); //$NON-NLS-1$
+					buf.append("    System.out.println(\"here\");\n"); //$NON-NLS-1$
 					buf.append("}\n"); //$NON-NLS-1$
 				}
 				return buf.toString();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/highlighting/SemanticHighlightings.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/highlighting/SemanticHighlightings.java
@@ -46,7 +46,6 @@ import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
-import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingsCore;
 import org.eclipse.jdt.internal.ui.javaeditor.SemanticToken;
 
 import com.google.common.collect.ImmutableListMultimap;
@@ -58,7 +57,7 @@ import com.google.common.collect.ListMultimap;
  * @since 3.0
  */
 @SuppressWarnings("restriction")
-public class SemanticHighlightings extends SemanticHighlightingsCore {
+public class SemanticHighlightings {
 
 	private static final ImmutableListMultimap.Builder<String, String> SCOPES_BUILDER = ImmutableListMultimap.builder();
 

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -12,15 +12,15 @@
             <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
             <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
             <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
-            <repository location="https://download.eclipse.org/tools/orbit/R-builds/R20190602212107/repository"/>
+            <repository location="https://download.eclipse.org/tools/orbit/R-builds/R20200529191137/repository"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/buildship/updates/e415/milestones/3.x/3.1.4.v20200326-1311-m/"/>
+            <repository location="https://download.eclipse.org/buildship/updates/e415/releases/3.x/3.1.4.v20200326-1743/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-	    <repository location="https://download.eclipse.org/technology/m2e/milestones/1.15/1.15.0.20200304-0718/"/>
+	    <repository location="https://download.eclipse.org/technology/m2e/releases/1.16.0/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
@@ -30,12 +30,9 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.15/R-4.15-202003050155/"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2019-09/"/>
+            <repository location="https://download.eclipse.org/releases/2020-06/202006171000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>
@@ -44,10 +41,6 @@
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.9.0/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
-        </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <repository location="https://download.eclipse.org/eclipse/updates/4.15-P-builds/P20200318-0455/"/>
-            <unit id="org.eclipse.jdt.java14patch.feature.group" version="0.0.0"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -56,11 +56,6 @@
 										<version>0.0.0</version>
 										<type>eclipse-feature</type>
 									</dependency>
-									<dependency>
-										<artifactId>org.eclipse.jdt.java14patch</artifactId>
-										<version>0.0.0</version>
-										<type>eclipse-feature</type>
-									</dependency>
 								</dependencies>
 							</configuration>
 						</plugin>


### PR DESCRIPTION
Eclipse 4.16 bits are available from stable URLs. We can get rid of the java 14 patch dependency.
Some small changes in org.eclipse.jdt.internal.corext.refactoring.Checks require a few adjustments on the jdt.ls side.