### PR TITLE
Support inferSelection when extract to field

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -273,9 +273,9 @@ public class RefactorProcessor {
 
 		CUCorrectionProposal proposal = null;
 		if (this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported()) {
-			proposal = RefactorProposalUtility.getExtractMethodCommandProposal(params, context, coveringNode, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractMethodInferSelectionSupport());
+			proposal = RefactorProposalUtility.getExtractMethodCommandProposal(params, context, coveringNode, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractMethodInferSelectionSupported());
 		} else {
-			proposal = RefactorProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractMethodInferSelectionSupport());
+			proposal = RefactorProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, this.preferenceManager.getClientPreferences().isExtractMethodInferSelectionSupported());
 		}
 
 		if (proposal == null) {
@@ -291,7 +291,7 @@ public class RefactorProcessor {
 			return false;
 		}
 
-		CUCorrectionProposal proposal = RefactorProposalUtility.getGenericExtractFieldProposal(params, context, problemsAtLocation, null, null, this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported());
+		CUCorrectionProposal proposal = RefactorProposalUtility.getGenericExtractFieldProposal(params, context, problemsAtLocation, null, null, this.preferenceManager.getClientPreferences().isAdvancedExtractRefactoringSupported(), this.preferenceManager.getClientPreferences().isExtractFieldInferSelectionSupported());
 
 		if (proposal == null) {
 			return false;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GetRefactorEditHandler.java
@@ -88,6 +88,10 @@ public class GetRefactorEditHandler {
 				proposal = (LinkedCorrectionProposal) RefactorProposalUtility.getConvertVariableToFieldProposal(params.context, context, problemsAtLocation, formatterOptions, initializeIn, false);
 			} else if (RefactorProposalUtility.EXTRACT_FIELD_COMMAND.equals(params.command)) {
 				String initializeIn = (params.commandArguments != null && !params.commandArguments.isEmpty()) ? JSONUtility.toModel(params.commandArguments.get(0), String.class) : null;
+				SelectionInfo info = (params.commandArguments != null && params.commandArguments.size() > 1) ? JSONUtility.toModel(params.commandArguments.get(1), SelectionInfo.class) : null;
+				if (info != null) {
+					context = new InnovationContext(unit, info.offset, info.length);
+				}
 				proposal = (LinkedCorrectionProposal) RefactorProposalUtility.getExtractFieldProposal(params.context, context, problemsAtLocation, formatterOptions, initializeIn, false);
 			} else if (InvertBooleanUtility.INVERT_VARIABLE_COMMAND.equals(params.command)) {
 				proposal = (LinkedCorrectionProposal) InvertBooleanUtility.getInvertVariableProposal(params.context, context, context.getCoveringNode(), false);
@@ -193,7 +197,7 @@ public class GetRefactorEditHandler {
 	}
 
 	private static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formatterOptions) throws CoreException {
-		return RefactorProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, formatterOptions, false, false);
+		return RefactorProposalUtility.getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, formatterOptions, false);
 	}
 
 	public static class RenamePosition {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractFieldRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractConstantRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractMethodRefactoring;
 import org.eclipse.jdt.ls.core.internal.corext.refactoring.code.ExtractTempRefactoring;
@@ -80,6 +81,19 @@ public class InferSelectionHandler {
 					}
 					parent = parent.getParent();
 				}
+			} else if (RefactorProposalUtility.EXTRACT_FIELD_COMMAND.equals(params.command)) {
+				while (parent != null && parent instanceof Expression) {
+					if (parent instanceof ParenthesizedExpression) {
+						parent = parent.getParent();
+						continue;
+					}
+					ExtractFieldRefactoring refactoring = new ExtractFieldRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+						List<String> scopes = RefactorProposalUtility.getInitializeScopes(refactoring);
+						selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength(), scopes));
+					}
+					parent = parent.getParent();
+				}
 			}
 
 		} catch (CoreException e) {
@@ -96,11 +110,17 @@ public class InferSelectionHandler {
 		public String name;
 		public int offset;
 		public int length;
+		public List<String> params;
 
 		public SelectionInfo(String name, int offset, int length) {
+			this(name, offset, length, null);
+		}
+
+		public SelectionInfo(String name, int offset, int length, List<String> params) {
 			this.name = name;
 			this.offset = offset;
 			this.length = length;
+			this.params = params;
 		}
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InferSelectionHandler.java
@@ -90,7 +90,9 @@ public class InferSelectionHandler {
 					ExtractFieldRefactoring refactoring = new ExtractFieldRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
 					if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
 						List<String> scopes = RefactorProposalUtility.getInitializeScopes(refactoring);
-						selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength(), scopes));
+						if (!scopes.isEmpty()) {
+							selectionCandidates.add(new SelectionInfo(parent.toString(), parent.getStartPosition(), parent.getLength(), scopes));
+						}
 					}
 					parent = parent.getParent();
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -211,7 +211,7 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("advancedExtractRefactoringSupport", "false").toString());
 	}
 
