### PR TITLE
Improve tracing capability of m2e through m2e.logback.configuration.

### DIFF
--- a/launch/jdt.ls.remote.server.launch
+++ b/launch/jdt.ls.remote.server.launch
@@ -36,6 +36,9 @@
 <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
 <setAttribute key="selected_features"/>
 <setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:default"/>
 <setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
 <setEntry value="com.google.guava@default:default"/>
 <setEntry value="com.ibm.icu@default:default"/>
@@ -91,6 +94,7 @@
 <setEntry value="org.eclipse.m2e.core@default:default"/>
 <setEntry value="org.eclipse.m2e.jdt@default:default"/>
 <setEntry value="org.eclipse.m2e.lifecyclemapping.defaults@default:default"/>
+<setEntry value="org.eclipse.m2e.logback.configuration@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.indexer@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.runtime.slf4j.simple@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.runtime@default:default"/>

--- a/launch/jdt.ls.socket-stream.launch
+++ b/launch/jdt.ls.socket-stream.launch
@@ -37,6 +37,9 @@
 <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
 <setAttribute key="selected_features"/>
 <setAttribute key="selected_target_bundles">
+<setEntry value="ch.qos.logback.classic@default:default"/>
+<setEntry value="ch.qos.logback.core@default:default"/>
+<setEntry value="ch.qos.logback.slf4j@default:default"/>
 <setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
 <setEntry value="com.google.guava@default:default"/>
 <setEntry value="com.ibm.icu@default:default"/>
@@ -92,6 +95,7 @@
 <setEntry value="org.eclipse.m2e.core@default:default"/>
 <setEntry value="org.eclipse.m2e.jdt@default:default"/>
 <setEntry value="org.eclipse.m2e.lifecyclemapping.defaults@default:default"/>
+<setEntry value="org.eclipse.m2e.logback.configuration@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.indexer@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.runtime.slf4j.simple@default:default"/>
 <setEntry value="org.eclipse.m2e.maven.runtime@default:default"/>

--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -6,6 +6,7 @@ bin.includes = META-INF/,\
                lib/jsoup-1.9.2.jar,\
                lib/remark-1.2.0.jar,\
                lifecycle-mapping-metadata.xml,\
+               logback.xml,\
                plugin.properties,\
                gradle/checksums/checksums.json,\
                gradle/checksums/versions.json

--- a/org.eclipse.jdt.ls.core/logback.xml
+++ b/org.eclipse.jdt.ls.core/logback.xml
@@ -1,0 +1,10 @@
+<configuration scan="true">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>%date [%thread] %-5level %logger{35} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -97,6 +97,9 @@ public class JavaLanguageServerPlugin extends Plugin {
 	public static final String HTTPS_PROXY_USER = "https.proxyUser";
 	public static final String HTTP_PROXY_USER = "http.proxyUser";
 
+	private static final String LOGBACK_CONFIG_FILE_PROPERTY = "logback.configurationFile";
+	private static final String LOGBACK_DEFAULT_FILENAME = "logback.xml";
+
 	/**
 	 * Source string send to clients for messages such as diagnostics.
 	 **/
@@ -157,8 +160,9 @@ public class JavaLanguageServerPlugin extends Plugin {
 		} catch (BundleException e) {
 			logException(e.getMessage(), e);
 		}
+		boolean isDebug = Boolean.getBoolean("jdt.ls.debug");
 		try {
-			redirectStandardStreams();
+			redirectStandardStreams(isDebug);
 		} catch (FileNotFoundException e) {
 			logException(e.getMessage(), e);
 		}
@@ -190,6 +194,24 @@ public class JavaLanguageServerPlugin extends Plugin {
 		// turn off substring code completion if isn't explicitly set
 		if (System.getProperty(AssistOptions.PROPERTY_SubstringMatch) == null) {
 			System.setProperty(AssistOptions.PROPERTY_SubstringMatch, "false");
+		}
+
+		if (isDebug && System.getProperty(LOGBACK_CONFIG_FILE_PROPERTY) == null) {
+			File stateDir = getStateLocation().toFile();
+			File configFile = new File(stateDir, LOGBACK_DEFAULT_FILENAME);
+			if (!configFile.isFile()) {
+				try (InputStream is = bundleContext.getBundle().getEntry(LOGBACK_DEFAULT_FILENAME).openStream(); FileOutputStream fos = new FileOutputStream(configFile)) {
+					for (byte[] buffer = new byte[1024 * 4];;) {
+						int n = is.read(buffer);
+						if (n < 0) {
+							break;
+						}
+						fos.write(buffer, 0, n);
+					}
+				}
+			}
+			// ContextInitializer.CONFIG_FILE_PROPERTY
+			System.setProperty(LOGBACK_CONFIG_FILE_PROPERTY, configFile.getAbsolutePath());
 		}
 	}
 
@@ -474,12 +496,11 @@ public class JavaLanguageServerPlugin extends Plugin {
 		return context == null ? "Unknown" : context.getBundle().getVersion().toString();
 	}
 
-	private static void redirectStandardStreams() throws FileNotFoundException {
+	private static void redirectStandardStreams(boolean isDebug) throws FileNotFoundException {
 		in = System.in;
 		out = System.out;
 		err = System.err;
 		System.setIn(new ByteArrayInputStream(new byte[0]));
-		boolean isDebug = Boolean.getBoolean("jdt.ls.debug");
 		if (isDebug) {
 			String id = "jdt.ls-" + new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();

--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -57,6 +57,7 @@
       <plugin id="org.eclipse.m2e.core"/>
       <plugin id="org.eclipse.m2e.jdt"/>
       <plugin id="org.eclipse.m2e.lifecyclemapping.defaults"/>
+      <plugin id="org.eclipse.m2e.logback.configuration"/>
       <plugin id="org.eclipse.m2e.maven.runtime"/>
       <plugin id="org.eclipse.m2e.workspace.cli"/>
       <plugin id="org.eclipse.osgi"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -20,6 +20,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
 	    <repository location="https://download.eclipse.org/technology/m2e/milestones/1.17/1.17.0.20200924-1339/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
- Add 'org.eclipse.m2e.logback.feature' to target platform
- Add 'org.eclipse.m2e.logback' plugin to language server product
- This exposes the 'logback.configurationFile' system property through
  which one can provide a logback configuration

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

A few notes on how this could work :

Suppose we want to log using standard out/err :

In : `/path/to/logback.xml`
```
<configuration scan="true">
  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
      <pattern>%date [%thread] %-5level %logger{35} - %msg%n</pattern>
    </encoder>
  </appender>
  <root level="DEBUG">
    <appender-ref ref="STDOUT" />
  </root>
</configuration>
```
Now when launching JDT-LS, we need to set `-Dlogback.configurationFile=/path/to/logback.xml -Djdt.ls.debug=true`
(The latter ensures JDT-LS will create the correct log files in the workspace `.metadata` folder. One would need to use `java.jdt.ls.vmargs` to set these on the client side.

A custom logfile location is also possible, but all that configuration would happen in the logback.xml without the need for setting 
`jdt.ls.debug=true`

**Update :**

With this change, the [default logging](https://git.eclipse.org/c/m2e/m2e-core.git/tree/org.eclipse.m2e.logback.configuration/defaultLogbackConfiguration/logback.xml) for m2e would generate 'INFO' level logging only in `${workspace}/.metadata/.plugins/org.eclipse.m2e.logback.configuration/0.log`.

@fbricon 