### PR TITLE
Update formatter profile options before applying

### DIFF
--- a/org.eclipse.jdt.ls.tests/formatter resources/version13.xml
+++ b/org.eclipse.jdt.ls.tests/formatter resources/version13.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="Eclipse" version="13">
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+</profile>
+</profiles>


### PR DESCRIPTION
Will update formatter options to the newest version before applying them. This could work for many scenarios where deprecated formatter settings (in previous profile version) are ignored.

Fixes redhat-developer/vscode-java#1640

Signed-off-by: Shi Chen <chenshi@microsoft.com>