### PR TITLE
Enhanced IBuildSupport usage to support other build tools such as bazel

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ExtensionsExtractor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ExtensionsExtractor.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * The class simplifies extracting extensions from the extension points.
+ *
+ * @author D.Bushenko
+ *
+ */
+public class ExtensionsExtractor {
+	public static <T> List<T> extractExtensions( final String namespace
+											   , final String extensionPointName) {
+
+		final var extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(namespace, extensionPointName);
+		final var configs = extensionPoint.getConfigurationElements();
+
+		return Arrays
+				.stream(configs)
+				.map(ExtensionsExtractor::<T>makeExtension)
+				.collect(Collectors.toUnmodifiableList());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> T makeExtension(IConfigurationElement config) {
+		try {
+			return (T) config.createExecutableExtension("class");
+
+		} catch (Exception ex) {
+			throw new IllegalArgumentException("Could not create the extension", ex);
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BuildSupportManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/BuildSupportManager.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.managers;
+
+import static org.eclipse.jdt.ls.core.internal.ExtensionsExtractor.extractExtensions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.ls.core.internal.IConstants;
+
+/**
+ * This is an orchestrator who is responsible for fetching and searching
+ * IBuildSupport objects.
+ *
+ * @author D.Bushenko
+ *
+ */
+public class BuildSupportManager {
+	private static final BuildSupportManager instance = new BuildSupportManager();
+	private List<IBuildSupport> lazyLoadedBuildSupportList;
+
+	private BuildSupportManager() {
+	}
+
+	public static List<IBuildSupport> obtainBuildSupports() {
+		if (instance.lazyLoadedBuildSupportList == null) {
+			instance.lazyLoadedBuildSupportList = extractExtensions(IConstants.PLUGIN_ID, "buildSupport");
+		}
+
+		return instance.lazyLoadedBuildSupportList;
+	}
+
+	public static Optional<IBuildSupport> find(IProject project) {
+		return instance.find(bs -> bs.applies(project));
+	}
+
+	public static Optional<IBuildSupport> find(String buildToolName) {
+		return instance.find(bs -> bs.buildToolName().equalsIgnoreCase(buildToolName));
+	}
+
+	/////////
+
+	private Optional<IBuildSupport> find(Predicate<? super IBuildSupport> predicate) {
+		return obtainBuildSupports()
+				.stream()
+				.filter(predicate)
+				.findFirst();
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseBuildSupport.java
@@ -103,5 +103,9 @@ public class EclipseBuildSupport implements IBuildSupport {
 		}
 	}
 
+	@Override
+	public String buildToolName() {
+		return "Eclipse";
+	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -98,7 +98,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 					.addExclusions("**/build")//default gradle build dir
 					.addExclusions("**/bin");
 			for (IProject project : ProjectUtils.getAllProjects()) {
-				if (!ProjectUtils.isGradleProject(project)) {
+				if (!BuildSupportManager.find("Gradle").get().applies(project)) {
 					String path = project.getLocation().toOSString();
 					gradleDetector.addExclusions(path);
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -137,4 +137,10 @@ public interface IBuildSupport {
 	default void unregisterPreferencesChangeListener(PreferenceManager preferenceManager) throws CoreException {
 	}
 
+	String buildToolName();
+
+	default boolean hasTemporaryProjectFolder() {
+		return false;
+	}
+
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -137,7 +137,9 @@ public interface IBuildSupport {
 	default void unregisterPreferencesChangeListener(PreferenceManager preferenceManager) throws CoreException {
 	}
 
-	String buildToolName();
+	default String buildToolName() {
+		return "UnknownBuildTool";
+	}
 
 	default boolean hasTemporaryProjectFolder() {
 		return false;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.managers;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClassFile;
@@ -143,6 +145,9 @@ public interface IBuildSupport {
 
 	default boolean hasTemporaryProjectFolder() {
 		return false;
+	}
+
+	default void deleteInvalidProjects(Collection<IPath> rootPaths, IProgressMonitor monitor) {
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupport.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.m2e.core.internal.MavenPluginActivator;
 import org.eclipse.m2e.core.internal.project.ProjectConfigurationManager;
 import org.eclipse.m2e.core.internal.project.registry.ProjectRegistryManager;
@@ -66,7 +67,7 @@ public class MavenBuildSupport implements IBuildSupport {
 
 	@Override
 	public boolean applies(IProject project) {
-		return ProjectUtils.isMavenProject(project);
+		return ProjectUtils.hasNature(project, IMavenConstants.NATURE_ID);
 	}
 
 	@Override
@@ -92,7 +93,7 @@ public class MavenBuildSupport implements IBuildSupport {
 	}
 
 	public void collectProjects(Collection<IProject> projects, IProject project, IProgressMonitor monitor) {
-		if (!project.isOpen() || !ProjectUtils.isMavenProject(project)) {
+		if (!project.isOpen() || !applies(project)) {
 			return;
 		}
 		projects.add(project);
@@ -153,6 +154,11 @@ public class MavenBuildSupport implements IBuildSupport {
 	@Override
 	public List<String> getWatchPatterns() {
 		return WATCH_FILE_PATTERNS;
+	}
+
+	@Override
+	public String buildToolName() {
+		return "Maven";
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -90,7 +90,10 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 					.addExclusions("**/target"); //default maven build dir
 			//@formatter:on
 			for (IProject project : ProjectUtils.getAllProjects()) {
-				if (!ProjectUtils.isMavenProject(project)) {
+				// MavenBuildSupport must be available, otherwise the whole system is broken.
+				IBuildSupport buildSupport = BuildSupportManager.find("Maven").get();
+
+				if (!buildSupport.applies(project)) {
 					String path = project.getLocation().toOSString();
 					mavenDetector.addExclusions(path);
 				}
@@ -151,7 +154,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			} else {
 				IProject project = container.getProject();
 				boolean valid = !ProjectUtils.isJavaProject(project) || project.getFile(IJavaProject.CLASSPATH_FILE_NAME).exists();
-				if (ProjectUtils.isMavenProject(project) && valid) {
+				if (BuildSupportManager.find("Maven").get().applies(project) && valid) {
 					projects.add(container.getProject());
 				} else if (project != null) {
 					//Project doesn't have the Maven nature, so we (re)import it

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -349,9 +349,12 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 
 	@Override
 	public Job updateProject(IProject project, boolean force) {
-		if (project == null || (!ProjectUtils.isMavenProject(project) && !ProjectUtils.isGradleProject(project))) {
+		// Try to find any build support which will handle this project.
+		// It may be built-in maven/gradle or extended with plugins bazel support.
+		if (BuildSupportManager.find(project).isEmpty()) {
 			return null;
 		}
+
 		JavaLanguageServerPlugin.sendStatus(ServiceStatus.Message, "Updating " + project.getName() + " configuration");
 		WorkspaceJob job = new WorkspaceJob("Update project " + project.getName()) {
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -125,16 +125,20 @@ public class StandardProjectsManager extends ProjectsManager {
 			if (project.equals(getDefaultProject())) {
 				continue;
 			}
-			if (project.exists() && (ResourceUtils.isContainedIn(project.getLocation(), rootPaths) || ProjectUtils.isGradleProject(project) || workspaceProjects.contains(project.getName()))) {
+
+			if (project.exists() && (ResourceUtils.isContainedIn(project.getLocation(), rootPaths) ||
+									 workspaceProjects.contains(project.getName()))) {
 				try {
-					project.getDescription();
-					if (ProjectUtils.isGradleProject(project)) {
+					Optional<IBuildSupport> maybeBuildSupport = BuildSupportManager.find(project);
+					if (maybeBuildSupport.isPresent() && maybeBuildSupport.get().hasTemporaryProjectFolder()) {
+						project.getDescription();
 						if (ResourceUtils.isContainedIn(project.getLocation(), rootPaths)) {
 							validGradleProjects.add(project);
 						} else {
 							suspiciousGradleProjects.add(project);
 						}
 					}
+
 				} catch (CoreException e) {
 					try {
 						project.delete(true, monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AdvancedOrganizeImportsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AdvancedOrganizeImportsHandlerTest.java
@@ -33,10 +33,10 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.ValidateEditException;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.AbstractSourceTestCase;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler.ImportCandidate;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler.ImportSelection;
+import org.eclipse.jdt.ls.core.internal.managers.BuildSupportManager;
 import org.eclipse.text.edits.TextEdit;
 import org.junit.Test;
 
@@ -142,7 +142,7 @@ public class AdvancedOrganizeImportsHandlerTest extends AbstractSourceTestCase {
 	public void testAmbiguousStaticImports() throws Exception {
 		importProjects("maven/salut4");
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject("salut4");
-		assertTrue(ProjectUtils.isMavenProject(project));
+		assertTrue(BuildSupportManager.find("Maven").get().applies(project));
 		String[] favourites = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getJavaCompletionFavoriteMembers();
 		try {
 			List<String> list = new ArrayList<>();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractGradleBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractGradleBasedTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 
 /**
  * @author Fred Bricon
@@ -43,7 +42,7 @@ public abstract class AbstractGradleBasedTest extends AbstractProjectsManagerBas
 
 	protected void assertIsGradleProject(IProject project) {
 		assertNotNull(project);
-		assertTrue(project.getName() +" is missing the Gradle nature", ProjectUtils.isGradleProject(project));
+		assertTrue(project.getName() + " is missing the Gradle nature", BuildSupportManager.find("Gradle").get().applies(project));
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractMavenBasedTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 
 /**
  * @author Fred Bricon
@@ -53,7 +52,7 @@ public abstract class AbstractMavenBasedTest extends AbstractProjectsManagerBase
 
 	protected void assertIsMavenProject(IProject project) {
 		assertNotNull(project);
-		assertTrue(project.getName() +" is missing the Maven nature", ProjectUtils.isMavenProject(project));
+		assertTrue(project.getName() + " is missing the Maven nature", BuildSupportManager.find("Maven").get().applies(project));
 	}
 
 	protected String comment(String s, String from, String to) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -165,7 +165,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			assertEquals(2, projects.size());//default + 1 eclipse projects
 			IProject eclipse = WorkspaceHelper.getProject("eclipsegradle");
 			assertNotNull(eclipse);
-			assertTrue(eclipse.getName() + " does not have the Gradle nature", ProjectUtils.isGradleProject(eclipse));
+			assertTrue(eclipse.getName() + " does not have the Gradle nature", BuildSupportManager.find("Gradle").get().applies(eclipse));
 		} finally {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGradleWrapperEnabled(enabled);
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGradleVersion(gradleVersion);
@@ -184,7 +184,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			assertEquals(2, projects.size());//default + 1 eclipse projects
 			IProject project = WorkspaceHelper.getProject("simple-gradle");
 			assertNotNull(project);
-			assertTrue(project.getName() + " does not have the Gradle nature", ProjectUtils.isGradleProject(project));
+			assertTrue(project.getName() + " does not have the Gradle nature", BuildSupportManager.find("Gradle").get().applies(project));
 			assertTrue(gradleUserHome.exists());
 			ProjectConfiguration projectConfiguration = CorePlugin.configurationManager().loadProjectConfiguration(project);
 			assertEquals(gradleUserHome, projectConfiguration.getBuildConfiguration().getGradleUserHome());
@@ -250,7 +250,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 			assertEquals(2, projects.size());//default + 1 eclipse projects
 			IProject eclipse = WorkspaceHelper.getProject("eclipse");
 			assertNotNull(eclipse);
-			assertFalse(eclipse.getName() + " has the Gradle nature", ProjectUtils.isGradleProject(eclipse));
+			assertFalse(eclipse.getName() + " has the Gradle nature", BuildSupportManager.find("Gradle").get().applies(eclipse));
 		} finally {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setImportGradleEnabled(enabled);
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenBuildSupportTest.java
@@ -46,7 +46,6 @@ import org.eclipse.jdt.internal.core.BinaryType;
 import org.eclipse.jdt.ls.core.internal.DependencyUtil;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.SourceContentProvider;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
@@ -227,11 +226,11 @@ public class MavenBuildSupportTest extends AbstractMavenBasedTest {
 	public void testBatchImport() throws Exception {
 		IProject project = importMavenProject("batch");
 		waitForBackgroundJobs();
-		assertTrue(ProjectUtils.isMavenProject(project));
+		assertTrue(BuildSupportManager.find("Maven").get().applies(project));
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		assertEquals(root.getProjects().length, 14);
 		project = root.getProject("batchchild");
-		assertTrue(ProjectUtils.isMavenProject(project));
+		assertTrue(BuildSupportManager.find("Maven").get().applies(project));
 	}
 
 	protected void testNonStandardCompilerId(String projectName) throws Exception {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -41,7 +41,6 @@ import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.handlers.ProgressReporterManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
@@ -143,7 +142,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 			assertEquals(2, projects.size());//default + 1 eclipse projects
 			IProject eclipse = WorkspaceHelper.getProject("eclipse");
 			assertNotNull(eclipse);
-			assertFalse(eclipse.getName() + " has the Maven nature", ProjectUtils.isMavenProject(eclipse));
+			assertFalse(eclipse.getName() + " has the Maven nature", BuildSupportManager.find("Maven").get().applies(eclipse));
 		} finally {
 			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setImportMavenEnabled(enabled);
 		}


### PR DESCRIPTION
Removed hardcoded checks for maven and gradle build tools.
Removed implicit assumption that there only two build tools: maven and gradle.
Enhanced IBuildSupport usage so that we may add more build tools such as bazel.

Signed-off-by: Dmitry Bushenko <d.bushenko@gmail.com>