### PR TITLE
Correct minor typo in exception message

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -172,7 +172,7 @@ public final class ProjectUtils {
 
 		if (!parentSrcPaths.isEmpty()) {
 			throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, Messages
-					.format("Cannot add the folder ''{0}'' to the source path because it''s parent folder is already in the source path of the project ''{1}''.", new String[] { sourcePath.toOSString(), project.getProject().getName() })));
+					.format("Cannot add the folder ''{0}'' to the source path because its parent folder is already in the source path of the project ''{1}''.", new String[] { sourcePath.toOSString(), project.getProject().getName() })));
 		}
 
 		if (exclusionPaths != null) {


### PR DESCRIPTION
Correct a minor typo in the exception message that responds to a failed attempt to add a folder to the Java source path which is already implicitly included by one of its parents.

Fixes redhat-developer/vscode-java#1833