### PR TITLE
Fix failed to find root path when workspace changes

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListener.java
@@ -47,11 +47,12 @@ public class InvisibleProjectPreferenceChangeListener implements IPreferencesCha
 
 				try {
 					IFolder workspaceLinkFolder = javaProject.getProject().getFolder(ProjectUtils.WORKSPACE_LINK);
-					if (!workspaceLinkFolder.exists()) {
+					IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(workspaceLinkFolder.getLocation());
+					if (rootPath == null) {
 						continue;
 					}
 					List<IPath> sourcePaths = InvisibleProjectImporter.getSourcePaths(newPreferences.getInvisibleProjectSourcePaths(), workspaceLinkFolder);
-					List<IPath> excludingPaths = InvisibleProjectImporter.getExcludingPath(javaProject, null, workspaceLinkFolder);
+					List<IPath> excludingPaths = InvisibleProjectImporter.getExcludingPath(javaProject, rootPath, workspaceLinkFolder);
 					IPath outputPath = InvisibleProjectImporter.getOutputPath(javaProject, newPreferences.getInvisibleProjectOutputPath(), true /*isUpdate*/);
 					IClasspathEntry[] classpathEntries = InvisibleProjectImporter.resolveClassPathEntries(javaProject, sourcePaths, excludingPaths, outputPath);
 					javaProject.setRawClasspath(classpathEntries, outputPath, new NullProgressMonitor());


### PR DESCRIPTION
Fix a regression bug introduced in #1658 

When debugging Java Language Server, and the workspace changed, a error message pops as below:

![WeChat Screenshot_20210312163642](https://user-images.githubusercontent.com/6193897/111095543-9ce8bc00-8578-11eb-9f5d-f71b7e711aec.png)

This is because some stale elements remains in the JDT workspace.

Signed-off-by: Sheng Chen <sheche@microsoft.com>