### PR TITLE
Hide inline variable commands when no reference found

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -346,7 +346,7 @@ public class RefactorProcessor {
 				// Inline Local Variable
 				if (binding.getJavaElement() instanceof ILocalVariable && RefactoringAvailabilityTesterCore.isInlineTempAvailable((ILocalVariable) binding.getJavaElement())) {
 					InlineTempRefactoring refactoring= new InlineTempRefactoring((VariableDeclaration) decl);
-					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK() && refactoring.getReferences().length > 0) {
 						String label = CorrectionMessages.QuickAssistProcessor_inline_local_description;
 						int relevance = IProposalRelevance.INLINE_LOCAL;
 						RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, CodeActionKind.RefactorInline, context.getCompilationUnit(), refactoring, relevance);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineVariableTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineVariableTest.java
@@ -71,4 +71,22 @@ public class InlineVariableTest extends AbstractSelectionTest {
 		Expected expected = new Expected(INLINE_LOCAL_VARIABLE, buf.toString(), CodeActionKind.RefactorInline);
 		assertCodeActions(cu, expected);
 	}
+
+	@Test
+	public void testInlineLocalVariableWithNoReferences() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo(String[] parameters, int j) {\n");
+		buf.append("        int temp = parameters.length + j;\n");
+		buf.append("        int /*]*/temp1/*[*/ = temp;\n");
+		buf.append("        System.out.println(temp);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		assertCodeActionNotExists(cu, INLINE_LOCAL_VARIABLE);
+	}
 }


### PR DESCRIPTION
Just hide meanless refactor commands when a variable has no reference. The following gifs show the effect of this PR.
Before:
![before](https://user-images.githubusercontent.com/45906942/96204648-6c83fe00-0f97-11eb-83cd-1945634730f7.gif)
After:
![after](https://user-images.githubusercontent.com/45906942/96204660-71e14880-0f97-11eb-8dcb-79423a280c9f.gif)


