### PR TITLE
Improve the performance of inferSelection

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -330,6 +330,22 @@ public class ExtractMethodRefactoring extends Refactoring {
 	 */
 	@Override
 	public RefactoringStatus checkInitialConditions(IProgressMonitor pm) throws CoreException {
+		RefactoringStatus result = this.internalCheckInitialConditions(pm);
+		if (fSelectionStart < 0 || fSelectionLength == 0 || result.hasFatalError()) {
+			return result;
+		}
+		initializeParameterInfos();
+		initializeUsedNames();
+		initializeDuplicates();
+		initializeDestinations();
+		return result;
+	}
+
+	public RefactoringStatus checkInferConditions(IProgressMonitor pm) throws CoreException {
+		return this.internalCheckInitialConditions(pm);
+	}
+
+	private RefactoringStatus internalCheckInitialConditions(IProgressMonitor pm) throws CoreException {
 		RefactoringStatus result = new RefactoringStatus();
 		pm.beginTask("", 100); //$NON-NLS-1$
 
@@ -362,10 +378,6 @@ public class ExtractMethodRefactoring extends Refactoring {
 		if (fVisibility == -1) {
 			setVisibility(Modifier.PRIVATE);
 		}
-		initializeParameterInfos();
-		initializeUsedNames();
-		initializeDuplicates();
-		initializeDestinations();
 		return result;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -689,7 +689,7 @@ public class RefactorProposalUtility {
 					continue;
 				}
 				ExtractMethodRefactoring refactoring = new ExtractMethodRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength(), formattingOptions);
-				if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+				if (refactoring.checkInferConditions(new NullProgressMonitor()).isOK()) {
 					return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_METHOD, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_METHOD_COMMAND, params));
 				}
 				parent = parent.getParent();


### PR DESCRIPTION
When the language server is just finding valid expression, `ExtractMethodRefactoring.checkInitialConditions()` has no need to do some initialize methods, in some corner cases such as working on a large Java file with many duplicate methods, this may affect the performance of `inferSelection`. 

This PR is to remove the unnecessary processes.

Signed-off-by: Shi Chen <chenshi@microsoft.com>