### PR TITLE
Integrate the client's file formatting options with JDT code action handlers

### DIFF
--- a/launch/jdt.ls.socket-stream.launch
+++ b/launch/jdt.ls.socket-stream.launch
@@ -40,12 +40,12 @@
 <setEntry value="ch.qos.logback.classic@default:default"/>
 <setEntry value="ch.qos.logback.core@default:default"/>
 <setEntry value="ch.qos.logback.slf4j@default:default"/>
-<setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
+<setEntry value="com.google.gson@default:default"/>
 <setEntry value="com.google.guava@default:default"/>
 <setEntry value="javax.inject@default:default"/>
 <setEntry value="javax.xml@default:default"/>
 <setEntry value="org.apache.ant@default:default"/>
-<setEntry value="org.apache.commons.io*2.6.0.v20190123-2029@default:default"/>
+<setEntry value="org.apache.commons.io@default:default"/>
 <setEntry value="org.apache.commons.lang3@default:default"/>
 <setEntry value="org.apache.felix.scr@1:true"/>
 <setEntry value="org.apache.log4j@default:default"/>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Red Hat Inc. and others.
+ * Copyright (c) 2016-2020 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -24,6 +24,7 @@ import org.eclipse.jdt.ls.core.internal.lsp.ExecuteCommandProposedClient;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
@@ -220,6 +221,13 @@ public class JavaClientConnection {
 	 */
 	public void semanticHighlighting(SemanticHighlightingParams params) {
 		client.semanticHighlighting(params);
+	}
+
+	/**
+	 * @see {@link LanguageClient#configuration(ConfigurationParams)}
+	 */
+	public List<Object> configuration(ConfigurationParams configurationParams) {
+		return this.client.configuration(configurationParams).join();
 	}
 
 	public void disconnect() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/GenerateGetterSetterOperation.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.ls.core.internal.codemanipulation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -158,7 +159,8 @@ public class GenerateGetterSetterOperation {
 			stub = GetterSetterUtil.getSetterStub(field, name, generateComments, flags);
 		}
 
-		String formattedStub = CodeFormatterUtil.format(CodeFormatter.K_CLASS_BODY_DECLARATIONS, stub, 0, delimiter, type.getJavaProject().getOptions(true));
+		Map<String, String> options = type.getCompilationUnit() != null ? type.getCompilationUnit().getOptions(true) : type.getJavaProject().getOptions(true);
+		String formattedStub = CodeFormatterUtil.format(CodeFormatter.K_CLASS_BODY_DECLARATIONS, stub, 0, delimiter, options);
 		MethodDeclaration declaration = (MethodDeclaration) rewrite.getASTRewrite().createStringPlaceholder(formattedStub, ASTNode.METHOD_DECLARATION);
 		rewrite.insertLast(declaration, null);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -99,9 +99,8 @@ public class AnonymousTypeCompletionProposal {
 		buf.append(newBody);
 		// use the code formatter
 		String lineDelim = TextUtilities.getDefaultLineDelimiter(document);
-		final IJavaProject project = fCompilationUnit.getJavaProject();
 		IRegion lineInfo = document.getLineInformationOfOffset(fReplacementOffset);
-		Map<String, String> options = project != null ? project.getOptions(true) : JavaCore.getOptions();
+		Map<String, String> options = fCompilationUnit.getOptions(true);
 		String replacementString = CodeFormatterUtil.format(CodeFormatter.K_EXPRESSION, buf.toString(), 0, lineDelim, options);
 		int lineEndOffset = lineInfo.getOffset() + lineInfo.getLength();
 		int p = offset;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
@@ -147,7 +147,7 @@ public class OverrideCompletionProposal {
 
 				ITrackedNodePosition position= rewrite.track(stub);
 				try {
-					Map<String, String> options = fJavaProject.getOptions(true);
+					Map<String, String> options = fCompilationUnit.getOptions(true);
 
 					rewrite.rewriteAST(recoveredDocument, options).apply(recoveredDocument);
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -600,7 +600,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 				result.addTextEditGroup(new TextEditGroup(RefactoringCoreMessages.ExtractMethodRefactoring_organize_imports, new TextEdit[] { edit }));
 			}
 			try {
-				Map formatter = this.fFormatterOptions == null ? fCUnit.getJavaProject().getOptions(true) : this.fFormatterOptions;
+				Map formatter = this.fFormatterOptions == null ? fCUnit.getOptions(true) : this.fFormatterOptions;
 				IDocument document = new Document(fCUnit.getSource());
 				root.addChild(fRewriter.rewriteAST(document, formatter));
 			} catch (JavaModelException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/delegates/DelegateCreator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/delegates/DelegateCreator.java
@@ -361,7 +361,7 @@ public abstract class DelegateCreator {
 	public void createEdit() throws JavaModelException {
 		try {
 			IDocument document= new Document(fDelegateRewrite.getCu().getBuffer().getContents());
-			TextEdit edit= fDelegateRewrite.getASTRewrite().rewriteAST(document, fDelegateRewrite.getCu().getJavaProject().getOptions(true));
+			TextEdit edit= fDelegateRewrite.getASTRewrite().rewriteAST(document, fDelegateRewrite.getCu().getOptions(true));
 			edit.apply(document, TextEdit.UPDATE_REGIONS);
 
 			int tabWidth = CodeFormatterUtil.getTabWidth(fOriginalRewrite.getCu().getJavaProject());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/reorg/DeleteChangeCreator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/reorg/DeleteChangeCreator.java
@@ -133,7 +133,7 @@ class DeleteChangeCreator {
 	private static TextChange addTextEditFromRewrite(TextChangeManager manager, ICompilationUnit cu, ASTRewrite rewrite) throws CoreException {
 		try {
 			ITextFileBuffer buffer= RefactoringFileBuffers.acquire(cu);
-			TextEdit resultingEdits= rewrite.rewriteAST(buffer.getDocument(), cu.getJavaProject().getOptions(true));
+			TextEdit resultingEdits= rewrite.rewriteAST(buffer.getDocument(), cu.getOptions(true));
 			TextChange textChange= manager.get(cu);
 			if (textChange instanceof TextFileChange) {
 				TextFileChange tfc= (TextFileChange) textChange;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/AbstractMethodCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/AbstractMethodCorrectionProposal.java
@@ -154,7 +154,7 @@ public abstract class AbstractMethodCorrectionProposal extends ASTRewriteCorrect
 			if (!isAbstractMethod && !isVoid) {
 				ReturnStatement returnStatement= ast.newReturnStatement();
 				returnStatement.setExpression(ASTNodeFactory.newDefaultExpression(ast, returnType, 0));
-				bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, String.valueOf('\n'), getCompilationUnit().getJavaProject().getOptions(true));
+				bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, String.valueOf('\n'), getCompilationUnit().getOptions(true));
 			}
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ConstructorFromSuperclassProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ConstructorFromSuperclassProposal.java
@@ -163,7 +163,7 @@ public class ConstructorFromSuperclassProposal extends LinkedCorrectionProposal 
 			}
 		}
 
-		String bodyStatement = (invocation == null) ? "" : ASTNodes.asFormattedString(invocation, 0, String.valueOf('\n'), getCompilationUnit().getJavaProject().getOptions(true)); //$NON-NLS-1$
+		String bodyStatement = (invocation == null) ? "" : ASTNodes.asFormattedString(invocation, 0, String.valueOf('\n'), getCompilationUnit().getOptions(true)); //$NON-NLS-1$
 		String placeHolder= CodeGeneration.getMethodBodyContent(getCompilationUnit(), name, name, true, bodyStatement, String.valueOf('\n'));
 		if (placeHolder != null) {
 			ASTNode todoNode= rewrite.createStringPlaceholder(placeHolder, ASTNode.RETURN_STATEMENT);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ModifierChangeCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ModifierChangeCorrectionProposal.java
@@ -113,7 +113,7 @@ public class ModifierChangeCorrectionProposal extends LinkedCorrectionProposal {
 							if (expression != null) {
 								ReturnStatement returnStatement = ast.newReturnStatement();
 								returnStatement.setExpression(expression);
-								bodyStatement = ASTNodes.asFormattedString(returnStatement, 0, delimiter, unit.getJavaProject().getOptions(true));
+								bodyStatement = ASTNodes.asFormattedString(returnStatement, 0, delimiter, unit.getOptions(true));
 							}
 						}
 						String placeHolder = CodeGeneration.getMethodBodyContent(unit, methodBinding.getDeclaringClass().getName(), methodBinding.getName(), false, bodyStatement, delimiter);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+
+public class ConfigurationHandler {
+
+	private ConfigurationHandler() {}
+
+	/**
+	 * Query the format setting (insertSpace and tabSize) for the given uri.
+	 * Will return {@code null} if the 'workspace/configuration' request is not supported,
+	 * @param uri The target uri to query
+	 * @return 	a map stores the setting keys and their values, for any setting key which is not
+	 * 			available at the client side, a {@code null} value will be provided.
+	 */
+	public static Map<String, Object> getFormattingOptions(String uri) {
+		if (!JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isWorkspaceConfigurationSupported()) {
+			return null;
+		};
+
+		List<ConfigurationItem> configurationItems = new ArrayList<>();
+		// TODO: extract to const once it's available in Preferences.java
+		String[] settingKeys = {"java.format.tabSize", "java.format.insertSpaces"};
+		
+		ConfigurationItem tabSizeItem = new ConfigurationItem();
+		tabSizeItem.setScopeUri(uri);
+		tabSizeItem.setSection(settingKeys[0]);
+		configurationItems.add(tabSizeItem);
+		
+		ConfigurationItem insertSpacesItem = new ConfigurationItem();
+		insertSpacesItem.setScopeUri(uri);
+		insertSpacesItem.setSection(settingKeys[1]);
+		configurationItems.add(insertSpacesItem);
+	
+		ConfigurationParams configurationParams = new ConfigurationParams(configurationItems);
+		List<Object> response = JavaLanguageServerPlugin.getInstance().getClientConnection().configuration(configurationParams);
+
+		Map<String, Object> results = new HashMap<>();
+		int minLength = Math.min(settingKeys.length, response.size());
+		for (int i = 0; i < minLength; i++) {
+			results.put(settingKeys[i], response.get(i));
+		}
+		return results;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandler.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.lsp4j.ConfigurationItem;
 import org.eclipse.lsp4j.ConfigurationParams;
 
@@ -36,8 +37,10 @@ public class ConfigurationHandler {
 		};
 
 		List<ConfigurationItem> configurationItems = new ArrayList<>();
-		// TODO: extract to const once it's available in Preferences.java
-		String[] settingKeys = {"java.format.tabSize", "java.format.insertSpaces"};
+		String[] settingKeys = {
+			Preferences.JAVA_CONFIGURATION_TABSIZE,
+			Preferences.JAVA_CONFIGURATION_INSERTSPACES
+		};
 		
 		ConfigurationItem tabSizeItem = new ConfigurationItem();
 		tabSizeItem.setScopeUri(uri);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -141,7 +141,7 @@ public class FormatterHandler {
 	}
 
 	public static Map<String, String> getOptions(FormattingOptions options, ICompilationUnit cu) {
-		Map<String, String> eclipseOptions = cu.getJavaProject().getOptions(true);
+		Map<String, String> eclipseOptions = cu.getOptions(true);
 
 		Map<String, String> customOptions = options.entrySet().stream().filter(map -> chekIfValueIsNotNull(map.getValue())).collect(toMap(e -> e.getKey(), e -> getOptionValue(e.getValue())));
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -41,6 +41,7 @@ import org.eclipse.jdt.ls.core.internal.BuildWorkspaceStatus;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JVMConfigurator;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
@@ -212,6 +213,11 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		pm.setConnection(client);
 		WorkingCopyOwner.setPrimaryBufferProvider(this.workingCopyOwner);
 		this.documentLifeCycleHandler = new DocumentLifeCycleHandler(this.client, preferenceManager, pm, true);
+	}
+
+	// For testing purpose
+	public void setClientConnection(JavaClientConnection client) {
+		this.client = client;
 	}
 
 	//For testing purposes

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -64,6 +64,9 @@ public class WorkspaceSymbolHandler{
 				@Override
 				public void acceptTypeNameMatch(TypeNameMatch match) {
 					try {
+						if (maxResults > 0 && symbols.size() >= maxResults) {
+							return;
+						}
 						Location location = null;
 						try {
 							if (!sourceOnly && match.getType().isBinary()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -119,6 +119,10 @@ public class ClientPreferences {
 		return v3supported && capabilities.getWorkspace() != null && isDynamicRegistrationSupported(capabilities.getWorkspace().getDidChangeWatchedFiles());
 	}
 
+	public boolean isWorkspaceConfigurationSupported() {
+		return v3supported && capabilities.getWorkspace() != null && isTrue(capabilities.getWorkspace().getConfiguration());
+	}
+
 	public boolean isDocumentSymbolDynamicRegistered() {
 		return v3supported && isDynamicRegistrationSupported(capabilities.getTextDocument().getDocumentSymbol());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -69,6 +69,14 @@ public class Preferences {
 	 */
 	public static final String JAVA_REFERENCES_INCLUDE_DECOMPILED_SOURCES = "java.references.includeDecompiledSources";
 	/**
+	 * Insert spaces when pressing Tab
+	 */
+	public static final String JAVA_CONFIGURATION_INSERTSPACES = "java.format.insertSpaces";
+	/**
+	 * Tab Size
+	 */
+	public static final String JAVA_CONFIGURATION_TABSIZE = "java.format.tabSize";
+	/**
 	 * Specifies Java Execution Environments.
 	 */
 	public static final String JAVA_CONFIGURATION_RUNTIMES = "java.configuration.runtimes";

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -31,6 +31,9 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.19-I-builds/I20210217-1800/"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
             <repository location="https://download.eclipse.org/releases/2020-12/202012161000/"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AbstractQuickFixTest.java
@@ -302,13 +302,17 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 		Assert.assertNotNull(c.getArguments());
 		Assert.assertTrue(c.getArguments().get(0) instanceof WorkspaceEdit);
 		WorkspaceEdit we = (WorkspaceEdit) c.getArguments().get(0);
-		if (we.getDocumentChanges() != null) {
-			return ResourceUtils.dos2Unix(evaluateChanges(we.getDocumentChanges()));
-		}
-		return ResourceUtils.dos2Unix(evaluateChanges(we.getChanges()));
+		return evaluateWorkspaceEdit(we);
 	}
 
-	private String evaluateChanges(List<Either<TextDocumentEdit, ResourceOperation>> documentChanges) throws BadLocationException, JavaModelException {
+	public static String evaluateWorkspaceEdit(WorkspaceEdit edit) throws JavaModelException, BadLocationException {
+		if (edit.getDocumentChanges() != null) {
+			return ResourceUtils.dos2Unix(evaluateChanges(edit.getDocumentChanges()));
+		}
+		return ResourceUtils.dos2Unix(evaluateChanges(edit.getChanges()));
+	}
+
+	public static String evaluateChanges(List<Either<TextDocumentEdit, ResourceOperation>> documentChanges) throws BadLocationException, JavaModelException {
 		List<TextDocumentEdit> changes = documentChanges.stream().filter(e -> e.isLeft()).map(e -> e.getLeft()).collect(Collectors.toList());
 		assertFalse("No edits generated", changes.isEmpty());
 		Set<String> uris = changes.stream().map(tde -> tde.getTextDocument().getUri()).distinct().collect(Collectors.toSet());
@@ -318,7 +322,7 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 		return ResourceUtils.dos2Unix(evaluateChanges(uri, edits));
 	}
 
-	protected String evaluateChanges(Map<String, List<TextEdit>> changes) throws BadLocationException, JavaModelException {
+	public static String evaluateChanges(Map<String, List<TextEdit>> changes) throws BadLocationException, JavaModelException {
 		Iterator<Entry<String, List<TextEdit>>> editEntries = changes.entrySet().iterator();
 		Entry<String, List<TextEdit>> entry = editEntries.next();
 		assertNotNull("No edits generated", entry);
@@ -326,7 +330,7 @@ public class AbstractQuickFixTest extends AbstractProjectsManagerBasedTest {
 		return ResourceUtils.dos2Unix(evaluateChanges(entry.getKey(), entry.getValue()));
 	}
 
-	private String evaluateChanges(String uri, List<TextEdit> edits) throws BadLocationException, JavaModelException {
+	private static String evaluateChanges(String uri, List<TextEdit> edits) throws BadLocationException, JavaModelException {
 		assertFalse("No edits generated: " + edits, edits == null || edits.isEmpty());
 		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri);
 		assertNotNull("CU not found: " + uri, cu);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ConfigurationHandlerTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
+import org.junit.Test;
+
+public class ConfigurationHandlerTest extends AbstractProjectsManagerBasedTest {
+
+    @Test
+    public void testGetConfigurationWhenItIsNotSupported() {
+        ClientPreferences clientPreferences = mock(ClientPreferences.class);
+        when(clientPreferences.isWorkspaceConfigurationSupported()).thenReturn(false);
+        when(preferenceManager.getClientPreferences()).thenReturn(clientPreferences);
+
+        assertNull(ConfigurationHandler.getFormattingOptions("fakeUri"));
+    }
+}


### PR DESCRIPTION
- Enable the capability to fetch indentation settings from the client

Signed-off-by: Sheng Chen <sheche@microsoft.com>

[Jinbo Wang]: Adopt the new compilation unit API to consume the client's formatting options.
- Using ICompliationUnit.getOptions(true) to replace the old options project.getOptions(true)
- Fetch the client's formatting options while generating code action proposals

Fixes #1157
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Based on #1194