### PR TITLE
Should not enable preview compiler options if the tooling doesn't support the early access JDK

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
@@ -323,7 +323,7 @@ public class JVMConfigurator implements IVMInstallChangedListener {
 			Map<String, String> options = javaProject.getOptions(false);
 			JavaCore.setComplianceOptions(compliance, options);
 		}
-		if (JavaCore.compareJavaVersions(version, JavaCore.latestSupportedJavaVersion()) >= 0) {
+		if (JavaCore.isSupportedJavaVersion(version) && JavaCore.compareJavaVersions(version, JavaCore.latestSupportedJavaVersion()) >= 0) {
 			//Enable Java preview features for the latest JDK release by default and stfu about it
 			javaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
 			javaProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);


### PR DESCRIPTION
Fixes #1644

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>