### PR TITLE
Fix wildcard import semantic tokens

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -151,7 +151,8 @@ public class SemanticTokensVisitor extends ASTVisitor {
 
 	@Override
 	public boolean visit(ImportDeclaration node) {
-		if (node.isOnDemand()) {
+		IBinding binding = node.resolveBinding();
+		if (binding == null || binding instanceof IPackageBinding) {
 			visitPackageName(node.getName());
 		}
 		else {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/semantic-tokens/src/foo/Packages.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/semantic-tokens/src/foo/Packages.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.NonExistentClass;
 import java.nio.*;
 import java.*;
+import java.lang.Math.*;
+import static java.lang.Math.*;
 
 public class Packages {
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
@@ -137,6 +137,12 @@ public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest 
 		assertToken(decodedTokens, 5, 7, 4, "namespace");
 		assertToken(decodedTokens, 5, 12, 3, "namespace");
 		assertToken(decodedTokens, 6, 7, 4, "namespace");
+		assertToken(decodedTokens, 7, 7, 4, "namespace");
+		assertToken(decodedTokens, 7, 12, 4, "namespace");
+		assertToken(decodedTokens, 7, 17, 4, "class", "public", "readonly");
+		assertToken(decodedTokens, 8, 14, 4, "namespace");
+		assertToken(decodedTokens, 8, 19, 4, "namespace");
+		assertToken(decodedTokens, 8, 24, 4, "class", "public", "readonly");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#1545
I also added some more assertions to the test case for packages, to prevent future regressions.