### PR TITLE
Enhance the condition of inline constant

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -324,21 +324,12 @@ public class RefactorProcessor {
 					// Inline Constant (static final field)
 					if (RefactoringAvailabilityTesterCore.isInlineConstantAvailable((IField) varBinding.getJavaElement())) {
 						InlineConstantRefactoring refactoring = new InlineConstantRefactoring(context.getCompilationUnit(), context.getASTRoot(), context.getSelectionOffset(), context.getSelectionLength());
-						if (refactoring != null && refactoring.checkInitialConditions(new NullProgressMonitor()).isOK()) {
+						if (refactoring != null && refactoring.checkInitialConditions(new NullProgressMonitor()).isOK() && refactoring.getReferences(new NullProgressMonitor(), new RefactoringStatus()).length > 0) {
 							refactoring.setRemoveDeclaration(refactoring.isDeclarationSelected());
 							refactoring.setReplaceAllReferences(refactoring.isDeclarationSelected());
 							CheckConditionsOperation check = new CheckConditionsOperation(refactoring, CheckConditionsOperation.FINAL_CONDITIONS);
 							final CreateChangeOperation create = new CreateChangeOperation(check, RefactoringStatus.FATAL);
 							create.run(new NullProgressMonitor());
-							int referenceCount = 0;
-							Change change = create.getChange();
-							Change[] refactoringChanges = ((DynamicValidationRefactoringChange)change).getChildren();
-							for (Change refactoringChange : refactoringChanges) {
-								referenceCount += ((CompilationUnitChange)refactoringChange).getChangeGroups().length;
-							}
-							if (referenceCount <= 1 && refactoring.isDeclarationSelected()) {
-								return true;
-							}
 							String label = ActionMessages.InlineConstantRefactoringAction_label;
 							int relevance = IProposalRelevance.INLINE_LOCAL;
 							ChangeCorrectionProposal proposal = new ChangeCorrectionProposal(label, CodeActionKind.RefactorInline, create.getChange(), relevance);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineConstantTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/InlineConstantTest.java
@@ -123,4 +123,20 @@ public class InlineConstantTest extends AbstractSelectionTest {
 		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
 		assertCodeActionNotExists(cu, INLINE_CONSTANT);
 	}
+
+	@Test
+	public void testInlineConstant_ReferenceInImports() throws Exception {
+		IPackageFragment pack1 = testSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("import java.util.HashMap;\n");
+		buf.append("import java.util.Map;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static final Map /*]*/map/*[*/ = new HashMap<>();\n");
+		buf.append("}\n");
+
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		assertCodeActionNotExists(cu, INLINE_CONSTANT);
+	}
 }


### PR DESCRIPTION
As @testforstephen mentioned [the corner case](https://github.com/eclipse/eclipse.jdt.ls/pull/1575/files#r507586130) in #1575 , it's better to have `getReferences()` in `InlineConstantRefactoring`. Since it has been available in JDT, we can apply it now.

Signed-off-by: Shi Chen <chenshi@microsoft.com>