### PR TITLE
Fix semantic tokens offset due to document updates

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommand.java
@@ -17,19 +17,15 @@ import java.util.Collections;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentLifeCycleHandler;
-import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokenManager;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokens;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensLegend;
 import org.eclipse.jdt.ls.core.internal.semantictokens.SemanticTokensVisitor;
-import org.eclipse.jface.text.IDocument;
 
 public class SemanticTokensCommand {
 	public static SemanticTokens provide(String uri) {
@@ -38,22 +34,17 @@ public class SemanticTokensCommand {
 	}
 
 	private static SemanticTokens doProvide(String uri) {
-		IDocument document = null;
-
 		ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(uri);
-		if (typeRoot != null) {
-			try {
-				document = JsonRpcHelpers.toDocument(typeRoot.getBuffer());
-			} catch (JavaModelException e) {
-				JavaLanguageServerPlugin.logException("Failed to provide semantic tokens for " + uri, e);
-			}
-		}
-		if (document == null) {
+		if (typeRoot == null) {
 			return new SemanticTokens(Collections.emptyList());
 		}
 
-		SemanticTokensVisitor collector = new SemanticTokensVisitor(document, SemanticTokenManager.getInstance());
 		CompilationUnit root = CoreASTProvider.getInstance().getAST(typeRoot, CoreASTProvider.WAIT_YES, new NullProgressMonitor());
+		if (root == null) {
+			return new SemanticTokens(Collections.emptyList());
+		}
+
+		SemanticTokensVisitor collector = new SemanticTokensVisitor(root, SemanticTokenManager.getInstance());
 		root.accept(collector);
 		return collector.getSemanticTokens();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -31,17 +32,15 @@ import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.Type;
-import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
-import org.eclipse.jface.text.IDocument;
 
 public class SemanticTokensVisitor extends ASTVisitor {
-	private IDocument document;
+	private CompilationUnit cu;
 	private SemanticTokenManager manager;
 	private List<SemanticToken> tokens;
 
-	public SemanticTokensVisitor(IDocument document, SemanticTokenManager manager) {
+	public SemanticTokensVisitor(CompilationUnit cu, SemanticTokenManager manager) {
 		this.manager = manager;
-		this.document = document;
+		this.cu = cu;
 		this.tokens = new ArrayList<>();
 	}
 
@@ -85,9 +84,8 @@ public class SemanticTokensVisitor extends ASTVisitor {
 		int currentLine = 0;
 		int currentColumn = 0;
 		for (SemanticToken token : this.tokens) {
-			int[] lineAndColumn = JsonRpcHelpers.toLine(this.document, token.getOffset());
-			int line = lineAndColumn[0];
-			int column = lineAndColumn[1];
+			int line = cu.getLineNumber(token.getOffset()) - 1;
+			int column = cu.getColumnNumber(token.getOffset());
 			int deltaLine = line - currentLine;
 			if (deltaLine != 0) {
 				currentLine = line;


### PR DESCRIPTION
Fixes part of redhat-developer/vscode-java#1597.
See redhat-developer/vscode-java#1632 for the second part of the fix.

This is done by getting the token line and column number directly from its compilation unit, rather than the document, which for whatever reason gets out-of-sync during frequent updates.