### PR TITLE
Expose the anonymousToNest refactor more widely

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassToNestedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassToNestedTest.java
@@ -188,4 +188,97 @@ public class AnonymousClassToNestedTest extends AbstractSelectionTest {
 		Range range = CodeActionUtil.getRange(cu, "Foo() {", 0);
 		assertCodeActions(cu, range, expected);
 	}
+
+	@Test
+	public void testConvertToNestedCursor1() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new Foo(/*cursor*/) {};\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    private final class FooExtension extends Foo {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new FooExtension();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected expected = new Expected(CONVERT_ANONYMOUS_TO_NESTED, buf.toString(), CodeActionKind.Refactor);
+
+		Range range = CodeActionUtil.getRange(cu, "/*cursor*/", 0);
+		assertCodeActions(cu, range, expected);
+	}
+
+	@Test
+	public void testConvertToNestedCursor2() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new Foo() /*cursor*/{};\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    private final class FooExtension extends Foo {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new FooExtension();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected expected = new Expected(CONVERT_ANONYMOUS_TO_NESTED, buf.toString(), CodeActionKind.Refactor);
+
+		Range range = CodeActionUtil.getRange(cu, "/*cursor*/", 0);
+		assertCodeActions(cu, range, expected);
+	}
+
+	@Test
+	public void testConvertToNestedCursor3() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new Foo() {/*cursor*/};\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("class Foo {}\n");
+		buf.append("public class E {\n");
+		buf.append("    private final class FooExtension extends Foo {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    public void test() {\n");
+		buf.append("        Foo foo = new FooExtension();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected expected = new Expected(CONVERT_ANONYMOUS_TO_NESTED, buf.toString(), CodeActionKind.Refactor);
+
+		Range range = CodeActionUtil.getRange(cu, "/*cursor*/", 0);
+		assertCodeActions(cu, range, expected);
+	}
 }


### PR DESCRIPTION
This PR is to make the refactoring **convert anonymous class to nested** more widely.

Before, the refactor will only show on the simple name `Foo` in the example below

### Before
```java
public class E {
    public void test() {
        Foo foo = new /**/Foo/**/() {};
    }
}
```

Now we expand the its appearance to the whole class instance creation, which is the same behavior as the **anonymous to lamda** refactoring we have. (This refactor in IntelliJ also has a wider visibility)

### Now

```java
public class E {
    public void test() {
        Foo foo = new Foo(/*work as well*/) /*work as well*/{/*work as well*/};
    }
}
```