### PR TITLE
Add more options to query project settings

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -223,6 +224,22 @@ public final class ProjectUtils {
 		}
 
 		return result.toArray(new IPath[0]);
+	}
+
+	public static IPath[] listReferencedLibraries(IJavaProject project) throws JavaModelException {
+		List<IPath> libraries = new LinkedList<>();
+		for (IClasspathEntry entry : project.getRawClasspath()) {
+			if (entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+				IClasspathEntry resolvedEntry = JavaCore.getResolvedClasspathEntry(entry);
+				if (resolvedEntry == null) {
+					continue;
+				}
+
+				libraries.add(resolvedEntry.getPath());
+			}
+		}
+
+		return libraries.toArray(IPath[]::new);
 	}
 
 	public static boolean isOnSourcePath(IPath sourcePath, IJavaProject project) throws JavaModelException {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -62,7 +62,7 @@ public class ProjectCommand {
 
 	public static final String VM_LOCATION = IConstants.PLUGIN_ID + ".vm.location";
 	public static final String SOURCE_PATHS = IConstants.PLUGIN_ID + ".sourcePaths";
-	public static final String DEFAULT_OUTPUT_PATH = IConstants.PLUGIN_ID + ".defaultOutputPath";
+	public static final String OUTPUT_PATH = IConstants.PLUGIN_ID + ".outputPath";
 	public static final String REFERENCED_LIBRARIES = IConstants.PLUGIN_ID + ".referencedLibraries";
 	private static final String TEST_SCOPE_VALUE = "test";
 
@@ -78,8 +78,8 @@ public class ProjectCommand {
 	 *                        Besides the options defined in JavaCore, the following keys can also be used:
 	 *                        - "org.eclipse.jdt.ls.core.vm.location": Get the location of the VM assigned to build the given Java project
 	 *                        - "org.eclipse.jdt.ls.core.sourcePaths": Get the source root paths of the given Java project
-	 *                        - "org.eclipse.jdt.ls.core.defaultOutputPath": Get the default output path of the given Java project. Note that the default output path
-	 *                                                                       may not be equal to the output path of each source root.
+	 *                        - "org.eclipse.jdt.ls.core.outputPath": Get the default output path of the given Java project. Note that the default output path
+	 *                                                                may not be equal to the output path of each source root.
 	 *                        - "org.eclipse.jdt.ls.core.referencedLibraries": Get all the referenced library files of the given Java project
 	 * @return A <code>Map<string, string></code> with all the setting keys and
 	 *         their values.
@@ -109,7 +109,7 @@ public class ProjectCommand {
 							.toArray(String[]::new);
 					settings.putIfAbsent(key, sourcePaths);
 					break;
-				case DEFAULT_OUTPUT_PATH:
+				case OUTPUT_PATH:
 					IPath outputPath = javaProject.getOutputLocation();
 					if (outputPath == null) {
 						settings.putIfAbsent(key, "");

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -60,6 +61,9 @@ import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 public class ProjectCommand {
 
 	public static final String VM_LOCATION = IConstants.PLUGIN_ID + ".vm.location";
+	public static final String SOURCE_PATHS = IConstants.PLUGIN_ID + ".sourcePaths";
+	public static final String DEFAULT_OUTPUT_PATH = IConstants.PLUGIN_ID + ".defaultOutputPath";
+	public static final String REFERENCED_LIBRARIES = IConstants.PLUGIN_ID + ".referencedLibraries";
 	private static final String TEST_SCOPE_VALUE = "test";
 
 	/**
@@ -73,14 +77,19 @@ public class ProjectCommand {
 	 *                        "org.eclipse.jdt.core.compiler.source"].
 	 *                        Besides the options defined in JavaCore, the following keys can also be used:
 	 *                        - "org.eclipse.jdt.ls.core.vm.location": Get the location of the VM assigned to build the given Java project
+	 *                        - "org.eclipse.jdt.ls.core.sourcePaths": Get the source root paths of the given Java project
+	 *                        - "org.eclipse.jdt.ls.core.defaultOutputPath": Get the default output path of the given Java project. Note that the default output path
+	 *                                                                       may not be equal to the output path of each source root.
+	 *                        - "org.eclipse.jdt.ls.core.referencedLibraries": Get all the referenced library files of the given Java project
 	 * @return A <code>Map<string, string></code> with all the setting keys and
 	 *         their values.
 	 * @throws CoreException
 	 * @throws URISyntaxException
 	 */
-	public static Map<String, String> getProjectSettings(String uri, List<String> settingKeys) throws CoreException, URISyntaxException {
+	public static Map<String, Object> getProjectSettings(String uri, List<String> settingKeys) throws CoreException, URISyntaxException {
 		IJavaProject javaProject = getJavaProjectFromUri(uri);
-		Map<String, String> settings = new HashMap<>();
+		IProject project = javaProject.getProject();
+		Map<String, Object> settings = new HashMap<>();
 		for (String key : settingKeys) {
 			switch(key) {
 				case VM_LOCATION:
@@ -93,6 +102,26 @@ public class ProjectCommand {
 						continue;
 					}
 					settings.putIfAbsent(key, location.getAbsolutePath());
+					break;
+				case SOURCE_PATHS:
+					String[] sourcePaths = Arrays.stream(ProjectUtils.listSourcePaths(javaProject))
+							.map(p -> project.getFolder(p.makeRelativeTo(project.getFullPath())).getLocation().toOSString())
+							.toArray(String[]::new);
+					settings.putIfAbsent(key, sourcePaths);
+					break;
+				case DEFAULT_OUTPUT_PATH:
+					IPath outputPath = javaProject.getOutputLocation();
+					if (outputPath == null) {
+						settings.putIfAbsent(key, "");
+					} else {
+						settings.putIfAbsent(key, project.getFolder(outputPath.makeRelativeTo(project.getFullPath())).getLocation().toOSString());
+					}
+					break;
+				case REFERENCED_LIBRARIES:
+					String[] referencedLibraries = Arrays.stream(ProjectUtils.listReferencedLibraries(javaProject))
+							.map(p -> p.toOSString())
+							.toArray(String[]::new);
+					settings.putIfAbsent(key, referencedLibraries);
 					break;
 				default:
 					settings.putIfAbsent(key, javaProject.getOption(key, true));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -98,9 +98,9 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
     public void testGetProjectOutputPath() throws Exception {
         IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
         String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
-        List<String> settingKeys = Arrays.asList(ProjectCommand.DEFAULT_OUTPUT_PATH);
+        List<String> settingKeys = Arrays.asList(ProjectCommand.OUTPUT_PATH);
         Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
-        String actualOutputPath = (String) options.get(ProjectCommand.DEFAULT_OUTPUT_PATH);
+        String actualOutputPath = (String) options.get(ProjectCommand.OUTPUT_PATH);
         String expectedOutputPath = project.getFolder("bin").getLocation().toOSString();
         assertEquals(expectedOutputPath, actualOutputPath);
     }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -46,7 +46,7 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         IProject project = WorkspaceHelper.getProject("salut");
         String uriString = project.getFile("src/main/java/Foo.java").getLocationURI().toString();
         List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
-        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
         assertEquals(settingKeys.size(), options.size());
         assertEquals("1.7", options.get("org.eclipse.jdt.core.compiler.compliance"));
@@ -59,7 +59,7 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         IProject project = WorkspaceHelper.getProject("salut2");
         String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
         List<String> settingKeys = Arrays.asList("org.eclipse.jdt.core.compiler.compliance", "org.eclipse.jdt.core.compiler.source");
-        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
         assertEquals(settingKeys.size(), options.size());
         assertEquals("1.8", options.get("org.eclipse.jdt.core.compiler.compliance"));
@@ -72,7 +72,7 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         IProject project = WorkspaceHelper.getProject("salut2");
         String uriString = project.getFile("src/main/java/foo/Bar.java").getLocationURI().toString();
         List<String> settingKeys = Arrays.asList(ProjectCommand.VM_LOCATION);
-        Map<String, String> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(uriString, settingKeys);
 
         IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(uriString);
         IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
@@ -80,6 +80,41 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         File location = vmInstall.getInstallLocation();
         assertNotNull(location);
         assertEquals(location.getAbsolutePath(), options.get(ProjectCommand.VM_LOCATION));
+    }
+
+    @Test
+    public void testGetProjectSourcePaths() throws Exception {
+        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList(ProjectCommand.SOURCE_PATHS);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+        String[] actualSourcePaths = (String[]) options.get(ProjectCommand.SOURCE_PATHS);
+        String expectedSourcePath = project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("src").getLocation().toOSString();
+        assertTrue(actualSourcePaths.length == 1);
+        assertEquals(expectedSourcePath, actualSourcePaths[0]);
+    }
+
+    @Test
+    public void testGetProjectOutputPath() throws Exception {
+        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList(ProjectCommand.DEFAULT_OUTPUT_PATH);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+        String actualOutputPath = (String) options.get(ProjectCommand.DEFAULT_OUTPUT_PATH);
+        String expectedOutputPath = project.getFolder("bin").getLocation().toOSString();
+        assertEquals(expectedOutputPath, actualOutputPath);
+    }
+
+    @Test
+    public void testGetProjectReferencedLibraryPaths() throws Exception {
+        IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
+        String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
+        List<String> settingKeys = Arrays.asList(ProjectCommand.REFERENCED_LIBRARIES);
+        Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
+        String[] actualReferencedLibraryPaths = (String[]) options.get(ProjectCommand.REFERENCED_LIBRARIES);
+        String expectedReferencedLibraryPath = project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("lib").getFile("mylib.jar").getLocation().toOSString();
+        assertTrue(actualReferencedLibraryPaths.length == 1);
+        assertEquals(expectedReferencedLibraryPath, actualReferencedLibraryPaths[0]);
     }
 
     @Test
@@ -97,7 +132,6 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
 
     @Test
     public void testGetInvisibleProjectFromUri() throws Exception {
-        importProjects("singlefile/simple");
         IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
         String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();
         IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(linkedFolder);


### PR DESCRIPTION
Add more options in the API `getProjectSettings` for other down-stream dependencies to use.

requires https://github.com/redhat-developer/vscode-java/pull/1828

Signed-off-by: Sheng Chen <sheche@microsoft.com>