### PR TITLE
Update TP to use Eclipse 2020-12 M2.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/dom/TypeAnnotationRewrite.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/dom/TypeAnnotationRewrite.java
@@ -52,7 +52,7 @@ public class TypeAnnotationRewrite {
 	 */
 	public static void removePureTypeAnnotations(ASTNode node, ChildListPropertyDescriptor childListProperty, ASTRewrite rewrite, TextEditGroup editGroup) {
 		CompilationUnit root= (CompilationUnit) node.getRoot();
-		if (!JavaModelUtil.is18OrHigher(root.getJavaElement().getJavaProject())) {
+		if (!JavaModelUtil.is1d8OrHigher(root.getJavaElement().getJavaProject())) {
 			return;
 		}
 		ListRewrite listRewrite= rewrite.getListRewrite(node, childListProperty);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/RefactoringAvailabilityTester.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/RefactoringAvailabilityTester.java
@@ -965,8 +965,8 @@ public final class RefactoringAvailabilityTester {
 			return false;
 		}
 		if (type == IJavaElement.METHOD && declaring.isInterface()) {
-			boolean is18OrHigher = JavaModelUtil.is18OrHigher(member.getJavaProject());
-			if (!is18OrHigher || !Flags.isStatic(member.getFlags())) {
+			boolean is1d8OrHigher = JavaModelUtil.is1d8OrHigher(member.getJavaProject());
+			if (!is1d8OrHigher || !Flags.isStatic(member.getFlags())) {
 				return false;
 			}
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
@@ -207,7 +207,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
 	boolean isValidDestination(ASTNode node) {
 		boolean isInterface = node instanceof TypeDeclaration && ((TypeDeclaration) node).isInterface();
-		return !(node instanceof AnnotationTypeDeclaration) && !(isInterface && !JavaModelUtil.is18OrHigher(fCUnit.getJavaProject()));
+		return !(node instanceof AnnotationTypeDeclaration) && !(isInterface && !JavaModelUtil.is1d8OrHigher(fCUnit.getJavaProject()));
 	}
 
 	public RefactoringStatus checkInitialConditions(ImportRewrite rewriter) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
@@ -226,7 +226,7 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 		if (!Checks.isDeclaredIn(fTempDeclarationNode, MethodDeclaration.class)
 				&& !Checks.isDeclaredIn(fTempDeclarationNode, Initializer.class)
 				&& !Checks.isDeclaredIn(fTempDeclarationNode, LambdaExpression.class)) {
-			if (JavaModelUtil.is18OrHigher(fCu.getJavaProject())) {
+			if (JavaModelUtil.is1d8OrHigher(fCu.getJavaProject())) {
 				return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.RenameTempRefactoring_only_in_methods_initializers_and_lambda);
 			}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -154,7 +154,7 @@ public class LocalCorrectionsSubProcessor {
 			proposals.add(proposal);
 		}
 
-		if (JavaModelUtil.is17OrHigher(cu.getJavaProject())) {
+		if (JavaModelUtil.is1d7OrHigher(cu.getJavaProject())) {
 			refactoring = SurroundWithTryCatchRefactoring.create(cu, offset, length, true);
 			if (refactoring == null) {
 				return;
@@ -226,7 +226,7 @@ public class LocalCorrectionsSubProcessor {
 				proposals.add(proposal);
 			}
 
-			if (JavaModelUtil.is17OrHigher(cu.getJavaProject())) {
+			if (JavaModelUtil.is1d7OrHigher(cu.getJavaProject())) {
 				List<CatchClause> catchClauses = surroundingTry.catchClauses();
 
 				if (catchClauses != null && catchClauses.size() == 1) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewMethodCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewMethodCorrectionProposal.java
@@ -71,7 +71,7 @@ public class NewMethodCorrectionProposal extends AbstractMethodCorrectionProposa
 			return 0;
 		}
 		boolean isTargetInterface= getSenderBinding().isInterface();
-		if (isTargetInterface && !JavaModelUtil.is18OrHigher(getCompilationUnit().getJavaProject())) {
+		if (isTargetInterface && !JavaModelUtil.is1d8OrHigher(getCompilationUnit().getJavaProject())) {
 			// only abstract methods are allowed for interface present in less than Java 1.8
 			return getInterfaceMethodModifiers(targetTypeDecl, true);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
@@ -148,7 +148,7 @@ public class UnresolvedElementsSubProcessor {
 			if (locationInParent == ExpressionMethodReference.EXPRESSION_PROPERTY) {
 				typeKind= TypeKinds.REF_TYPES;
 			} else if (locationInParent == MethodInvocation.EXPRESSION_PROPERTY) {
-				if (JavaModelUtil.is18OrHigher(cu.getJavaProject())) {
+				if (JavaModelUtil.is1d8OrHigher(cu.getJavaProject())) {
 					typeKind= TypeKinds.CLASSES | TypeKinds.INTERFACES | TypeKinds.ENUMS;
 				} else {
 					typeKind= TypeKinds.CLASSES;
@@ -550,23 +550,6 @@ public class UnresolvedElementsSubProcessor {
 
 	private static int evauateTypeKind(ASTNode node, IJavaProject project) {
 		int kind = ASTResolving.getPossibleTypeKinds(node, JavaModelUtil.is50OrHigher(project));
-
-		/*
-		 *  TODO : This code block should be contributed to ASTResolving.getPossibleTypeKinds(..)
-		 *  Support determining type of the 'permits' node type.
-		 */
-		ASTNode parent = node.getParent();
-		if (parent instanceof Type) {
-			Type type = (Type) parent;
-			TypeDeclaration typeDecl = ASTNodes.getParent(node, TypeDeclaration.class);
-			if (type.getLocationInParent() == TypeDeclaration.PERMITS_TYPES_PROPERTY) {
-				kind = TypeKinds.CLASSES;
-				if (typeDecl != null && typeDecl.isInterface()) {
-					kind |= TypeKinds.INTERFACES;
-				}
-			}
-		}
-
 		return kind;
 	}
 
@@ -1039,7 +1022,7 @@ public class UnresolvedElementsSubProcessor {
 				ITypeBinding[] parameterTypes= getParameterTypes(arguments);
 				if (parameterTypes != null) {
 					String sig = org.eclipse.jdt.ls.core.internal.corrections.ASTResolving.getMethodSignature(methodName, parameterTypes, false);
-					boolean is18OrHigher= JavaModelUtil.is18OrHigher(targetCU.getJavaProject());
+					boolean is1d8OrHigher= JavaModelUtil.is1d8OrHigher(targetCU.getJavaProject());
 
 					boolean isSenderBindingInterface= senderDeclBinding.isInterface();
 					if (nodeParentType == senderDeclBinding) {
@@ -1047,7 +1030,7 @@ public class UnresolvedElementsSubProcessor {
 					} else {
 						label= Messages.format(CorrectionMessages.UnresolvedElementsSubProcessor_createmethod_other_description, new Object[] { sig, BasicElementLabels.getJavaElementName(senderDeclBinding.getName()) } );
 					}
-					if (is18OrHigher || !isSenderBindingInterface
+					if (is1d8OrHigher || !isSenderBindingInterface
 							|| (nodeParentType != senderDeclBinding && (!(sender instanceof SimpleName) || !((SimpleName) sender).getIdentifier().equals(senderDeclBinding.getName())))) {
 						proposals.add(new NewMethodCorrectionProposal(label, targetCU, invocationNode, arguments,
 								senderDeclBinding, IProposalRelevance.CREATE_METHOD));
@@ -1059,7 +1042,7 @@ public class UnresolvedElementsSubProcessor {
 							senderDeclBinding= Bindings.getBindingOfParentType(anonymDecl.getParent());
 							isSenderBindingInterface= senderDeclBinding.isInterface();
 							if (!senderDeclBinding.isAnonymous()) {
-								if (is18OrHigher || !isSenderBindingInterface) {
+								if (is1d8OrHigher || !isSenderBindingInterface) {
 									String[] args = new String[] { sig,
 											org.eclipse.jdt.ls.core.internal.corrections.ASTResolving.getTypeSignature(senderDeclBinding) };
 									label= Messages.format(CorrectionMessages.UnresolvedElementsSubProcessor_createmethod_other_description, args);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDocLocations.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDocLocations.java
@@ -290,15 +290,15 @@ public class JavaDocLocations {
 		 * This breaks all clients that directly create such URLs.
 		 * We can't know what format is required, so we just guess by the project's compiler compliance.
 		 */
-		boolean is18OrHigher = JavaModelUtil.is18OrHigher(meth.getJavaProject());
-		buf.append(is18OrHigher ? '-' : '(');
+		boolean is1d8OrHigher = JavaModelUtil.is1d8OrHigher(meth.getJavaProject());
+		buf.append(is1d8OrHigher ? '-' : '(');
 		String[] params = meth.getParameterTypes();
 		IType declaringType = meth.getDeclaringType();
 		boolean isVararg = Flags.isVarargs(meth.getFlags());
 		int lastParam = params.length - 1;
 		for (int i = 0; i <= lastParam; i++) {
 			if (i != 0) {
-				buf.append(is18OrHigher ? "-" : ", "); //$NON-NLS-1$ //$NON-NLS-2$
+				buf.append(is1d8OrHigher ? "-" : ", "); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			String curr = Signature.getTypeErasure(params[i]);
 			String fullName = JavaModelUtil.getResolvedTypeName(curr, declaringType);
@@ -312,7 +312,7 @@ public class JavaDocLocations {
 					dim--;
 				}
 				while (dim > 0) {
-					buf.append(is18OrHigher ? ":A" : "[]"); //$NON-NLS-1$ //$NON-NLS-2$
+					buf.append(is1d8OrHigher ? ":A" : "[]"); //$NON-NLS-1$ //$NON-NLS-2$
 					dim--;
 				}
 				if (i == lastParam && isVararg) {
@@ -320,7 +320,7 @@ public class JavaDocLocations {
 				}
 			}
 		}
-		buf.append(is18OrHigher ? '-' : ')');
+		buf.append(is1d8OrHigher ? '-' : ')');
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/ModifierCorrectionSubProcessor.java
@@ -576,7 +576,7 @@ public class ModifierCorrectionSubProcessor {
 				proposals.add(proposal);
 			}
 
-			if (JavaModelUtil.is18OrHigher(cu.getJavaProject()) && parentIsInterface) {
+			if (JavaModelUtil.is1d8OrHigher(cu.getJavaProject()) && parentIsInterface) {
 				{
 					// insert proposal to add static modifier
 					String label = Messages.format(CorrectionMessages.ModifierCorrectionSubProcessor_changemodifiertostatic_description, decl.getName());

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -33,7 +33,7 @@
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2020-12/202010161000/"/>
+            <repository location="https://download.eclipse.org/releases/2020-12/202011061000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.jboss.tools.maven.apt.core" version="0.0.0"/>


### PR DESCRIPTION
- https://eclip.se/568036 JavaModelUtil is1[678]OrHigher ->
  is1d[678]OrHigher to avoid future conflicts
- https://eclip.se/567770 Remove upstreamed logic in
  ASTResolving.getPossibleTypeKinds().

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>