### PR TITLE
Support inferSelection when extract to variable

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -234,9 +234,9 @@ public class RefactorProcessor {
 
 		List<CUCorrectionProposal> newProposals = null;
 		if (this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported()) {
-			newProposals = RefactorProposalUtility.getExtractVariableCommandProposals(params, context, problemsAtLocation);
+			newProposals = RefactorProposalUtility.getExtractVariableCommandProposals(params, context, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractVariableInferSelectionSupported());
 		} else {
-			newProposals = RefactorProposalUtility.getExtractVariableProposals(params, context, problemsAtLocation);
+			newProposals = RefactorProposalUtility.getExtractVariableProposals(params, context, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractVariableInferSelectionSupported());
 		}
 
 		if (newProposals == null || newProposals.isEmpty()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -167,15 +167,15 @@ public class GetRefactorEditHandler {
 
 	private static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, String refactorType, Map formatterOptions) throws CoreException {
 		if (RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, false, false);
+			return RefactorProposalUtility.getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, false);
 		}
 
 		if (RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, false, false);
+			return RefactorProposalUtility.getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, false);
 		}
 
 		if (RefactorProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, false, false);
+			return RefactorProposalUtility.getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, false);
 		}
 
 		return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -68,7 +68,11 @@ public class GetRefactorEditHandler {
 			LinkedCorrectionProposal proposal = null;
 			if (RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(params.command) || RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(params.command)
 					|| RefactorProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(params.command)) {
-				proposal = (LinkedCorrectionProposal) getExtractVariableProposal(params.context, context, problemsAtLocation, params.command, formatterOptions);
+						SelectionInfo info = (params.commandArguments != null && !params.commandArguments.isEmpty()) ? JSONUtility.toModel(params.commandArguments.get(0), SelectionInfo.class) : null;
+						if (info != null) {
+							context = new InnovationContext(unit, info.offset, info.length);
+						}
+						proposal = (LinkedCorrectionProposal) getExtractVariableProposal(params.context, context, problemsAtLocation, params.command, formatterOptions);
 			} else if (RefactorProposalUtility.ASSIGN_VARIABLE_COMMAND.equals(params.command)) {
 				proposal = (LinkedCorrectionProposal) getAssignVariableProposal(params, context, problemsAtLocation, params.command, formatterOptions, locations);
 			} else if (RefactorProposalUtility.ASSIGN_FIELD_COMMAND.equals(params.command)) {
@@ -163,15 +167,15 @@ public class GetRefactorEditHandler {
 
 	private static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, String refactorType, Map formatterOptions) throws CoreException {
 		if (RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, false);
+			return RefactorProposalUtility.getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, false, false);
 		}
 
 		if (RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, false);
+			return RefactorProposalUtility.getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, false, false);
 		}
 
 		if (RefactorProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(refactorType)) {
-			return RefactorProposalUtility.getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, false);
+			return RefactorProposalUtility.getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, false, false);
 		}
 
 		return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -68,11 +68,11 @@ public class GetRefactorEditHandler {
 			LinkedCorrectionProposal proposal = null;
 			if (RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(params.command) || RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(params.command)
 					|| RefactorProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(params.command)) {
-						SelectionInfo info = (params.commandArguments != null && !params.commandArguments.isEmpty()) ? JSONUtility.toModel(params.commandArguments.get(0), SelectionInfo.class) : null;
-						if (info != null) {
-							context = new InnovationContext(unit, info.offset, info.length);
-						}
-						proposal = (LinkedCorrectionProposal) getExtractVariableProposal(params.context, context, problemsAtLocation, params.command, formatterOptions);
+				SelectionInfo info = (params.commandArguments != null && !params.commandArguments.isEmpty()) ? JSONUtility.toModel(params.commandArguments.get(0), SelectionInfo.class) : null;
+				if (info != null) {
+					context = new InnovationContext(unit, info.offset, info.length);
+				}
+				proposal = (LinkedCorrectionProposal) getExtractVariableProposal(params.context, context, problemsAtLocation, params.command, formatterOptions);
 			} else if (RefactorProposalUtility.ASSIGN_VARIABLE_COMMAND.equals(params.command)) {
 				proposal = (LinkedCorrectionProposal) getAssignVariableProposal(params, context, problemsAtLocation, params.command, formatterOptions, locations);
 			} else if (RefactorProposalUtility.ASSIGN_FIELD_COMMAND.equals(params.command)) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
@@ -41,7 +41,7 @@ public class InferSelectionHandler {
 		int start = DiagnosticsHelper.getStartOffset(unit, params.context.getRange());
 		int end = DiagnosticsHelper.getEndOffset(unit, params.context.getRange());
 		InnovationContext context = new InnovationContext(unit, start, end - start);
-		List<SelectionInfo> extractMethodInfos = new ArrayList<SelectionInfo>();
+		List<SelectionInfo> selectionCandidates = new ArrayList<SelectionInfo>();
 		ASTNode parent = context.getCoveringNode();
 		try {
 			if (RefactorProposalUtility.EXTRACT_METHOD_COMMAND.equals(params.command)) {
@@ -52,7 +52,7 @@ public class InferSelectionHandler {
 					}
 					ExtractMethodRefactoring refactoring = new ExtractMethodRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
 					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
+						selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
 					}
 					parent = parent.getParent();
 				}
@@ -64,7 +64,7 @@ public class InferSelectionHandler {
 					}
 					ExtractTempRefactoring refactoring = new ExtractTempRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
 					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
+						selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
 					}
 					parent = parent.getParent();
 				}
