### PR TITLE
Add support to INFO log level

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/LogHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/LogHandler.java
@@ -68,6 +68,8 @@ public class LogHandler {
 			return -1;
 		case "ERROR":
 			return IStatus.ERROR;
+		case "INFO":
+			return IStatus.ERROR | IStatus.WARNING | IStatus.INFO;
 		case "WARNING":
 		default:
 			return IStatus.ERROR | IStatus.WARNING;


### PR DESCRIPTION
There is no way get INFO logging level messages besides setting the log level to ALL.

This PR allows that. In my case, I need to listen to the ">> build jobs finished" and others.