### PR TITLE
Add code actions to support new Java 15 modifiers on permitted class.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
@@ -147,6 +147,9 @@ public final class CorrectionMessages extends NLS {
 	public static String RenameRefactoringProposal_additionalInfo;
 	public static String RenameRefactoringProposal_name;
 
+	public static String ModifierCorrectionSubProcessor_changemodifierto_final_description;
+	public static String ModifierCorrectionSubProcessor_changemodifierto_sealed_description;
+	public static String ModifierCorrectionSubProcessor_changemodifierto_nonsealed_description;
 	public static String ModifierCorrectionSubProcessor_changemodifiertoabstract_description;
 	public static String ModifierCorrectionSubProcessor_changemodifiertostatic_description;
 	public static String ModifierCorrectionSubProcessor_changemodifiertononstatic_description;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
@@ -146,6 +146,9 @@ RemoveDeclarationCorrectionProposal_removeunusedvar_description=Remove declarati
 RenameRefactoringProposal_additionalInfo=Start the Rename refactoring
 RenameRefactoringProposal_name=Rename in workspace
 
+ModifierCorrectionSubProcessor_changemodifierto_final_description=Change ''{0}'' to ''final''
+ModifierCorrectionSubProcessor_changemodifierto_sealed_description=Change ''{0}'' to ''sealed''
+ModifierCorrectionSubProcessor_changemodifierto_nonsealed_description=Change ''{0}'' to ''non-sealed''
 ModifierCorrectionSubProcessor_changemodifiertoabstract_description=Change ''{0}'' to ''abstract''
 ModifierCorrectionSubProcessor_changemodifiertostatic_description=Change ''{0}'' to ''static''
 ModifierCorrectionSubProcessor_changemodifiertodefault_description=Change ''{0}'' to ''default''

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -190,6 +190,10 @@ public class QuickFixProcessor {
 			case IProblem.IndirectAccessToStaticMethod:
 				LocalCorrectionsSubProcessor.addCorrectAccessToStaticProposals(context, problem, proposals);
 				break;
+			case IProblem.SealedMissingClassModifier:
+			case IProblem.SealedMissingInterfaceModifier:
+				ModifierCorrectionSubProcessor.addSealedMissingModifierProposal(context, problem, proposals);
+				break;
 			case IProblem.StaticMethodRequested:
 			case IProblem.NonStaticFieldFromStaticInvocation:
 			case IProblem.InstanceMethodDuringConstructorInvocation:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
@@ -962,4 +962,38 @@ public class ModifierCorrectionSubProcessor {
 		return null;
 	}
 
+	public static void addSealedMissingModifierProposal(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) {
+		if (proposals == null) {
+			return;
+		}
+		ASTNode selectedNode = problem.getCoveringNode(context.getASTRoot());
+		if (!(selectedNode instanceof SimpleName)) {
+			return;
+		}
+		if (!(((SimpleName) selectedNode).getParent() instanceof TypeDeclaration)) {
+			return;
+		}
+		TypeDeclaration typeDecl = (TypeDeclaration) ((SimpleName) selectedNode).getParent();
+		boolean isInterface = typeDecl.isInterface();
+
+		ICompilationUnit cu = context.getCompilationUnit();
+		ITypeBinding typeDeclBinding = typeDecl.resolveBinding();
+		int relevance = IProposalRelevance.CHANGE_MODIFIER_TO_FINAL;
+		String label;
+
+		if (!isInterface) {
+			// Add final modifier
+			label = Messages.format(CorrectionMessages.ModifierCorrectionSubProcessor_changemodifierto_final_description, typeDecl.getName());
+			proposals.add(new ModifierChangeCorrectionProposal(label, cu, typeDeclBinding, typeDecl, Modifier.FINAL, 0, relevance));
+		}
+
+		// Add sealed modifier
+		label = Messages.format(CorrectionMessages.ModifierCorrectionSubProcessor_changemodifierto_sealed_description, typeDecl.getName());
+		proposals.add(new ModifierChangeCorrectionProposal(label, cu, typeDeclBinding, typeDecl, Modifier.SEALED, 0, relevance));
+
+		// Add non-sealed modifier
+		label = Messages.format(CorrectionMessages.ModifierCorrectionSubProcessor_changemodifierto_nonsealed_description, typeDecl.getName());
+		proposals.add(new ModifierChangeCorrectionProposal(label, cu, typeDeclBinding, typeDecl, Modifier.NON_SEALED, 0, relevance));
+	}
+
 }


### PR DESCRIPTION
- Add support for code actions to generate sealed/un-sealed/final
  modifiers on class with sealed direct super-class/super-interface
- Fixes #1555

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>