### PR TITLE
Download sources for the masses

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -65,6 +65,8 @@ import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaLanguageServerT
 import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.DigestStore;
+import org.eclipse.jdt.ls.core.internal.managers.ISourceDownloader;
+import org.eclipse.jdt.ls.core.internal.managers.MavenSourceDownloader;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.managers.StandardProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -119,6 +121,8 @@ public class JavaLanguageServerPlugin extends Plugin {
 	private static InputStream in;
 	private static PrintStream out;
 	private static PrintStream err;
+
+	private ISourceDownloader sourceDownloader;
 
 	private LanguageServer languageServer;
 	private ProjectsManager projectsManager;
@@ -592,7 +596,6 @@ public class JavaLanguageServerPlugin extends Plugin {
 
 			fContextTypeRegistry = registry;
 		}
-
 		return fContextTypeRegistry;
 	}
 
@@ -626,5 +629,12 @@ public class JavaLanguageServerPlugin extends Plugin {
 			typeFilter = new TypeFilter();
 		}
 		return typeFilter;
+	}
+
+	public static synchronized ISourceDownloader getDefaultSourceDownloader() {
+		if (pluginInstance.sourceDownloader == null) {
+			pluginInstance.sourceDownloader = new MavenSourceDownloader();
+		}
+		return pluginInstance.sourceDownloader;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
@@ -21,11 +22,14 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 
 import com.google.common.collect.Sets;
 
@@ -84,6 +88,19 @@ public class EclipseBuildSupport implements IBuildSupport {
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		boolean shouldDiscoverSources = (classFile.getJavaProject() != null && Objects.equals(ProjectsManager.getDefaultProject(), classFile.getJavaProject().getProject()));
+
+		if (!shouldDiscoverSources) {
+			PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
+			shouldDiscoverSources = preferencesManager != null && preferencesManager.getPreferences().isEclipseDownloadSources();
+		}
+		if (shouldDiscoverSources) {
+			JavaLanguageServerPlugin.getDefaultSourceDownloader().discoverSource(classFile, monitor);
+		}
 	}
 
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IMavenArtifactIdentifier.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IMavenArtifactIdentifier.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.m2e.core.embedder.ArtifactKey;
+
+public interface IMavenArtifactIdentifier {
+
+	public ArtifactKey identify(IPath path, IProgressMonitor monitor);
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ISourceDownloader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ISourceDownloader.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IClasspathEntry;
+
+/**
+ * Service to automatically discover and attach sources to unknown class files.
+ *
+ * @author Fred Bricon
+ *
+ */
+public interface ISourceDownloader {
+
+	/**
+	 * Discovers and attaches sources to the given {@link IClassFile}'s parent
+	 * {@link IClasspathEntry}, if it's a jar file.
+	 *
+	 * @param classFile
+	 *            the file to identify and search sources for
+	 * @param monitor
+	 *            a progress monitor
+	 * @throws CoreException
+	 */
+	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException;
+
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectBuildSupport.java
@@ -18,6 +18,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -71,6 +72,11 @@ public class InvisibleProjectBuildSupport extends EclipseBuildSupport implements
 		} else {
 			return SelectorUtils.matchPath(glob, path); // Case sensitive match in *nix
 		}
+	}
+
+	@Override
+	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		JavaLanguageServerPlugin.getDefaultSourceDownloader().discoverSource(classFile, monitor);
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -29,11 +28,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.eclipse.m2e.core.MavenPlugin;
@@ -44,12 +40,7 @@ import org.eclipse.m2e.core.project.IMavenProjectFacade;
 import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.eclipse.m2e.core.project.IProjectConfigurationManager;
 import org.eclipse.m2e.core.project.MavenUpdateRequest;
-import org.eclipse.m2e.jdt.IClasspathManager;
-import org.eclipse.m2e.jdt.MavenJdtPlugin;
 import org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 /**
  * @author Fred Bricon
@@ -57,9 +48,7 @@ import com.google.common.cache.CacheBuilder;
  */
 public class MavenBuildSupport implements IBuildSupport {
 
-	private static final int MAX_TIME_MILLIS = 3000;
 	private static final List<String> WATCH_FILE_PATTERNS = Collections.singletonList("**/pom.xml");
-	private static Cache<String, Boolean> downloadRequestsCache = CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(1, TimeUnit.HOURS).build();
 
 	private IProjectConfigurationManager configurationManager;
 	private ProjectRegistryManager projectManager;
@@ -151,36 +140,9 @@ public class MavenBuildSupport implements IBuildSupport {
 		return IBuildSupport.super.fileChanged(resource, changeType, monitor) || isBuildFile(resource);
 	}
 
-	/* (non-Javadoc)
-	 * @see org.eclipse.jdt.ls.core.internal.managers.IBuildSupport#getSource(org.eclipse.jdt.core.IClassFile, org.eclipse.core.runtime.IProgressMonitor)
-	 */
 	@Override
 	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
-		if (classFile == null) {
-			return;
-		}
-		IJavaElement element = classFile;
-		while (element.getParent() != null) {
-			element = element.getParent();
-			if (element instanceof IPackageFragmentRoot) {
-				final IPackageFragmentRoot fragment = (IPackageFragmentRoot) element;
-				IPath attachmentPath = fragment.getSourceAttachmentPath();
-				if (attachmentPath != null && !attachmentPath.isEmpty() && attachmentPath.toFile().exists()) {
-					break;
-				}
-				if (fragment.isArchive()) {
-					IPath path = fragment.getPath();
-					Boolean downloaded = downloadRequestsCache.getIfPresent(path.toString());
-					if (downloaded == null) {
-						downloadRequestsCache.put(path.toString(), true);
-						IClasspathManager buildpathManager = MavenJdtPlugin.getDefault().getBuildpathManager();
-						buildpathManager.scheduleDownload(fragment, true, true);
-						JobHelpers.waitForDownloadSourcesJobs(MAX_TIME_MILLIS);
-					}
-					break;
-				}
-			}
-		}
+		JavaLanguageServerPlugin.getDefaultSourceDownloader().discoverSource(classFile, monitor);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenCentralIdentifier.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenCentralIdentifier.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2020 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.internal.gradle.checksums.HashProvider;
+import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.osgi.util.NLS;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * @author Fred Bricon
+ *
+ *         Partially copied from
+ *         https://github.com/jbosstools/jbosstools-central/blob/24e907a07cbf81b9b7a9cafa69bd38b2271878eb/maven/plugins/org.jboss.tools.maven.core/src/org/jboss/tools/maven/core/internal/identification/MavenCentralIdentifier.java
+ *
+ */
+public class MavenCentralIdentifier implements IMavenArtifactIdentifier {
+
+	private static final String SHA1_SEARCH_QUERY = "https://search.maven.org/solrsearch/select?q=1:%22{0}%22&rows=1&wt=json";
+
+	private HashProvider hashProvider = new HashProvider(HashProvider.SHA1);
+
+	@Override
+	public ArtifactKey identify(IPath path, IProgressMonitor monitor) {
+		if (path == null) {
+			return null;
+		}
+		return identify(path.toFile(), monitor);
+	}
+
+	private ArtifactKey identify(File file, IProgressMonitor monitor) {
+		if (file == null || !file.isFile() || !file.canRead()) {
+			return null;
+		}
+		String sha1 = null;
+		try {
+			sha1 = hashProvider.getChecksum(file);
+		} catch (IOException e) {
+			JavaLanguageServerPlugin.logError("Failed to compute SHA1 checksum for " + file + " : " + e.getMessage());
+			return null;
+		}
+		return identifySha1(sha1, monitor);
+	}
+
+	private ArtifactKey identifySha1(String sha1, IProgressMonitor monitor) {
+		if (sha1 == null || sha1.isBlank()) {
+			return null;
+		}
+		String searchUrl = NLS.bind(SHA1_SEARCH_QUERY, sha1);
+		try {
+			return find(searchUrl, monitor);
+		} catch (Exception e) {
+			JavaLanguageServerPlugin.logError("Failed to identify " + sha1 + " with Maven Central : " + e.getMessage());
+		}
+		return null;
+	}
+
+	private ArtifactKey find(String searchUrl, IProgressMonitor monitor) throws IOException, InterruptedException {
+		Duration timeout = Duration.ofSeconds(10);
+		HttpClient client = HttpClient.newBuilder()
+				.connectTimeout(timeout)
+				.proxy(ProxySelector.getDefault())
+	            .version(Version.HTTP_2)
+				.build();
+		HttpRequest httpRequest = HttpRequest.newBuilder()
+				.timeout(timeout)
+		        .uri(URI.create(searchUrl))
+		        .GET()
+		        .build();
+
+		if (monitor == null) {
+			monitor = new NullProgressMonitor();
+		}
+		if (monitor.isCanceled()) {
+			return null;
+		}
+
+		//TODO implement request cancellation, according to monitor status
+		HttpResponse<String> response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+		JsonElement jsonElement = new JsonParser().parse(response.body());
+		if (jsonElement != null && jsonElement.isJsonObject()) {
+			return extractKey(jsonElement.getAsJsonObject());
+		}
+		return null;
+	}
+
+	private ArtifactKey extractKey(JsonObject modelNode) {
+		JsonObject response = modelNode.getAsJsonObject("response");
+		if (response != null) {
+			int num = response.get("numFound").getAsInt();
+			if (num > 0) {
+				JsonArray docs = response.getAsJsonArray("docs");
+					String a = null, g = null, v = null;
+					for (JsonElement d : docs) {
+						JsonObject o = d.getAsJsonObject();
+						a = o.get("a").getAsString();
+						g = o.get("g").getAsString();
+						v = o.get("v").getAsString();
+						if (a != null && g != null && v != null) {
+							return new ArtifactKey(g, a, v, null);
+						}
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenPropertiesIdentifier.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenPropertiesIdentifier.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.m2e.core.embedder.ArtifactKey;
+
+
+public class MavenPropertiesIdentifier implements IMavenArtifactIdentifier {
+
+	@Override
+	public ArtifactKey identify(IPath path, IProgressMonitor monitor) {
+		if (path == null) {
+			return null;
+		}
+		return identify(path.toFile());
+	}
+
+	private ArtifactKey identify(File file) {
+		if (file == null || !file.isFile() || !file.canRead()) {
+			return null;
+		}
+		try (ZipFile jar = new ZipFile(file)) {
+			return getArtifactFromPomProperties(jar);
+		} catch (IOException e) {
+			JavaLanguageServerPlugin.logError("Failed to identify " + file + " : " + e);
+		}
+		return null;
+	}
+
+	private ArtifactKey getArtifactFromPomProperties(ZipFile jar) throws IOException {
+		ZipEntry mavenEntry = jar.getEntry("META-INF/maven");//$NON-NLS-1$
+		if (mavenEntry == null) {
+			return null;
+		}
+		String jarName = jar.getName();
+		String entryName = mavenEntry.getName();
+		Enumeration<? extends ZipEntry> zipEntries = jar.entries();
+		ArtifactKey artifact = null;
+
+		while (zipEntries.hasMoreElements()) {
+			ZipEntry zipEntry = zipEntries.nextElement();
+			if (zipEntry.getName().endsWith("pom.properties") && zipEntry.getName().startsWith(entryName)) {
+				Properties props = new Properties();
+				props.load(jar.getInputStream(zipEntry));
+				String groupId = props.getProperty("groupId");
+				String artifactId = props.getProperty("artifactId");
+				String version = props.getProperty("version");
+				String classifier = props.getProperty("classifier");
+				if (groupId != null && artifactId != null && version != null) {
+					ArtifactKey currentArtifact = new ArtifactKey(groupId, artifactId, version, classifier);
+					if (artifact == null) {
+						artifact = currentArtifact;
+					} else {
+						//Shaded artifacts can contain multiple pom.properties. Our best bet is now to find the one matching the file name
+						// eg. org.fusesource.jansi:jansi:1.6
+						if (jarName.contains(artifactId + "-" + version)) {
+							artifact = currentArtifact;
+						}
+					}
+				}
+			}
+		}
+
+		return artifact;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenSourceDownloader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenSourceDownloader.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
+import org.eclipse.m2e.core.embedder.ArtifactKey;
+import org.eclipse.m2e.jdt.IClasspathManager;
+import org.eclipse.m2e.jdt.MavenJdtPlugin;
+import org.eclipse.m2e.jdt.internal.BuildPathManager;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+/**
+ * {@link ISourceDownloader} implementation based on m2e's
+ * {@link IClasspathManager}' source download facilities.
+ *
+ * @author Fred Bricon
+ *
+ */
+public class MavenSourceDownloader implements ISourceDownloader {
+
+	private static Cache<String, Boolean> downloadRequestsCache = CacheBuilder.newBuilder().maximumSize(100).expireAfterWrite(1, TimeUnit.HOURS).build();
+	private static final int MAX_TIME_MILLIS = 3000;
+
+	@Override
+	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		if (classFile == null) {
+			return;
+		}
+		IJavaElement element = classFile;
+		while (element.getParent() != null) {
+			element = element.getParent();
+			if (element instanceof IPackageFragmentRoot) {
+				final IPackageFragmentRoot fragment = (IPackageFragmentRoot) element;
+				IPath attachmentPath = fragment.getSourceAttachmentPath();
+				if (attachmentPath != null && !attachmentPath.isEmpty() && attachmentPath.toFile().exists()) {
+					break;
+				}
+				if (fragment.isArchive()) {
+					IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(fragment.getPath());
+					IPath path = file.getFullPath();
+					if (path == null || !path.toFile().exists()) {
+						path = file.getLocation();
+						if (path == null) {
+							return;
+						}
+					}
+					Boolean downloaded = downloadRequestsCache.getIfPresent(path.toString());
+					if (downloaded == null) {
+						downloadRequestsCache.put(path.toString(), true);
+						ArtifactKey artifact = new MavenPropertiesIdentifier().identify(path, monitor);
+						if (artifact == null) {
+							artifact = new MavenCentralIdentifier().identify(path, monitor);
+						}
+						if (artifact != null) {
+							BuildPathManager buildpathManager = (BuildPathManager) MavenJdtPlugin.getDefault().getBuildpathManager();
+							buildpathManager.scheduleDownload(fragment, artifact, true, true);
+							JobHelpers.waitForDownloadSourcesJobs(MAX_TIME_MILLIS);
+						}
+					}
+					break;
+				}
+			}
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -130,6 +130,11 @@ public class Preferences {
 	 */
 	public static final String MAVEN_DOWNLOAD_SOURCES = "java.maven.downloadSources";
 	/**
+	 * Preference key to enable/disable downloading source artifacts for Eclipse
+	 * projects.
+	 */
+	public static final String ECLIPSE_DOWNLOAD_SOURCES = "java.eclipse.downloadSources";
+	/**
 	 * Preference key to force update of Snapshots/Releases.
 	 */
 	public static final String MAVEN_UPDATE_SNAPSHOTS = "java.maven.updateSnapshots";
@@ -419,6 +424,7 @@ public class Preferences {
 	private String gradleUserHome;
 	private boolean importMavenEnabled;
 	private boolean mavenDownloadSources;
+	private boolean eclipseDownloadSources;
 	private boolean mavenUpdateSnapshots;
 	private boolean implementationsCodeLensEnabled;
 	private boolean javaFormatEnabled;
@@ -606,6 +612,7 @@ public class Preferences {
 		gradleUserHome = null;
 		importMavenEnabled = true;
 		mavenDownloadSources = false;
+		eclipseDownloadSources = false;
 		mavenUpdateSnapshots = false;
 		referencesCodeLensEnabled = true;
 		implementationsCodeLensEnabled = false;
@@ -684,8 +691,11 @@ public class Preferences {
 		prefs.setGradleUserHome(gradleUserHome);
 		boolean importMavenEnabled = getBoolean(configuration, IMPORT_MAVEN_ENABLED, true);
 		prefs.setImportMavenEnabled(importMavenEnabled);
-		boolean downloadSources = getBoolean(configuration, MAVEN_DOWNLOAD_SOURCES, false);
-		prefs.setMavenDownloadSources(downloadSources);
+		boolean mavenDownloadSources = getBoolean(configuration, MAVEN_DOWNLOAD_SOURCES, false);
+		prefs.setMavenDownloadSources(mavenDownloadSources);
+		boolean eclipseDownloadSources = getBoolean(configuration, ECLIPSE_DOWNLOAD_SOURCES, false);
+		prefs.setEclipseDownloadSources(eclipseDownloadSources);
+
 		boolean updateSnapshots = getBoolean(configuration, MAVEN_UPDATE_SNAPSHOTS, false);
 		prefs.setMavenUpdateSnapshots(updateSnapshots);
 		boolean referenceCodelensEnabled = getBoolean(configuration, REFERENCES_CODE_LENS_ENABLED_KEY, true);
@@ -1497,4 +1507,13 @@ public class Preferences {
 	public boolean isIncludeAccessors() {
 		return this.includeAccessors;
 	}
+	public boolean isEclipseDownloadSources() {
+		return eclipseDownloadSources;
+	}
+
+	public Preferences setEclipseDownloadSources(boolean enabled) {
+		this.eclipseDownloadSources = enabled;
+		return this;
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/HashProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/HashProvider.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
  */
 public class HashProvider {
 	public static final String SHA256 = "SHA-256";
+	public static final String SHA1 = "SHA-1";
 
 	private String alghorithm;
 

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/downloadSources/UsingRemark.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/downloadSources/UsingRemark.java
@@ -1,0 +1,4 @@
+import com.overzealous.remark.Remark;
+public class UsingRemark {
+	Remark remark = null;
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaProjectHelper.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/JavaProjectHelper.java
@@ -14,7 +14,9 @@
 package org.eclipse.jdt.ls.core.internal;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
@@ -98,5 +100,9 @@ public class JavaProjectHelper {
 
 	public static String toString(IClasspathEntry[] classpath) {
 		return Arrays.stream(classpath).map(cpe -> " - " + cpe.getPath().toString()).collect(Collectors.joining("\n"));
+	}
+
+	public static IClasspathEntry findJarEntry(IJavaProject jproject, String jarName) throws JavaModelException {
+		return Stream.of(jproject.getRawClasspath()).filter(cpe -> cpe.getEntryKind() == IClasspathEntry.CPE_LIBRARY || cpe.getPath() != null && Objects.equals(jarName, cpe.getPath().lastSegment())).findFirst().orElse(null);
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -228,7 +228,7 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		return createHoverRequest(uri, line, kar);
 	}
 
-	String createHoverRequest(URI file, int line, int kar) {
+	public static String createHoverRequest(URI file, int line, int kar) {
 		String fileURI = ResourceUtils.fixURI(file);
 		return HOVER_TEMPLATE.replace("${file}", fileURI)
 				.replace("${line}", String.valueOf(line))

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractInvisibleProjectBasedTest.java
@@ -14,21 +14,8 @@ package org.eclipse.jdt.ls.core.internal.managers;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceRunnable;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
-import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 
 /**
  * Base class for Invisible project tests.
@@ -37,11 +24,6 @@ import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
  *
  */
 public abstract class AbstractInvisibleProjectBasedTest extends AbstractProjectsManagerBasedTest {
-
-	protected IProject copyAndImportFolder(String folder, String triggerFile) throws Exception {
-		File projectFolder = copyFiles(folder, true);
-		return importRootFolder(projectFolder, triggerFile);
-	}
 
 	/**
 	 * Creates a temporary folder prefixed with <code>name</code> containing sources
@@ -86,27 +68,5 @@ public abstract class AbstractInvisibleProjectBasedTest extends AbstractProjects
 		FileUtils.copyFileToDirectory(new File(getSourceProjectDirectory(), "eclipse/source-attachment/foo-sources.jar"), libFile);
 	}
 
-	protected IProject importRootFolder(File projectFolder, String triggerFile) throws Exception {
-		IPath rootPath = Path.fromOSString(projectFolder.getAbsolutePath());
-		return importRootFolder(rootPath, triggerFile);
-	}
 
-	protected IProject importRootFolder(IPath rootPath, String triggerFile) throws Exception {
-		if (StringUtils.isNotBlank(triggerFile)) {
-			IPath triggerFilePath = rootPath.append(triggerFile);
-			Preferences preferences = preferenceManager.getPreferences();
-			preferences.setTriggerFiles(Arrays.asList(triggerFilePath));
-		}
-		final List<IPath> roots = Arrays.asList(rootPath);
-		IWorkspaceRunnable runnable = new IWorkspaceRunnable() {
-			@Override
-			public void run(IProgressMonitor monitor) throws CoreException {
-				projectsManager.initializeProjects(roots, monitor);
-			}
-		};
-		JavaCore.run(runnable, null, monitor);
-		waitForBackgroundJobs();
-		String invisibleProjectName = ProjectUtils.getWorkspaceInvisibleProjectName(rootPath);
-		return ResourcesPlugin.getWorkspace().getRoot().getProject(invisibleProjectName);
-	}
 }


### PR DESCRIPTION
- Fixes redhat-developer/vscode-java#1664
- Download maven-central artifact's sources on-demand

Signed-off-by: Fred Bricon <fbricon@gmail.com>
[rgrunber@redhat.com]: Fix testDynamicSourceLookups()
- Move testcase from HoverHandlerTest to InvisibleProjectBuildSupportTest
- Set up the external library after project import to mimic approach
  in other invisible projects
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

@fbricon 

Based on #1580 .