### PR TITLE
Update Buildship to 3.1.5

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -16,7 +16,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/buildship/updates/e415/releases/3.x/3.1.4.v20200326-1743/"/>
+            <repository location="https://download.eclipse.org/buildship/updates/e415/snapshots/3.x/3.1.5.v20200623-1251-s/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
brings dependency resolution markers to build.gradle files (See https://github.com/eclipse/buildship/issues/263)