### PR TITLE
Optimize default VM management to avoid unnecessary project updates

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
@@ -117,7 +117,7 @@ public abstract class BaseInitHandler {
 			if (!isWorkspaceInitialized()) {
 				// We don't care about triggering a full build here, like in onDidChangeConfiguration
 				try {
-					JVMConfigurator.configureDefaultVM(prefs);
+					JVMConfigurator.configureJVMs(prefs);
 					registerWorkspaceInitialized();
 				} catch (CoreException e) {
 					JavaLanguageServerPlugin.logException("Failed to configure Java Runtimes", e);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -428,7 +428,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		syncCapabilitiesToSettings();
 		boolean jvmChanged = false;
 		try {
-			jvmChanged = jvmConfigurator.configureDefaultVM(preferenceManager.getPreferences());
+			jvmChanged = jvmConfigurator.configureJVMs(preferenceManager.getPreferences());
 		} catch (Exception e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}

--- a/org.eclipse.jdt.ls.tests.syntaxserver/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ls.tests.syntaxserver/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JVMConfiguratorTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JVMConfiguratorTest.java
@@ -71,10 +71,8 @@ public class JVMConfiguratorTest extends AbstractInvisibleProjectBasedTest {
 
 	@Test
 	public void testDefaultVM() throws CoreException {
-		Preferences prefs = new Preferences();
 		String javaHome = new File(TestVMType.getFakeJDKsLocation(), "9").getAbsolutePath();
-		prefs.setJavaHome(javaHome);
-		boolean changed = JVMConfigurator.configureDefaultVM(prefs);
+		boolean changed = JVMConfigurator.configureDefaultVM(javaHome);
 		IVMInstall newDefaultVM = JavaRuntime.getDefaultVMInstall();
 		assertTrue("A VM hasn't been changed", changed);
 		assertNotEquals(originalVm, newDefaultVM);


### PR DESCRIPTION
With the previous code, the java.home was initially prepared to be used as default VM, even though there was a default runtime set, potentially triggering unnecessary full builds 