### PR TITLE
Support String formatting via delegate command

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -56,6 +56,9 @@
                   id="java.edit.organizeImports">
             </command>
             <command
+                  id="java.edit.stringFormatting">
+            </command>
+            <command
                   id="java.project.updateSourceAttachment">
             </command>
             <command

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -14,6 +14,7 @@ package org.eclipse.jdt.ls.core.internal;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -22,6 +23,7 @@ import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
+import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.ResolveSourceMappingHandler;
 import org.eclipse.jdt.ls.core.internal.commands.SemanticTokensCommand;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
@@ -57,6 +59,9 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 						// workspaceEdit on the custom command.
 						return result;
 					}
+				case "java.edit.stringFormatting":
+					FormatterHandler handler = new FormatterHandler(JavaLanguageServerPlugin.getPreferencesManager());
+					return handler.stringFormatting((String) arguments.get(0), JSONUtility.toModel(arguments.get(1), Map.class), Integer.parseInt((String) arguments.get(2)), monitor);
 				case "java.project.resolveSourceAttachment":
 					return SourceAttachmentCommand.resolveSourceAttachment(arguments, monitor);
 				case "java.project.updateSourceAttachment":

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -324,8 +324,7 @@ public class FormatterHandler {
 	 *                    the content to format
 	 * @param options
 	 *                    the Map includes formatter options, If set to
-	 *                    <code>null</code>, then use the current settings from
-	 *                    <code>JavaCore#getOptions</code>.
+	 *                    <code>null</code>, then use the default formatter settings.
 	 * @param version
 	 *                    the version of the formatter options
 	 * @param monitor
@@ -337,11 +336,13 @@ public class FormatterHandler {
 		IDocument document = new Document();
 		document.set(content);
 		Map<String, String> formatOptions = new HashMap<String, String>();
-		if (options != null && version < ProfileVersionerCore.getCurrentVersion()) {
-			formatOptions = ProfileVersionerCore.updateAndComplete(options, version);
-		} else {
+		if (options == null || version == ProfileVersionerCore.getCurrentVersion()) {
 			formatOptions = DefaultCodeFormatterOptions.getEclipseDefaultSettings().getMap();
-			formatOptions.putAll(options);
+			if (options != null) {
+				formatOptions.putAll(options);
+			}
+		} else {
+			formatOptions = ProfileVersionerCore.updateAndComplete(options, version);
 		}
 		CodeFormatter formatter = ToolFactory.createCodeFormatter(formatOptions);
 		IRegion region = new Region(0, document.getLength());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -335,15 +335,7 @@ public class FormatterHandler {
 	public String stringFormatting(String content, Map<String, String> options, int version, IProgressMonitor monitor) {
 		IDocument document = new Document();
 		document.set(content);
-		Map<String, String> formatOptions = new HashMap<String, String>();
-		if (options == null || version == ProfileVersionerCore.getCurrentVersion()) {
-			formatOptions = DefaultCodeFormatterOptions.getEclipseDefaultSettings().getMap();
-			if (options != null) {
-				formatOptions.putAll(options);
-			}
-		} else {
-			formatOptions = ProfileVersionerCore.updateAndComplete(options, version);
-		}
+		Map<String, String> formatOptions = (options == null) ? DefaultCodeFormatterOptions.getEclipseDefaultSettings().getMap() : ProfileVersionerCore.updateAndComplete(options, version);
 		CodeFormatter formatter = ToolFactory.createCodeFormatter(formatOptions);
 		IRegion region = new Region(0, document.getLength());
 		int kind = CodeFormatter.K_COMPILATION_UNIT;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -16,6 +16,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,10 +34,13 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.corext.refactoring.util.TextEditUtil;
+import org.eclipse.jdt.internal.formatter.DefaultCodeFormatterOptions;
+import org.eclipse.jdt.internal.ui.preferences.formatter.ProfileVersionerCore;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
@@ -311,4 +315,48 @@ public class FormatterHandler {
 		return null;
 	}
 
+	/**
+	 * A utility function to format a String with given formatter options.
+	 *
+	 * @see org.eclipse.jdt.core.formatter.CodeFormatterApplication#formatFile(File,
+	 *      CodeFormatter)
+	 * @param content
+	 *                    the content to format
+	 * @param options
+	 *                    the Map includes formatter options, If set to
+	 *                    <code>null</code>, then use the current settings from
+	 *                    <code>JavaCore#getOptions</code>.
+	 * @param version
+	 *                    the version of the formatter options
+	 * @param monitor
+	 *                    the progress monitor
+	 *
+	 * @return the formatted String
+	 */
+	public String stringFormatting(String content, Map<String, String> options, int version, IProgressMonitor monitor) {
+		IDocument document = new Document();
+		document.set(content);
+		Map<String, String> formatOptions = new HashMap<String, String>();
+		if (options != null && version < ProfileVersionerCore.getCurrentVersion()) {
+			formatOptions = ProfileVersionerCore.updateAndComplete(options, version);
+		} else {
+			formatOptions = DefaultCodeFormatterOptions.getEclipseDefaultSettings().getMap();
+			formatOptions.putAll(options);
+		}
+		CodeFormatter formatter = ToolFactory.createCodeFormatter(formatOptions);
+		IRegion region = new Region(0, document.getLength());
+		int kind = CodeFormatter.K_COMPILATION_UNIT;
+		if (preferenceManager.getPreferences().isJavaFormatComments()) {
+			kind = kind | CodeFormatter.F_INCLUDE_COMMENTS;
+		}
+		TextEdit edit = formatter.format(kind, content, region.getOffset(), region.getLength(), 0, TextUtilities.getDefaultLineDelimiter(document));
+		if (edit != null) {
+			try {
+				edit.apply(document);
+			} catch (Exception e) {
+				// Do nothing
+			}
+		}
+		return document.get();
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
@@ -789,21 +789,64 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testStringFormattingWithUpdating() throws Exception {
+		//@formatter:off
+		String text = "package org.sample;\n"
+					+ "\n"
+					+ "    public      class     Baz {public void test1() {Object o = new Object() {};}}  \n";
+		//@formatter:on
+		Map<String, String> options = new HashMap<>();
+		options.put("org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration", "do not insert");
+		FormatterHandler handler = new FormatterHandler(preferenceManager);
+		String formattedText =  handler.stringFormatting(text, options, 13, monitor);
+		//@formatter:off
+		String expectedText =
+			  "package org.sample;\n"
+			+ "\n"
+			+ "public class Baz {\n"
+			+ "\tpublic void test1() {\n"
+			+ "\t\tObject o = new Object() {};\n"
+			+ "\t}\n"
+			+ "}\n";
+		//@formatter:on
+		assertEquals(formattedText, expectedText);
+	}
+
+	@Test
 	public void testStringFormatting() throws Exception {
 		//@formatter:off
 		String text = "package org.sample;\n"
 					+ "\n"
 					+ "    public      class     Baz {}  \n";
 		//@formatter:on
+		FormatterHandler handler = new FormatterHandler(preferenceManager);
 		Map<String, String> options = new HashMap<>();
 		options.put("org.eclipse.jdt.core.formatter.blank_lines_after_package", "3");
-		FormatterHandler handler = new FormatterHandler(preferenceManager);
 		String formattedText =  handler.stringFormatting(text, options, 21, monitor);
 		//@formatter:off
 		String expectedText =
 			  "package org.sample;\n"
 			+ "\n"
 			+ "\n"
+			+ "\n"
+			+ "public class Baz {\n"
+			+ "}\n";
+		//@formatter:on
+		assertEquals(formattedText, expectedText);
+	}
+
+	@Test
+	public void testStringFormattingWithDefaultSettings() throws Exception {
+		//@formatter:off
+		String text = "package org.sample;\n"
+					+ "\n"
+					+ "    public      class     Baz {}  \n";
+		//@formatter:on
+		FormatterHandler handler = new FormatterHandler(preferenceManager);
+		String formattedText =  handler.stringFormatting(text, null, 21, monitor);
+		//@formatter:off
+		String expectedText =
+			  "package org.sample;\n"
 			+ "\n"
 			+ "public class Baz {\n"
 			+ "}\n";

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandlerTest.java
@@ -18,7 +18,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
@@ -786,6 +788,28 @@ public class FormatterHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals(textResult, newText);
 	}
 
+	@Test
+	public void testStringFormatting() throws Exception {
+		//@formatter:off
+		String text = "package org.sample;\n"
+					+ "\n"
+					+ "    public      class     Baz {}  \n";
+		//@formatter:on
+		Map<String, String> options = new HashMap<>();
+		options.put("org.eclipse.jdt.core.formatter.blank_lines_after_package", "3");
+		FormatterHandler handler = new FormatterHandler(preferenceManager);
+		String formattedText =  handler.stringFormatting(text, options, 21, monitor);
+		//@formatter:off
+		String expectedText =
+			  "package org.sample;\n"
+			+ "\n"
+			+ "\n"
+			+ "\n"
+			+ "public class Baz {\n"
+			+ "}\n";
+		//@formatter:on
+		assertEquals(formattedText, expectedText);
+	}
 
 	@After
 	public void tearDown() {


### PR DESCRIPTION
When developing the Java formatter Setting Page, a preview part is needed. However, existing format methods have the following limitation:
- Based on file. If we have a temporary file containing the preview content background, the writing or modifying on the file will trigger VS Code (maybe other clients as well) to open an editor on the temporary file. This behavior can only be avoided by calling `document.save()` after applying `WorkspaceEdit` in VS Code by now, see https://github.com/microsoft/vscode/issues/96920. but saving the content to disk will cost more time than just keeping them in the memory.
- The current mechanism of formatting in Language Server is to monitor the modifying of the formatter profile. As a preview, the frequency of changing the settings would be frequent, which may cause saving to the local xml file many times.

Thus, I would like to offer a delegate command to support string formatting with given options. 

Signed-off-by: Shi Chen <chenshi@microsoft.com>