### PR TITLE
Add source method declaration lookups to the workspace symbol search.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -74,6 +74,12 @@ public class Preferences {
 	 * references.
 	 */
 	public static final String JAVA_REFERENCES_INCLUDE_DECOMPILED_SOURCES = "java.references.includeDecompiledSources";
+
+	/**
+	 * Include method declarations from source files in symbol search.
+	 */
+	public static final String JAVA_SYMBOLS_INCLUDE_SOURCE_METHOD_DECLARATIONS = "java.symbols.includeSourceMethodDeclarations";
+
 	/**
 	 * Insert spaces when pressing Tab
 	 */
@@ -103,6 +109,7 @@ public class Preferences {
 	 * Specifies the file path or url to the Java setting.
 	 */
 	public static final String JAVA_SETTINGS_URL = "java.settings.url";
+
 	/**
 	 * Specifies filter applied on projects to exclude some file system objects
 	 * while populating the resources tree.
@@ -490,6 +497,7 @@ public class Preferences {
 	private List<String> preferredContentProviderIds;
 	private boolean includeAccessors;
 	private boolean includeDecompiledSources;
+	private boolean includeSourceMethodDeclarations;
 
 	private String mavenUserSettings;
 	private String mavenGlobalSettings;
@@ -698,6 +706,7 @@ public class Preferences {
 		resourceFilters = JAVA_RESOURCE_FILTERS_DEFAULT;
 		includeAccessors = true;
 		includeDecompiledSources = true;
+		includeSourceMethodDeclarations = false;
 		insertSpaces = true;
 		tabSize = DEFAULT_TAB_SIZE;
 	}
@@ -970,6 +979,8 @@ public class Preferences {
 		prefs.setIncludeAccessors(includeAccessors);
 		boolean includeDecompiledSources = getBoolean(configuration, JAVA_REFERENCES_INCLUDE_DECOMPILED_SOURCES, true);
 		prefs.setIncludeDecompiledSources(includeDecompiledSources);
+		boolean includeSourceMethodDeclarations = getBoolean(configuration, JAVA_SYMBOLS_INCLUDE_SOURCE_METHOD_DECLARATIONS, false);
+		prefs.setIncludeSourceMethodDeclarations(includeSourceMethodDeclarations);
 		return prefs;
 	}
 
@@ -1671,6 +1682,14 @@ public class Preferences {
 
 	public boolean isIncludeDecompiledSources() {
 		return this.includeDecompiledSources;
+	}
+
+	public boolean isIncludeSourceMethodDeclarations() {
+		return this.includeSourceMethodDeclarations;
+	}
+
+	public void setIncludeSourceMethodDeclarations(boolean includeSourceMethodDeclarations) {
+		this.includeSourceMethodDeclarations = includeSourceMethodDeclarations;
 	}
 
 	public Preferences setInsertSpaces(boolean insertSpaces) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -166,4 +166,22 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		boolean hasEmptyName = results.stream().filter(s -> (s.getName() == null || s.getName().isEmpty())).findFirst().isPresent();
 		assertFalse("Found empty name", hasEmptyName);
 	}
+
+	@Test
+	public void testSearchSourcMethodDeclarations() {
+		preferences.setIncludeSourceMethodDeclarations(true);
+		List<SymbolInformation> results = handler.search("deleteSomething", "hello", true, monitor);
+		assertNotNull(results);
+		assertEquals("Found " + results.size() + " result", 1, results.size());
+		SymbolInformation res = results.get(0);
+		assertEquals(SymbolKind.Method, res.getKind());
+		assertEquals(res.getContainerName(), "org.sample.Baz");
+
+		results = handler.search("main", "hello", true, monitor);
+		assertNotNull(results);
+		assertEquals("Found " + results.size() + " result", 9, results.size());
+		boolean allMethods = results.stream().allMatch(s -> s.getKind() == SymbolKind.Method);
+		assertTrue("Found a non-method symbol", allMethods);
+		preferences.setIncludeSourceMethodDeclarations(false);
+	}
 }


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

I think the term "symbol" can include more than just type declarations. Pretty much any member should be included. With that said, including declarations from non-sources could bring up too many matches, so I've included just method declarations from source files.

![method_decl_search](https://user-images.githubusercontent.com/1417342/110992350-cc62b300-8343-11eb-862c-1c0f6f9d090b.gif)