-	public boolean isExtractMethodInferSelectionSupport() {
+	public boolean isExtractMethodInferSelectionSupported() {
 		Object supportList = extendedClientCapabilities.getOrDefault("inferSelectionSupport", new ArrayList<>());
 		if (supportList instanceof List<?>) {
 			return ((List<?>)supportList).contains("extractMethod");
@@ -223,6 +223,14 @@ public class ClientPreferences {
 		Object supportList = extendedClientCapabilities.getOrDefault("inferSelectionSupport", new ArrayList<>());
 		if (supportList instanceof List<?>) {
 			return ((List<?>)supportList).contains("extractVariable");
+		}
+		return false;
+	}
+
+	public boolean isExtractFieldInferSelectionSupported() {
+		Object supportList = extendedClientCapabilities.getOrDefault("inferSelectionSupport", new ArrayList<>());
+		if (supportList instanceof List<?>) {
+			return ((List<?>)supportList).contains("extractField");
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -559,7 +559,7 @@ public class RefactorProposalUtility {
 						refactoring.setInitializeIn(scope.ordinal());
 					}
 					List<String> scopes = getInitializeScopes(refactoring);
-					if (scopes.size() > 0) {
+					if (!scopes.isEmpty()) {
 						return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_FIELD, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_FIELD_COMMAND, params));
 					}
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/RefactorProposalUtility.java
@@ -517,22 +517,56 @@ public class RefactorProposalUtility {
 	 * Merge the "Extract to Field" and "Convert Local Variable to Field" to a
 	 * generic "Extract to Field".
 	 */
-	public static CUCorrectionProposal getGenericExtractFieldProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, String initializeIn, boolean returnAsCommand)
+	public static CUCorrectionProposal getGenericExtractFieldProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, String initializeIn, boolean returnAsCommand, boolean inferSelectionSupport)
 			throws CoreException {
 		CUCorrectionProposal proposal = getConvertVariableToFieldProposal(params, context, problemsAtLocation, formatterOptions, initializeIn, returnAsCommand);
 		if (proposal != null) {
 			return proposal;
 		}
 
-		return getExtractFieldProposal(params, context, problemsAtLocation, formatterOptions, initializeIn, returnAsCommand);
+		return getExtractFieldProposal(params, context, problemsAtLocation, formatterOptions, initializeIn, returnAsCommand, inferSelectionSupport);
 	}
 
 	public static CUCorrectionProposal getExtractFieldProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, String initializeIn, boolean returnAsCommand) throws CoreException {
+		return getExtractFieldProposal(params, context, problemsAtLocation, formatterOptions, initializeIn, returnAsCommand, false);
+	}
+
+	private static CUCorrectionProposal getExtractFieldProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, String initializeIn, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
 		if (!supportsExtractVariable(context)) {
 			return null;
 		}
-
 		final ICompilationUnit cu = context.getCompilationUnit();
+		String label = CorrectionMessages.QuickAssistProcessor_extract_to_field_description;
+		int relevance;
+		if (context.getSelectionLength() == 0) {
+			relevance = IProposalRelevance.EXTRACT_LOCAL_ZERO_SELECTION;
+		} else if (problemsAtLocation) {
+			relevance = IProposalRelevance.EXTRACT_LOCAL_ERROR;
+		} else {
+			relevance = IProposalRelevance.EXTRACT_LOCAL;
+		}
+		if (context.getSelectionLength() == 0 && inferSelectionSupport) {
+			ASTNode parent = context.getCoveringNode();
+			while (parent != null && parent instanceof Expression) {
+				if (parent instanceof ParenthesizedExpression) {
+					parent = parent.getParent();
+					continue;
+				}
+				ExtractFieldRefactoring refactoring = new ExtractFieldRefactoring(context.getASTRoot(), parent.getStartPosition(), parent.getLength());
+				if (refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+					InitializeScope scope = InitializeScope.fromName(initializeIn);
+					if (scope != null) {
+						refactoring.setInitializeIn(scope.ordinal());
+					}
+					List<String> scopes = getInitializeScopes(refactoring);
+					if (scopes.size() > 0) {
+						return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_FIELD, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_FIELD_COMMAND, params));
+					}
+				}
+				parent = parent.getParent();
+			}
+			return null;
+		}
 		ExtractFieldRefactoring extractFieldRefactoringSelectedOnly = new ExtractFieldRefactoring(context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
 		extractFieldRefactoringSelectedOnly.setFormatterOptions(formatterOptions);
 		if (extractFieldRefactoringSelectedOnly.checkInitialConditions(new NullProgressMonitor()).isOK()) {
@@ -540,32 +574,10 @@ public class RefactorProposalUtility {
 			if (scope != null) {
 				extractFieldRefactoringSelectedOnly.setInitializeIn(scope.ordinal());
 			}
-			String label = CorrectionMessages.QuickAssistProcessor_extract_to_field_description;
-			int relevance;
-			if (context.getSelectionLength() == 0) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ZERO_SELECTION;
-			} else if (problemsAtLocation) {
-				relevance = IProposalRelevance.EXTRACT_LOCAL_ERROR;
-			} else {
-				relevance = IProposalRelevance.EXTRACT_LOCAL;
-			}
-
 			if (returnAsCommand) {
-				List<String> scopes = new ArrayList<>();
-				if (extractFieldRefactoringSelectedOnly.canEnableSettingDeclareInMethod()) {
-					scopes.add(InitializeScope.CURRENT_METHOD.getName());
-				}
-
-				if (extractFieldRefactoringSelectedOnly.canEnableSettingDeclareInFieldDeclaration()) {
-					scopes.add(InitializeScope.FIELD_DECLARATION.getName());
-				}
-
-				if (extractFieldRefactoringSelectedOnly.canEnableSettingDeclareInConstructors()) {
-					scopes.add(InitializeScope.CLASS_CONSTRUCTORS.getName());
-				}
+				List<String> scopes = getInitializeScopes(extractFieldRefactoringSelectedOnly);
 				return new CUCorrectionCommandProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_FIELD, cu, relevance, APPLY_REFACTORING_COMMAND_ID, Arrays.asList(EXTRACT_FIELD_COMMAND, params, new ExtractFieldInfo(scopes)));
 			}
-
 			LinkedProposalModelCore linkedProposalModel = new LinkedProposalModelCore();
 			extractFieldRefactoringSelectedOnly.setLinkedProposalModel(linkedProposalModel);
 			RefactoringCorrectionProposal proposal = new RefactoringCorrectionProposal(label, JavaCodeActionKind.REFACTOR_EXTRACT_FIELD, cu, extractFieldRefactoringSelectedOnly, relevance) {
@@ -580,6 +592,22 @@ public class RefactorProposalUtility {
 		}
 
 		return null;
+	}
+
+	public static List<String> getInitializeScopes(ExtractFieldRefactoring refactoring) throws CoreException {
+		List<String> scopes = new ArrayList<>();
+		if (refactoring.canEnableSettingDeclareInMethod()) {
+			scopes.add(InitializeScope.CURRENT_METHOD.getName());
+		}
+
+		if (refactoring.canEnableSettingDeclareInFieldDeclaration()) {
+			scopes.add(InitializeScope.FIELD_DECLARATION.getName());
+		}
+
+		if (refactoring.canEnableSettingDeclareInConstructors()) {
+			scopes.add(InitializeScope.CLASS_CONSTRUCTORS.getName());
+		}
+		return scopes;
 	}
 
 	public static CUCorrectionProposal getExtractConstantProposal(CodeActionParams params, IInvocationContext context, boolean problemsAtLocation, Map formatterOptions, boolean returnAsCommand) throws CoreException {
@@ -710,7 +738,11 @@ public class RefactorProposalUtility {
 		return null;
 	}
 
-	public static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formattingOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
+	public static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formattingOptions, boolean returnAsCommand) throws CoreException {
+		return getExtractMethodProposal(params, context, coveringNode, problemsAtLocation, formattingOptions, returnAsCommand, false);
+	}
+
+	private static CUCorrectionProposal getExtractMethodProposal(CodeActionParams params, IInvocationContext context, ASTNode coveringNode, boolean problemsAtLocation, Map formattingOptions, boolean returnAsCommand, boolean inferSelectionSupport) throws CoreException {
 		if (!(coveringNode instanceof Expression) && !(coveringNode instanceof Statement) && !(coveringNode instanceof Block)) {
 			return null;
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InferSelectionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InferSelectionHandlerTest.java
@@ -154,6 +154,34 @@ public class InferSelectionHandlerTest extends AbstractSelectionTest {
 		Assert.assertEquals(infos.get(1).length, 13);
 	}
 
+	@Test
+	public void testInferSelectionWhenExtractField() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    private String test = \"test\";\n");
+		buf.append("    public int foo() {\n");
+		buf.append("        int hashCode = this./*|*/test.hashCode();\n");
+		buf.append("        return 0;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		Range selection = getVerticalBarRange(cu);
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(cu, selection);
+		InferSelectionParams inferParams = new InferSelectionParams(RefactorProposalUtility.EXTRACT_FIELD_COMMAND, params);
+		List<SelectionInfo> infos = InferSelectionHandler.inferSelectionsForRefactor(inferParams);
+		Assert.assertNotNull(infos);
+		Assert.assertEquals(infos.size(), 2);
+		Assert.assertEquals(infos.get(0).name, "this.test");
+		Assert.assertEquals(infos.get(0).length, 14);
+		Assert.assertEquals(infos.get(1).name, "this.test.hashCode()");
+		Assert.assertEquals(infos.get(1).length, 25);
+	}
+
 	/**
 	 * Find the last position of vertical bar comment.
 	 * @param cu the ICompilationUnit containing source


### PR DESCRIPTION
Relates to redhat-developer/vscode-java#1721

Add support to `extractField` In `inferSelectionSupport` capability, making it possible to infer selections if there is no selection range when extract to field.

Also add a field `params` in `SelectionInfo` to support send scope information from the server to the client.

To keep the consistency, also rename `isExtractMethodInferSelectionSupport` to `isExtractMethodInferSelectionSupported` and change some invocation about extracting method.

Signed-off-by: Shi Chen chenshi@microsoft.com