### PR TITLE
Suppress CoreException thrown by TokenScanner when EOF reached.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -133,7 +133,9 @@ public class SnippetCompletionProposal {
 								return false;
 							}
 						} catch (CoreException e) {
-							JavaLanguageServerPlugin.logException(e.getMessage(), e);
+							if (e.getStatus().getCode() != TokenScanner.END_OF_FILE) {
+								JavaLanguageServerPlugin.logException(e.getMessage(), e);
+							}
 						}
 						if (node instanceof CompletionOnSingleNameReference) {
 							CompilationUnit ast = CoreASTProvider.getInstance().getAST(cu, CoreASTProvider.WAIT_YES, null);


### PR DESCRIPTION
- Fixes #1611
- TokenScanner.readNext(..) throws CoreException with appropriate code
  when EOF is reached instead of returning TokenNameEOF so the
  exception logging should be suppressed in this case

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>