### PR TITLE
[feat] Enable workspace lifecycle mapping metadata

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -226,6 +226,11 @@ public class Preferences {
 	public static final String MAVEN_GLOBAL_SETTINGS_KEY = "java.configuration.maven.globalSettings";
 
 	/**
+	 * Preference key for Maven lifecycle-mapping-metadata.xml location.
+	 */
+	public static final String MAVEN_LIFECYCLE_MAPPING_METADATA_KEY = "java.configuration.maven.lifeCycleMappingMetadata";
+
+	/**
 	 * Preference key to enable/disable the 'completion'.
 	 */
 	public static final String COMPLETION_ENABLED_KEY = "java.completion.enabled";
@@ -459,6 +464,7 @@ public class Preferences {
 
 	private String mavenUserSettings;
 	private String mavenGlobalSettings;
+	private String workspaceLifecycleMappingMetadataFile;
 
 	private List<String> javaCompletionFavoriteMembers;
 	private List<?> gradleWrapperList;
@@ -809,6 +815,9 @@ public class Preferences {
 
 		String mavenGlobalSettings = getString(configuration, MAVEN_GLOBAL_SETTINGS_KEY, null);
 		prefs.setMavenGlobalSettings(mavenGlobalSettings);
+
+		String mavenLifecycleMappingMetadata = getString(configuration, MAVEN_LIFECYCLE_MAPPING_METADATA_KEY, null);
+		prefs.setWorkspaceLifecycleMappingMetadataFile(mavenLifecycleMappingMetadata);
 
 		String sortOrder = getString(configuration, MEMBER_SORT_ORDER, null);
 		prefs.setMembersSortOrder(sortOrder);
@@ -1364,6 +1373,15 @@ public class Preferences {
 
 	public String getMavenGlobalSettings() {
 		return mavenGlobalSettings;
+	}
+
+	public Preferences setWorkspaceLifecycleMappingMetadataFile(String mavenLifecycleMetadataMapping) {
+		this.workspaceLifecycleMappingMetadataFile = ResourceUtils.expandPath(mavenLifecycleMetadataMapping);
+		return this;
+	}
+
+	public String getWorkspaceLifecycleMappingMetadataFile() {
+		return workspaceLifecycleMappingMetadataFile;
 	}
 
 	public String[] getImportOrder() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/StandardPreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/StandardPreferenceManager.java
@@ -83,7 +83,18 @@ public class StandardPreferenceManager extends PreferenceManager {
 				getMavenConfiguration().setGlobalSettingsFile(newMavenGlobalSettings);
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException("failed to set Maven global settings", e);
-				preferences.setMavenUserSettings(oldMavenSettings);
+				preferences.setMavenGlobalSettings(oldMavenGlobalSettings);
+			}
+		}
+
+		String newWorkspaceLifecycleMappingMetadata = preferences.getWorkspaceLifecycleMappingMetadataFile();
+		String oldWorkspaceLifecycleMappingMetadata = getMavenConfiguration().getWorkspaceLifecycleMappingMetadataFile();
+		if (!Objects.equals(newWorkspaceLifecycleMappingMetadata, oldWorkspaceLifecycleMappingMetadata)) {
+			try {
+				getMavenConfiguration().setWorkspaceLifecycleMappingMetadataFile(newWorkspaceLifecycleMappingMetadata);
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("failed to set Maven workspace lifecycle mapping metadata", e);
+				preferences.setWorkspaceLifecycleMappingMetadataFile(oldWorkspaceLifecycleMappingMetadata);
 			}
 		}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -95,6 +95,27 @@ public class PreferenceManagerTest {
 	}
 
 	@Test
+	public void testUpdateMavenWorkspaceLifecycleMappingMetadata() throws Exception {
+		String path = "/foo/bar.xml";
+		Preferences preferences = Preferences.createFrom(Collections.singletonMap(Preferences.MAVEN_GLOBAL_SETTINGS_KEY, path));
+		preferenceManager.update(preferences);
+		verify(mavenConfig).setWorkspaceLifecycleMappingMetadataFile(path);
+
+		//check setting the same path doesn't call Maven's config update
+		reset(mavenConfig);
+		when(mavenConfig.getWorkspaceLifecycleMappingMetadataFile()).thenReturn(path);
+		preferenceManager.update(preferences);
+		verify(mavenConfig, never()).setWorkspaceLifecycleMappingMetadataFile(anyString());
+
+		//check setting null is allowed
+		reset(mavenConfig);
+		when(mavenConfig.getWorkspaceLifecycleMappingMetadataFile()).thenReturn(path);
+		preferences.setWorkspaceLifecycleMappingMetadataFile(null);
+		preferenceManager.update(preferences);
+		verify(mavenConfig).setWorkspaceLifecycleMappingMetadataFile(null);
+	}
+
+	@Test
 	public void testInitialize() throws Exception {
 		preferenceManager.initialize();
 		assertEquals(JavaCore.ENABLED, JavaCore.getOptions().get(JavaCore.CODEASSIST_VISIBILITY_CHECK));


### PR DESCRIPTION
## what
This is a setting from [M2E IMavenConfiguration](https://github.com/eclipse-m2e/m2e-core/blob/6e1fe6dac976196977a52ddbb7b103ca8cd63f1e/org.eclipse.m2e.core/src/org/eclipse/m2e/core/embedder/IMavenConfiguration.java#L77) that takes in a filepath to a lifecycle-mapping-metadata.xml file ([ex](https://git.eclipse.org/c/m2e/m2e-core.git/tree/org.eclipse.m2e.lifecyclemapping.defaults/lifecycle-mapping-metadata.xml))

## why
best described in the following issue: https://github.com/redhat-developer/vscode-java/issues/935

If a MOJO does not explicitly define their own lifecycle mapping then their autogenerated files may be left out of the classpath, and from a developer's perspective, the only action they can take is to add a custom lifecycle mapping to their project's pom.xml

While the workaround of adding to your pom is fine for small project with a couple modules, this is really frustrating for large projects with multiple modules.

## changes
- expose a configuration key to set the lifecycle-mapping-metadata.xml
- add new getter/setter to Preferences
- set the lifecycle mapping metadata file in StandardPreferenceManager
- add unit test to PreferenceManagerTest for desired behavior

side change: found a small bug where failing to set the global maven settings would revert the userSettings preferences -- went ahead and patched that here: https://github.com/a1re1/eclipse.jdt.ls/blob/4c041195398c6070460d5f60f1b0a776c81a0d48/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/StandardPreferenceManager.java#L86