### PR TITLE
Adopt the helpers from jdt.core.manipulation to deal with the CU's preferences

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/OverrideMethodsOperation.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/codemanipulation/OverrideMethodsOperation.java
@@ -140,7 +140,7 @@ public class OverrideMethodsOperation {
 			return null;
 		}
 
-		CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(cu.getResource());
+		CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(cu);
 		ImportRewriteContext context = new ContextSensitiveImportRewriteContext(astRoot, typeNode.getStartPosition(), importRewrite);
 		for (IMethodBinding methodBinding : methodBindings) {
 			MethodDeclaration stub = StubUtility2Core.createImplementationStubCore(cu, astRewrite, importRewrite, context, methodBinding, typeBinding, settings, typeBinding.isInterface(), typeNode, false);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -173,7 +173,7 @@ public class AnonymousTypeCompletionProposal {
 					bindings = new IMethodBinding[0];
 				}
 			}
-			CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(fJavaProject.getProject());
+			CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(fCompilationUnit);
 			IMethodBinding[] methodsToOverride = null;
 			settings.createComments = false;
 			List<IMethodBinding> result = new ArrayList<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/OverrideCompletionProposal.java
@@ -138,7 +138,7 @@ public class OverrideCompletionProposal {
 				methodToOverride= Bindings.findMethodInType(node.getAST().resolveWellKnownType("java.lang.Object"), fMethodName, fParamTypes); //$NON-NLS-1$
 			}
 			if (methodToOverride != null) {
-				CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(fJavaProject.getProject());
+				CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(fCompilationUnit);
 				MethodDeclaration stub = StubUtility2Core.createImplementationStubCore(fCompilationUnit, rewrite, importRewrite,
 						context, methodToOverride, declaringType, settings, declaringType.isInterface(), node,
 						snippetStringSupport);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/delegates/DelegateCreator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/refactoring/delegates/DelegateCreator.java
@@ -364,8 +364,8 @@ public abstract class DelegateCreator {
 			TextEdit edit= fDelegateRewrite.getASTRewrite().rewriteAST(document, fDelegateRewrite.getCu().getOptions(true));
 			edit.apply(document, TextEdit.UPDATE_REGIONS);
 
-			int tabWidth = CodeFormatterUtil.getTabWidth(fOriginalRewrite.getCu().getJavaProject());
-			int identWidth = CodeFormatterUtil.getIndentWidth(fOriginalRewrite.getCu().getJavaProject());
+			int tabWidth = CodeFormatterUtil.getTabWidth(fOriginalRewrite.getCu());
+			int identWidth = CodeFormatterUtil.getIndentWidth(fOriginalRewrite.getCu());
 
 			String newSource= Strings.trimIndentation(document.get(fTrackedPosition.getStartPosition(), fTrackedPosition.getLength()),
 					tabWidth, identWidth, false);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/AbstractMethodCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/AbstractMethodCorrectionProposal.java
@@ -172,7 +172,7 @@ public abstract class AbstractMethodCorrectionProposal extends ASTRewriteCorrect
 		}
 		decl.setBody(body);
 
-		CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(getCompilationUnit().getResource());
+		CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(getCompilationUnit());
 		if (settings.createComments && !fSenderBinding.isAnonymous()) {
 			String string = CodeGeneration.getMethodComment(getCompilationUnit(), fSenderBinding.getName(), decl, null,
 					String.valueOf('\n'));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ConstructorFromSuperclassProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ConstructorFromSuperclassProposal.java
@@ -89,7 +89,7 @@ public class ConstructorFromSuperclassProposal extends LinkedCorrectionProposal 
 
 		createImportRewrite((CompilationUnit) fTypeNode.getRoot());
 
-		CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(getCompilationUnit().getJavaProject());
+		CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(getCompilationUnit());
 		if (!settings.createComments) {
 			settings= null;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/JavadocTagsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/JavadocTagsSubProcessor.java
@@ -94,12 +94,12 @@ public class JavadocTagsSubProcessor {
 		protected void addEdits(IDocument document, TextEdit rootEdit) throws CoreException {
 			try {
 				String lineDelimiter= TextUtilities.getDefaultLineDelimiter(document);
-				final IJavaProject project= getCompilationUnit().getJavaProject();
+				final ICompilationUnit unit= getCompilationUnit();
 				IRegion region= document.getLineInformationOfOffset(fInsertPosition);
 
 				String lineContent= document.get(region.getOffset(), region.getLength());
-				String indentString= Strings.getIndentString(lineContent, project);
-				String str= Strings.changeIndent(fComment, 0, project, indentString, lineDelimiter);
+				String indentString= Strings.getIndentString(lineContent, unit);
+				String str= Strings.changeIndent(fComment, 0, unit, indentString, lineDelimiter);
 				InsertEdit edit= new InsertEdit(fInsertPosition, str);
 				rootEdit.addChild(edit);
 				if (fComment.charAt(fComment.length() - 1) != '\n') {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandler.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTesterCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.MoveInnerToTopRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.structure.MoveInstanceMethodProcessor;
@@ -221,7 +222,7 @@ public class MoveHandler {
 		}
 
 		IMethod method = (IMethod) methodBinding.getJavaElement();
-		MoveInstanceMethodProcessor processor = new MoveInstanceMethodProcessor(method, PreferenceManager.getCodeGenerationSettings(method.getJavaProject().getProject()));
+		MoveInstanceMethodProcessor processor = new MoveInstanceMethodProcessor(method, PreferenceManager.getCodeGenerationSettings(unit));
 		Refactoring refactoring = new MoveRefactoring(processor);
 		CheckConditionsOperation check = new CheckConditionsOperation(refactoring, CheckConditionsOperation.INITIAL_CONDITONS);
 		try {
@@ -448,7 +449,7 @@ public class MoveHandler {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Moving instance method...", 100);
 		IMethod method = (IMethod) methodBinding.getJavaElement();
-		MoveInstanceMethodProcessor processor = new MoveInstanceMethodProcessor(method, PreferenceManager.getCodeGenerationSettings(method.getJavaProject().getProject()));
+		MoveInstanceMethodProcessor processor = new MoveInstanceMethodProcessor(method, PreferenceManager.getCodeGenerationSettings(unit));
 		Refactoring refactoring = new MoveRefactoring(processor);
 		CheckConditionsOperation check = new CheckConditionsOperation(refactoring, CheckConditionsOperation.INITIAL_CONDITONS);
 		try {
@@ -514,7 +515,9 @@ public class MoveHandler {
 			return new RefactorWorkspaceEdit("Failed to move static member because no members are selected or no destination is specified.");
 		}
 
-		MoveStaticMembersProcessor processor = new MoveStaticMembersProcessor(members, PreferenceManager.getCodeGenerationSettings(members[0].getJavaProject().getProject()));
+		CodeGenerationSettings settings = members[0].getTypeRoot() instanceof ICompilationUnit ? PreferenceManager.getCodeGenerationSettings((ICompilationUnit) members[0].getTypeRoot())
+											: PreferenceManager.getCodeGenerationSettings(members[0].getJavaProject().getProject());
+		MoveStaticMembersProcessor processor = new MoveStaticMembersProcessor(members, settings);
 		Refactoring refactoring = new MoveRefactoring(processor);
 		CheckConditionsOperation check = new CheckConditionsOperation(refactoring, CheckConditionsOperation.INITIAL_CONDITONS);
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Moving static members...", 100);
@@ -558,7 +561,7 @@ public class MoveHandler {
 
 		SubMonitor subMonitor = SubMonitor.convert(monitor, "Moving type to new file...", 100);
 		try {
-			MoveInnerToTopRefactoring refactoring = new MoveInnerToTopRefactoring(type, PreferenceManager.getCodeGenerationSettings(unit.getJavaProject().getProject()));
+			MoveInnerToTopRefactoring refactoring = new MoveInnerToTopRefactoring(type, PreferenceManager.getCodeGenerationSettings(unit));
 			CheckConditionsOperation check = new CheckConditionsOperation(refactoring, CheckConditionsOperation.ALL_CONDITIONS);
 			check.run(subMonitor.split(50));
 			if (check.getStatus().getSeverity() >= RefactoringStatus.FATAL) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -32,6 +32,7 @@ import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
@@ -253,6 +254,15 @@ public class PreferenceManager {
 		// settings?
 		res.tabWidth = CodeFormatterUtil.getTabWidth(project);
 		res.indentWidth = CodeFormatterUtil.getIndentWidth(project);
+		return res;
+	}
+
+	public static CodeGenerationSettings getCodeGenerationSettings(ICompilationUnit cu) {
+		CodeGenerationSettings res = new CodeGenerationSettings();
+		res.overrideAnnotation = true;
+		res.createComments = false;
+		res.tabWidth = CodeFormatterUtil.getTabWidth(cu);
+		res.indentWidth = CodeFormatterUtil.getIndentWidth(cu);
 		return res;
 	}
 


### PR DESCRIPTION
This is a follow-up with the last PR #1657. 
Adopt the new helper methods from the utilities such as Strings, CodeFormatterUtil and JavaPreferencesSettings to deal with the compilation unit's preferences.

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>