### PR TITLE
Add semantic token type 'constructor'

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -280,13 +280,13 @@ public class SemanticTokensVisitor extends ASTVisitor {
 			}
 
 			if (simpleType.getName() instanceof SimpleName) {
-				addToken(simpleType.getName(), TokenType.METHOD,
+				addToken(simpleType.getName(), TokenType.CONSTRUCTOR,
 					TokenModifier.getApplicableModifiers(classInstanceCreation.resolveConstructorBinding()));
 			}
 			else {
 				QualifiedName qualifiedName = (QualifiedName) simpleType.getName();
 				qualifiedName.getQualifier().accept(this);
-				addToken(qualifiedName.getName(), TokenType.METHOD,
+				addToken(qualifiedName.getName(), TokenType.CONSTRUCTOR,
 					TokenModifier.getApplicableModifiers(classInstanceCreation.resolveConstructorBinding()));
 			}
 		}
@@ -299,7 +299,7 @@ public class SemanticTokensVisitor extends ASTVisitor {
 				((ASTNode) annotation).accept(this);
 			}
 
-			addToken(qualifiedType.getName(), TokenType.METHOD,
+			addToken(qualifiedType.getName(), TokenType.CONSTRUCTOR,
 				TokenModifier.getApplicableModifiers(classInstanceCreation.resolveConstructorBinding()));
 		}
 		else if (type instanceof NameQualifiedType) {
@@ -311,7 +311,7 @@ public class SemanticTokensVisitor extends ASTVisitor {
 				((ASTNode) annotation).accept(this);
 			}
 
-			addToken(nameQualifiedType.getName(), TokenType.METHOD,
+			addToken(nameQualifiedType.getName(), TokenType.CONSTRUCTOR,
 				TokenModifier.getApplicableModifiers(classInstanceCreation.resolveConstructorBinding()));
 		}
 		else if (type instanceof ParameterizedType) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
@@ -29,6 +29,7 @@ public enum TokenType {
 	ANNOTATION("annotation"),
 	ANNOTATION_MEMBER("annotationMember"),
 	METHOD("function"),
+	CONSTRUCTOR("constructor"),
 	PROPERTY("property"),
 	VARIABLE("variable"),
 	PARAMETER("parameter");
@@ -83,6 +84,9 @@ public enum TokenType {
 			}
 			case IBinding.METHOD: {
 				IMethodBinding methodBinding = (IMethodBinding) binding;
+				if (methodBinding.isConstructor()) {
+					return TokenType.CONSTRUCTOR;
+				}
 				if (methodBinding.isAnnotationMember()) {
 					return TokenType.ANNOTATION_MEMBER;
 				}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
@@ -82,11 +82,11 @@ public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest 
 	public void testSemanticTokens_Constructors() throws JavaModelException {
 		Map<Integer, Map<Integer, int[]>> decodedTokens = decodeSourceFile("Constructors.java");
 
-		assertToken(decodedTokens, 4, 9, 12, "function", "private", "declaration");
-		assertToken(decodedTokens, 5, 23, 12, "function", "private");
-		assertToken(decodedTokens, 6, 48, 10, "function", "protected");
-		assertToken(decodedTokens, 7, 64, 10, "function", "protected");
-		assertToken(decodedTokens, 8, 56, 10, "function", "protected");
+		assertToken(decodedTokens, 4, 9, 12, "constructor", "private", "declaration");
+		assertToken(decodedTokens, 5, 23, 12, "constructor", "private");
+		assertToken(decodedTokens, 6, 48, 10, "constructor", "protected");
+		assertToken(decodedTokens, 7, 64, 10, "constructor", "protected");
+		assertToken(decodedTokens, 8, 56, 10, "constructor", "protected");
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds a more specific token type for constructors, called `constructor`, which will allow constructors to be colored differently from methods, if desired. I could submit a PR to vscode-java, similar to redhat-developer/vscode-java#1540, which would allow `method` to be the supertype of `constructor`, in order to avoid breaking current color themes.

Unfortunately, I encountered a problem whilst implementing this: when a VS Code client receives a `constructor` token, the semantic highlighting completely breaks for that file. After some debugging, I found out that it was a bug in VS Code, so I have submitted an issue (microsoft/vscode#103104) about that. Until that gets fixed, this PR is not ready to be merged.