@@ -76,7 +76,7 @@ public class InferSelectionHandler {
 					}
 					ExtractConstantRefactoring refactoring = new ExtractConstantRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
 					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
-						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
+						selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
 					}
 					parent = parent.getParent();
 				}
@@ -86,10 +86,10 @@ public class InferSelectionHandler {
 			// do nothing.
 		}
 
-		if (extractMethodInfos.size() == 0) {
+		if (selectionCandidates.size() == 0) {
 			return null;
 		}
-		return extractMethodInfos;
+		return selectionCandidates;
 	}
 
 	public static class SelectionInfo {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
@@ -23,7 +23,9 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractConstantRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractMethodRefactoring;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractTempRefactoring;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
 import org.eclipse.jdt.ls.core.internal.corrections.InnovationContext;
 import org.eclipse.jdt.ls.core.internal.text.correction.RefactorProposalUtility;
@@ -49,6 +51,30 @@ public class InferSelectionHandler {
 						continue;
 					}
 					ExtractMethodRefactoring refactoring = new ExtractMethodRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
+					}
+					parent = parent.getParent();
+				}
+			} else if (RefactorProposalUtility.EXTRACT_VARIABLE_ALL_OCCURRENCE_COMMAND.equals(params.command) || RefactorProposalUtility.EXTRACT_VARIABLE_COMMAND.equals(params.command)) {
+				while (parent != null && parent instanceof Expression) {
+					if (parent instanceof ParenthesizedExpression) {
+						parent = parent.getParent();
+						continue;
+					}
+					ExtractTempRefactoring refactoring = new ExtractTempRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
+					}
+					parent = parent.getParent();
+				}
+			} else if (RefactorProposalUtility.EXTRACT_CONSTANT_COMMAND.equals(params.command)) {
+				while (parent != null && parent instanceof Expression) {
+					if (parent instanceof ParenthesizedExpression) {
+						parent = parent.getParent();
+						continue;
+					}
+					ExtractConstantRefactoring refactoring = new ExtractConstantRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
 					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 						extractMethodInfos.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength()));
 					}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -219,6 +219,14 @@ public class ClientPreferences {
 		return false;
 	}
 
+	public boolean isExtractVariableInferSelectionSupported() {
+		Object supportList = extendedClientCapabilities.getOrDefault("inferSelectionSupport", new ArrayList<>());
+		if (supportList instanceof List<?>) {
+			return ((List<?>)supportList).contains("extractVariable");
+		}
+		return false;
+	}
+
 	public boolean isAdvancedIntroduceParameterRefactoringSupported() {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("advancedIntroduceParameterRefactoringSupport", "false").toString());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -315,7 +315,11 @@ public class RefactorProposalUtility {
 		return true;
 	}
 
-	public static CUCorrectionProposal getExtractVariableAllOccurrenceProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
+	public static CUCorrectionProposal getExtractVariableAllOccurrenceProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		return getExtractVariableAllOccurrenceProposal(params, context, problemsAtLocation, formatterOptions, returnAsCommand, false);
+	}
+
+	private static CUCorrectionProposal getExtractVariableAllOccurrenceProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
 		final ICompilationUnit cu = context.getCompilationUnit();
 		String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_all_description;
 		int relevance;
@@ -365,7 +369,11 @@ public class RefactorProposalUtility {
 		return null;
 	}
 
-	public static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
+	public static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		return getExtractVariableProposal(params, context, problemsAtLocation, formatterOptions, returnAsCommand, false);
+	}
+
+	private static CUCorrectionProposal getExtractVariableProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
 		final ICompilationUnit cu = context.getCompilationUnit();
 		String label = CorrectionMessages.QuickAssistProcessor_extract_to_local_description;
 		int relevance;
@@ -574,7 +582,11 @@ public class RefactorProposalUtility {
 		return null;
 	}
 
-	public static CUCorrectionProposal getExtractConstantProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
+	public static CUCorrectionProposal getExtractConstantProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
+		return getExtractConstantProposal(params, context, problemsAtLocation, formatterOptions, returnAsCommand, false);
+	}
+
+	private static CUCorrectionProposal getExtractConstantProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
 		final ICompilationUnit cu = context.getCompilationUnit();
 		String label = CorrectionMessages.QuickAssistProcessor_extract_to_constant_description;
 		int relevance;


### PR DESCRIPTION
Relates to redhat-developer/vscode-java#1717

Add support to `extractVariable` In `inferSelectionSupport` capability, making it possible to infer selections if there is no selection range when extract to variable.

Signed-off-by: Shi Chen chenshi@microsoft.com