### PR TITLE
Keep typing after the 1st tab when completing imports

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -408,6 +408,9 @@ public class CompletionProposalReplacementProvider {
 			String str = proposal.getKind() == CompletionProposal.TYPE_REF ? computeJavaTypeReplacementString(proposal) : String.valueOf(proposal.getCompletion());
 			if (client.isCompletionSnippetsSupported()) {
 				str = CompletionUtils.sanitizeCompletion(str);
+				if (proposal.getKind() == CompletionProposal.PACKAGE_REF && str != null && str.endsWith(".*;")) {
+					str = str.replace(".*;", ".${0:*};");
+				}
 			}
 			buffer.append(str);
 			return;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -339,7 +339,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(item.getTextEdit());
 		TextEdit te = item.getTextEdit();
 		assertNotNull(te);
-		assertEquals("java.sql.*;",te.getNewText());
+		assertEquals("java.sql.${0:*};", te.getNewText());
 		assertNotNull(te.getRange());
 		Range range = te.getRange();
 		assertEquals(0, range.getStart().getLine());


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/1532

![importcompletion](https://user-images.githubusercontent.com/388609/87959012-8d30da80-cab2-11ea-87bc-18f3b7092db8.gif)


Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>