### PR TITLE
Embed m2e 1.17

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -20,7 +20,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-	    <repository location="https://download.eclipse.org/technology/m2e/releases/1.16.0/"/>
+	    <repository location="https://download.eclipse.org/technology/m2e/milestones/1.17/1.17.0.20200924-1339/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
m2e 1.17 now lazy loads a bunch of services, making its startup faster.
This helps jdt.ls shave a couple seconds off of its startup time as well.

﻿Signed-off-by: Fred Bricon <fbricon@gmail.com>
