### PR TITLE
Created type doesn't implement sealed interface.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
@@ -550,6 +550,23 @@ public class UnresolvedElementsSubProcessor {
 
 	private static int evauateTypeKind(ASTNode node, IJavaProject project) {
 		int kind = ASTResolving.getPossibleTypeKinds(node, JavaModelUtil.is50OrHigher(project));
+
+		/*
+		 *  TODO : This code block should be contributed to ASTResolving.getPossibleTypeKinds(..)
+		 *  Support determining type of the 'permits' node type.
+		 */
+		ASTNode parent = node.getParent();
+		if (parent instanceof Type) {
+			Type type = (Type) parent;
+			TypeDeclaration typeDecl = ASTNodes.getParent(node, TypeDeclaration.class);
+			if (type.getLocationInParent() == TypeDeclaration.PERMITS_TYPES_PROPERTY) {
+				kind = TypeKinds.CLASSES;
+				if (typeDecl != null && typeDecl.isInterface()) {
+					kind |= TypeKinds.INTERFACES;
+				}
+			}
+		}
+
 		return kind;
 	}
 


### PR DESCRIPTION
- Add quick fix to generate proper type declaration for sealed type
- Fixed #1553
- Add testcase

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

A few notes :
- The type being created that is being permitted is given 'non-sealed' modifier as that seems the most permissive. Seemed reasonable given we use 'public' when creating the type already.
- Currently I haven't found a way to add the methods (if any) needing to be implemented. The issue is that to use the ASTRewrite API, the type must already exist and in this case it doesn't. I can have another look at how JDT UI does this but this is basically why all of 'constructNewCUChange(..)' deals with java language tokens as Strings, completely avoiding the AST.