### PR TITLE
Hide inline constant commands when no reference found

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -336,7 +336,7 @@ public class RefactorProcessor {
 							for (Change refactoringChange : refactoringChanges) {
 								referenceCount += ((CompilationUnitChange)refactoringChange).getChangeGroups().length;
 							}
-							if (referenceCount == 1 && refactoring.isDeclarationSelected()) {
+							if (referenceCount <= 1 && refactoring.isDeclarationSelected()) {
 								return true;
 							}
 							String label = ActionMessages.InlineConstantRefactoringAction_label;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineConstantTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineConstantTest.java
@@ -109,4 +109,18 @@ public class InlineConstantTest extends AbstractSelectionTest {
 		Expected expected = new Expected(INLINE_CONSTANT, buf.toString(), CodeActionKind.RefactorInline);
 		assertCodeActions(cu, expected);
 	}
+
+	@Test
+	public void testInlineConstant_NoReference() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static final String /*]*/LOGGER_NAME/*[*/ = \"TEST.E\";\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		assertCodeActionNotExists(cu, INLINE_CONSTANT);
+	}
 }


### PR DESCRIPTION
hide meaningless refactor commands when a constant has no reference. The following gifs show the effect of this PR.
Before:
![before](https://user-images.githubusercontent.com/45906942/96396727-6772b900-11fa-11eb-8d65-03ad109467c4.gif)
After:
![after](https://user-images.githubusercontent.com/45906942/96396731-6b064000-11fa-11eb-8f43-673b6ff0e8ca.gif)