### PR TITLE
Check the existence of source folders when setting source paths

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -266,7 +266,10 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 			if (new org.eclipse.core.runtime.Path(sourcePath).isAbsolute()) {
 				throw new CoreException(new Status(IStatus.ERROR, IConstants.PLUGIN_ID, "The source path must be a relative path to the workspace."));
 			}
-			sourceList.add(workspaceLinkFolder.getFolder(sourcePath).getFullPath());
+			IFolder sourceFolder = workspaceLinkFolder.getFolder(sourcePath);
+			if (sourceFolder.exists()) {
+				sourceList.add(sourceFolder.getFullPath());
+			}
 		}
 		return sourceList;
 	}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/simple/test/Test.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/simple/test/Test.java
@@ -1,0 +1,2 @@
+public class Test {
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -287,9 +287,8 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 				sourcePaths.add(entry.getPath().makeRelativeTo(linkFolder.getFullPath()).toString());
 			}
 		}
-		assertEquals(2, sourcePaths.size());
+		assertEquals(1, sourcePaths.size());
 		assertTrue(sourcePaths.contains("foo"));
-		assertTrue(sourcePaths.contains("bar"));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
@@ -101,7 +101,7 @@ public class InvisibleProjectPreferenceChangeListenerTest extends AbstractInvisi
 
 		Preferences newPreferences = new Preferences();
 		initPreferences(newPreferences);
-		newPreferences.setInvisibleProjectSourcePaths(Arrays.asList("src", "src2"));
+		newPreferences.setInvisibleProjectSourcePaths(Arrays.asList("src", "test"));
 		InvisibleProjectPreferenceChangeListener listener = new InvisibleProjectPreferenceChangeListener();
 		listener.preferencesChange(preferenceManager.getPreferences(), newPreferences);
 
@@ -116,7 +116,7 @@ public class InvisibleProjectPreferenceChangeListenerTest extends AbstractInvisi
 
 		assertEquals(2, sourcePaths.size());
 		assertTrue(sourcePaths.contains("src"));
-		assertTrue(sourcePaths.contains("src2"));
+		assertTrue(sourcePaths.contains("test"));
 	}
 
 	@Test


### PR DESCRIPTION
When setting the source path in `settings.json` but the folder does not exist, an error will be thrown when build the project:

```
MESSAGE Error occured while building workspace. Details: 
 message: Project 'invisble-project_7472d942' is missing required source folder: '_/src2'; code: 964;
```

So this PR check the existence of the source folder before add it into the source paths.

Signed-off-by: Sheng Chen <sheche@microsoft.com>