### PR TITLE
Use ASTProvider to getAST for source action handlers

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017-2019 Red Hat Inc. and others.
+ * Copyright (c) 2017-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -87,8 +87,9 @@ public class CodeActionHandler {
 		int start = DiagnosticsHelper.getStartOffset(unit, params.getRange());
 		int end = DiagnosticsHelper.getEndOffset(unit, params.getRange());
 		InnovationContext context = new InnovationContext(unit, start, end - start);
-		context.setASTRoot(getASTRoot(unit));
-		if (monitor.isCanceled()) {
+		CompilationUnit astRoot = getASTRoot(unit, monitor);
+		context.setASTRoot(astRoot);
+		if (astRoot == null || monitor.isCanceled()) {
 			return Collections.emptyList();
 		}
 		IProblemLocationCore[] locations = this.getProblemLocationCores(unit, params.getContext().getDiagnostics());
@@ -161,7 +162,7 @@ public class CodeActionHandler {
 			return Collections.emptyList();
 		}
 		if (containsKind(codeActionKinds, CodeActionKind.Source)) {
-			codeActions.addAll(sourceAssistProcessor.getSourceActionCommands(params, context, locations));
+			codeActions.addAll(sourceAssistProcessor.getSourceActionCommands(params, context, locations, monitor));
 		}
 		if (monitor.isCanceled()) {
 			return Collections.emptyList();
@@ -233,7 +234,11 @@ public class CodeActionHandler {
 	}
 
 	public static CompilationUnit getASTRoot(ICompilationUnit unit) {
-		return CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, new NullProgressMonitor());
+		return getASTRoot(unit, new NullProgressMonitor());
+	}
+
+	public static CompilationUnit getASTRoot(ICompilationUnit unit, IProgressMonitor monitor) {
+		return CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
 	}
 
 	private static class ChangeCorrectionProposalComparator implements Comparator<ChangeCorrectionProposal> {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -84,15 +84,20 @@ public class CodeActionHandler {
 		if (unit == null || monitor.isCanceled()) {
 			return Collections.emptyList();
 		}
-		int start = DiagnosticsHelper.getStartOffset(unit, params.getRange());
-		int end = DiagnosticsHelper.getEndOffset(unit, params.getRange());
-		InnovationContext context = new InnovationContext(unit, start, end - start);
+
 		CompilationUnit astRoot = getASTRoot(unit, monitor);
-		context.setASTRoot(astRoot);
 		if (astRoot == null || monitor.isCanceled()) {
 			return Collections.emptyList();
 		}
+
+		int start = DiagnosticsHelper.getStartOffset(unit, params.getRange());
+		int end = DiagnosticsHelper.getEndOffset(unit, params.getRange());
+		InnovationContext context = new InnovationContext(unit, start, end - start);
+		context.setASTRoot(astRoot);
 		IProblemLocationCore[] locations = this.getProblemLocationCores(unit, params.getContext().getDiagnostics());
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
 
 		List<String> codeActionKinds = new ArrayList<>();
 		if (params.getContext().getOnly() != null && !params.getContext().getOnly().isEmpty()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
@@ -54,9 +54,7 @@ import org.eclipse.text.edits.TextEdit;
 public class GenerateConstructorsHandler {
 	// For test purpose
 	public static CheckConstructorsResponse checkConstructorsStatus(CodeActionParams params) {
-		IProgressMonitor monitor = new NullProgressMonitor();
-		IType type = SourceAssistProcessor.getSelectionType(params, monitor);
-		return checkConstructorStatus(type, monitor);
+		return checkConstructorsStatus(params, new NullProgressMonitor());
 	}
 
 	public static CheckConstructorsResponse checkConstructorsStatus(CodeActionParams params, IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
@@ -121,7 +121,7 @@ public class GenerateToStringHandler {
 
 	// For test purpose
 	public static TextEdit generateToString(IType type, LspVariableBinding[] fields, ToStringGenerationSettingsCore settings) {
-		return generateToString(type, fields, new NullProgressMonitor());
+		return generateToString(type, fields, settings, new NullProgressMonitor());
 	}
 
 	public static TextEdit generateToString(IType type, LspVariableBinding[] fields, ToStringGenerationSettingsCore settings, IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -858,43 +858,43 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public CompletableFuture<OverridableMethodsResponse> listOverridableMethods(CodeActionParams params) {
 		logInfo(">> java/listOverridableMethods");
-		return computeAsync((monitor) -> OverrideMethodsHandler.listOverridableMethods(params));
+		return computeAsync((monitor) -> OverrideMethodsHandler.listOverridableMethods(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> addOverridableMethods(AddOverridableMethodParams params) {
 		logInfo(">> java/addOverridableMethods");
-		return computeAsync((monitor) -> OverrideMethodsHandler.addOverridableMethods(params));
+		return computeAsync((monitor) -> OverrideMethodsHandler.addOverridableMethods(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<CheckHashCodeEqualsResponse> checkHashCodeEqualsStatus(CodeActionParams params) {
 		logInfo(">> java/checkHashCodeEqualsStatus");
-		return computeAsync((monitor) -> HashCodeEqualsHandler.checkHashCodeEqualsStatus(params));
+		return computeAsync((monitor) -> HashCodeEqualsHandler.checkHashCodeEqualsStatus(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> generateHashCodeEquals(GenerateHashCodeEqualsParams params) {
 		logInfo(">> java/generateHashCodeEquals");
-		return computeAsync((monitor) -> HashCodeEqualsHandler.generateHashCodeEquals(params));
+		return computeAsync((monitor) -> HashCodeEqualsHandler.generateHashCodeEquals(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<CheckToStringResponse> checkToStringStatus(CodeActionParams params) {
 		logInfo(">> java/checkToStringStatus");
-		return computeAsync((monitor) -> GenerateToStringHandler.checkToStringStatus(params));
+		return computeAsync((monitor) -> GenerateToStringHandler.checkToStringStatus(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> generateToString(GenerateToStringParams params) {
 		logInfo(">> java/generateToString");
-		return computeAsync((monitor) -> GenerateToStringHandler.generateToString(params));
+		return computeAsync((monitor) -> GenerateToStringHandler.generateToString(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> organizeImports(CodeActionParams params) {
 		logInfo(">> java/organizeImports");
-		return computeAsync((monitor) -> OrganizeImportsHandler.organizeImports(client, params));
+		return computeAsync((monitor) -> OrganizeImportsHandler.organizeImports(client, params, monitor));
 	}
 
 	@Override
@@ -912,25 +912,25 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public CompletableFuture<CheckConstructorsResponse> checkConstructorsStatus(CodeActionParams params) {
 		logInfo(">> java/checkConstructorsStatus");
-		return computeAsync((monitor) -> GenerateConstructorsHandler.checkConstructorsStatus(params));
+		return computeAsync((monitor) -> GenerateConstructorsHandler.checkConstructorsStatus(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> generateConstructors(GenerateConstructorsParams params) {
 		logInfo(">> java/generateConstructors");
-		return computeAsync((monitor) -> GenerateConstructorsHandler.generateConstructors(params));
+		return computeAsync((monitor) -> GenerateConstructorsHandler.generateConstructors(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<CheckDelegateMethodsResponse> checkDelegateMethodsStatus(CodeActionParams params) {
 		logInfo(">> java/checkDelegateMethodsStatus");
-		return computeAsync((monitor) -> GenerateDelegateMethodsHandler.checkDelegateMethodsStatus(params));
+		return computeAsync((monitor) -> GenerateDelegateMethodsHandler.checkDelegateMethodsStatus(params, monitor));
 	}
 
 	@Override
 	public CompletableFuture<WorkspaceEdit> generateDelegateMethods(GenerateDelegateMethodsParams params) {
 		logInfo(">> java/generateDelegateMethods");
-		return computeAsync((monitor) -> GenerateDelegateMethodsHandler.generateDelegateMethods(params));
+		return computeAsync((monitor) -> GenerateDelegateMethodsHandler.generateDelegateMethods(params, monitor));
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Corporation and others.
+ * Copyright (c) 2019-2020 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.List;
 
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.OverrideMethodsOperation;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.OverrideMethodsOperation.OverridableMethod;
@@ -25,16 +26,16 @@ import org.eclipse.text.edits.TextEdit;
 
 public class OverrideMethodsHandler {
 
-	public static OverridableMethodsResponse listOverridableMethods(CodeActionParams params) {
-		IType type = SourceAssistProcessor.getSelectionType(params);
+	public static OverridableMethodsResponse listOverridableMethods(CodeActionParams params, IProgressMonitor monitor) {
+		IType type = SourceAssistProcessor.getSelectionType(params, monitor);
 		String typeName = type == null ? "" : type.getTypeQualifiedName();
-		List<OverridableMethod> methods = OverrideMethodsOperation.listOverridableMethods(type);
+		List<OverridableMethod> methods = OverrideMethodsOperation.listOverridableMethods(type, monitor);
 		return new OverridableMethodsResponse(typeName, methods);
 	}
 
-	public static WorkspaceEdit addOverridableMethods(AddOverridableMethodParams params) {
-		IType type = SourceAssistProcessor.getSelectionType(params.context);
-		TextEdit edit = OverrideMethodsOperation.addOverridableMethods(type, params.overridableMethods);
+	public static WorkspaceEdit addOverridableMethods(AddOverridableMethodParams params, IProgressMonitor monitor) {
+		IType type = SourceAssistProcessor.getSelectionType(params.context, monitor);
+		TextEdit edit = OverrideMethodsOperation.addOverridableMethods(type, params.overridableMethods, monitor);
 		if (edit == null) {
 			return null;
 		}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

ASTProvider will cache the AST node for the active editor, should use it whenever possible.

Below is the profiling comparison on editing a Java file with 200 LOC.

- **Before**:  
The source action handlers will parse a new AST every time in the source action handler.  Most of time of getSourceActionCommands is on parsing AST node. And the time ratio between getSourceActionCommands and getCodeActionCommands is about 64%.
![image](https://user-images.githubusercontent.com/14052197/91310743-d4fafe00-e7e4-11ea-80a0-e302bcd85f24.png)

- **After**: 
Use ASTProvider to get AST node, and the time ratio reduces to 40%.
![image](https://user-images.githubusercontent.com/14052197/91310975-19869980-e7e5-11ea-98ba-341f47b47e9f.png)
