### PR TITLE
Change location of .tooling

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -15,8 +15,8 @@ package org.eclipse.jdt.ls.core.internal.managers;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.buildship.core.BuildConfiguration;
@@ -92,9 +92,9 @@ public class GradleBuildSupport implements IBuildSupport {
 	private boolean isRoot(IProject project, GradleBuild gradleBuild, IProgressMonitor monitor) {
 		if (gradleBuild instanceof InternalGradleBuild) {
 			CancellationTokenSource tokenSource = GradleConnector.newCancellationTokenSource();
-			Collection<EclipseProject> eclipseProjects = ((InternalGradleBuild) gradleBuild).getModelProvider().fetchModels(EclipseProject.class, FetchStrategy.LOAD_IF_NOT_CACHED, tokenSource, monitor);
+			Map<String, EclipseProject> eclipseProjects = ((InternalGradleBuild) gradleBuild).getModelProvider().fetchModels(EclipseProject.class, FetchStrategy.LOAD_IF_NOT_CACHED, tokenSource, monitor);
 			File projectDirectory = project.getLocation().toFile();
-			for (EclipseProject eclipseProject : eclipseProjects) {
+			for (EclipseProject eclipseProject : eclipseProjects.values()) {
 				File eclipseProjectDirectory = eclipseProject.getProjectDirectory();
 				if (eclipseProjectDirectory.equals(projectDirectory)) {
 					return eclipseProject.getParent() == null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
@@ -105,7 +105,7 @@ public class WrapperValidator {
 					reader = new InputStreamReader(new FileInputStream(versionFile), Charsets.UTF_8);
 					String json = CharStreams.toString(reader);
 					Gson gson = new GsonBuilder().create();
-					TypeToken<List<Map<String, String>>> typeToken = new TypeToken<List<Map<String, String>>>() {
+					TypeToken<List<Map<String, String>>> typeToken = new TypeToken<>() {
 					};
 					List<Map<String, String>> versions = gson.fromJson(json, typeToken.getType());
 					//@formatter:off
@@ -253,14 +253,24 @@ public class WrapperValidator {
 	}
 
 	private static File getVersionCacheFile() {
-		return new File(System.getProperty("user.home"), ".tooling/gradle/versions.json");
+		String xdgCache = getXdgCache();
+		return new File(xdgCache, "tooling/gradle/versions.json");
+	}
+
+	private static String getXdgCache() {
+		String xdgCache = System.getenv("XDG_CACHE_HOME");
+		if (xdgCache == null) {
+			xdgCache = System.getProperty("user.home") + "/.cache/";
+		}
+		return xdgCache;
 	}
 
 	public static File getSha256CacheFile() {
 		String checksumCache = System.getProperty("gradle.checksum.cacheDir");
 		File file;
 		if (checksumCache == null || checksumCache.isEmpty()) {
-			file = new File(System.getProperty("user.home"), ".tooling/gradle/checksums");
+			String xdgCache = getXdgCache();
+			file = new File(xdgCache, "tooling/gradle/checksums");
 		} else {
 			file = new File(checksumCache);
 		}

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -16,7 +16,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/buildship/updates/e415/snapshots/3.x/3.1.5.v20200806-2157-s/"/>
+            <repository location="https://download.eclipse.org/buildship/updates/e415/snapshots/3.x/3.1.5.v20210112-1646-s"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -235,6 +236,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 
 	protected void waitForBackgroundJobs() throws Exception {
 		JobHelpers.waitForJobsToComplete(monitor);
+		Job.getJobManager().join(CorePlugin.GRADLE_JOB_FAMILY, new NullProgressMonitor());
 	}
 
 	protected File getSourceProjectDirectory() {
@@ -256,7 +258,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		WorkspaceHelper.deleteAllProjects();
 		FileUtils.forceDelete(getWorkingProjectDirectory());
 		Job.getJobManager().setProgressProvider(null);
-		JobHelpers.waitForJobsToComplete();
+		waitForBackgroundJobs();
 	}
 
 	protected void assertIsJavaProject(IProject project) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -488,8 +488,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			projectsManager.updateProject(root, true);
 			projectsManager.updateProject(project1, true);
 			projectsManager.updateProject(project2, true);
-			JobHelpers.waitForJobsToComplete();
-			Job.getJobManager().join(CorePlugin.GRADLE_JOB_FAMILY, new NullProgressMonitor());
+			waitForBackgroundJobs();
 			ProjectConfiguration configuration = getProjectConfiguration(root);
 			// check the children .settings/org.eclipse.buildship.core.prefs
 			assertTrue(configuration.getBuildConfiguration().isOverrideWorkspaceSettings());
@@ -535,7 +534,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			IFile build = project.getFile("/build.gradle");
 			build.setContents(contents, true, false, null);
 			projectsManager.updateProject(project, false);
-			JobHelpers.waitForJobsToComplete();
+			waitForBackgroundJobs();
 			type = javaProject.findType("org.apache.commons.lang3.StringUtils");
 			assertNotNull(type);
 	}


### PR DESCRIPTION
Fixes #1654 
Java LS and buildship will use $XDG_CACHE_HOME/tooling, ~/.cache/tooling per default

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>