### PR TITLE
fill additionalTextEdits during completionItem/resolve 

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -91,10 +91,10 @@ public class AnonymousTypeCompletionProposal {
 	 * @see JavaTypeCompletionProposal#updateReplacementString(IDocument,char,int,ImportRewrite)
 	 */
 	public String updateReplacementString(IDocument document, int offset, ImportRewrite impRewrite) throws CoreException, BadLocationException {
-		String newBody = createNewBody(impRewrite);
-		if (newBody == null) {
-			return null;
-		}
+		// Construct empty body for performance concern
+		// See https://github.com/microsoft/language-server-protocol/issues/1032#issuecomment-648748013
+		String newBody = "{\n\t${0}\n}";
+
 		StringBuffer buf = new StringBuffer("new A()"); //$NON-NLS-1$
 		buf.append(newBody);
 		// use the code formatter

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -93,9 +93,9 @@ public class AnonymousTypeCompletionProposal {
 	public String updateReplacementString(IDocument document, int offset, ImportRewrite impRewrite) throws CoreException, BadLocationException {
 		// Construct empty body for performance concern
 		// See https://github.com/microsoft/language-server-protocol/issues/1032#issuecomment-648748013
-		String newBody = "{\n\t${0}\n}";
+		String newBody = fSnippetSupport ? "{\n\t${0}\n}" : "{\n\n}";
 
-		StringBuffer buf = new StringBuffer("new A()"); //$NON-NLS-1$
+		StringBuilder buf = new StringBuilder("new A()"); //$NON-NLS-1$
 		buf.append(newBody);
 		// use the code formatter
 		String lineDelim = TextUtilities.getDefaultLineDelimiter(document);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalReplacementProvider;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalRequestor;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess;
 import org.eclipse.jdt.ls.core.internal.javadoc.JavadocContentAccess2;
@@ -102,6 +103,10 @@ public class CompletionResolveHandler {
 		if (monitor.isCanceled()) {
 			param.setData(null);
 			return param;
+		}
+		if (manager.getClientPreferences().isResolveAdditionalTextEditsSupport()) {
+			CompletionProposalReplacementProvider proposalProvider = new CompletionProposalReplacementProvider(unit, completionResponse.getContext(), completionResponse.getOffset(), manager.getPreferences(), manager.getClientPreferences());
+			proposalProvider.updateAdditionalTextEdits(completionResponse.getProposals().get(proposalId), param, '\0');
 		}
 		if (data.containsKey(DATA_FIELD_DECLARATION_SIGNATURE)) {
 			String typeName = stripSignatureToFQN(String.valueOf(data.get(DATA_FIELD_DECLARATION_SIGNATURE)));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -229,6 +229,10 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("gradleChecksumWrapperPromptSupport", "false").toString());
 	}
 
+	public boolean isResolveAdditionalTextEditsSupport() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("resolveAdditionalTextEditsSupport", "false").toString());
+	}
+
 	public boolean isSupportsCompletionDocumentationMarkdown() {
 		//@formatter:off
 		return v3supported && capabilities.getTextDocument().getCompletion() != null

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1932,11 +1932,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999998684", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 23, 23, "IFoo(){\n" +
-				"\n" +
-				"		@Override\n" +
-				"		public String getName() {\n" +
-				"			${0:// TODO Auto-generated method stub\n\t\t\treturn null;}\n" +
-				"		}\n" +
+				"	${0}\n" +
 				"};", ci.getTextEdit());
 	}
 
@@ -1967,15 +1963,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999998684", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 23, 23, "IFoo(){\n" +
-				"\n		@Override\n" +
-				"		public void setName(String name) {\n" +
-				"			${0:// TODO Auto-generated method stub\n\t\t\t}\n" +
-				"		}\n" +
-				"\n		@Override\n" +
-				"		public String getName() {\n" +
-				"			// TODO Auto-generated method stub\n" +
-				"			return null;\n" +
-				"		}\n" +
+				"	${0}\n" +
 				"};", ci.getTextEdit());
 	}
 
@@ -2002,11 +1990,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999999372", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 20, 22, "(){\n" +
-				"\n" +
-				"	@Override\n" +
-				"	public void run() {\n" +
-				"		${0:// TODO Auto-generated method stub\n\t\t}\n" +
-				"	}\n" +
+				"	${0}\n" +
 				"}", ci.getTextEdit());
 	}
 
@@ -2033,11 +2017,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999999372", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 20, 24, "(){\n" +
-				"\n" +
-				"	@Override\n" +
-				"	public void run() {\n" +
-				"		${0:// TODO Auto-generated method stub\n\t\t}\n" +
-				"	}\n" +
+				"	${0}\n" +
 				"}", ci.getTextEdit());
 	}
 
@@ -2066,11 +2046,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999999372", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 32, 33, "(){\n" +
-				"\n" +
-				"	@Override\n" +
-				"	public void run() {\n" +
-				"		${0:// TODO Auto-generated method stub\n\t\t}\n" +
-				"	}\n" +
+				"	${0}\n" +
 				"}", ci.getTextEdit());
 	}
 
@@ -2100,11 +2076,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999999372", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 32, 33, "(){\n" +
-				"\n" +
-				"	@Override\n" +
-				"	public void run() {\n" +
-				"		${0:// TODO Auto-generated method stub\n\t\t}\n" +
-				"	}\n" +
+				"	${0}\n" +
 				"}", ci.getTextEdit());
 	}
 
@@ -2129,11 +2101,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("999999372", ci.getSortText());
 		assertNotNull(ci.getTextEdit());
 		assertTextEdit(2, 33, 33, "(){\n" +
-				"\n" +
-				"	@Override\n" +
-				"	public void run() {\n" +
-				"		${0:// TODO Auto-generated method stub\n\t\t}\n" +
-				"	}\n" +
+				"	${0}\n" +
 				"}", ci.getTextEdit());
 	}
 


### PR DESCRIPTION
The goal is to improve performance of completion. Previously all text edits (including addtional ones which cost much time for imports) are caclulated in `CompletionProposalReplacementProvider#updateReplacement`. Now we decouple them,
`TextEdits` is calculated in "completion" stage, and `AdditionalTextEdits` in "resolve" stage

~Currenly it's not ready for review, just to show you how far it would improve.~

#### Performance Preview
In the initial commit, I defer the calculation of imports (only for `TYPE_REF` candidates) to resolving stage. In spring-petclinic project, when I type "S" to complete, it takes:
* ~110ms for 50 items 
* ~330ms for all 3000+ items

(macOS, 2.9 GHz Dual-Core Intel Core i5, 8G RAM)

#### References
VS Code has already supported the so-called [Relaxed resolveCompletionItem](https://code.visualstudio.com/updates/v1_46#_relaxed-resolvecompletionitem) in v1.46.
Proposed spec in LSP https://github.com/microsoft/language-server-protocol/issues/1003
