### PR TITLE
Configure source suffix array to a Java libraries.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -428,9 +428,16 @@ public final class ProjectUtils {
 	public static IPath detectSources(Path file) {
 		String filename = file.getFileName().toString();
 		//better approach would be to (also) resolve sources using Maven central, or anything smarter really
-		String sourceName = filename.substring(0, filename.lastIndexOf(JAR_SUFFIX)) + SOURCE_JAR_SUFFIX;
-		Path sourcePath = file.getParent().resolve(sourceName);
-		return Files.isRegularFile(sourcePath) ? new org.eclipse.core.runtime.Path(sourcePath.toString()) : null;
+
+		// "java.references.detectSourcesJarSuffix" : ["-sources.jar", "_src.jar"];
+		List<String> detectSourcesJarSuffix = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getDetectSourcesJarSuffix();
+
+		for (String source_jar_suffix : detectSourcesJarSuffix) {
+			String sourceName = filename.substring(0, filename.lastIndexOf(JAR_SUFFIX)) + source_jar_suffix;
+			Path sourcePath = file.getParent().resolve(sourceName);
+			if(Files.isRegularFile(sourcePath))
+				return new org.eclipse.core.runtime.Path(sourcePath.toString());
+		}
 	}
 
 	private static boolean isBinary(Path file) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -390,6 +390,8 @@ public class Preferences {
 	public static final String JAVA_TEMPLATES_FILEHEADER = "java.templates.fileHeader";
 	// Specifies the type comment snippets for new Java type.
 	public static final String JAVA_TEMPLATES_TYPECOMMENT = "java.templates.typeComment";
+	// Specifies the source suffix array to a Java libraries.
+	public static final String JAVA_REFERENCES_DETECTSOURCESJARSUFFIX = "java.references.detectSourcesJarSuffix";
 
 	/**
 	 * The preferences for generating toString method.
@@ -516,6 +518,7 @@ public class Preferences {
 	private Set<RuntimeEnvironment> runtimes = new HashSet<>();
 	private List<String> resourceFilters;
 
+	private List<String> detectSourcesJarSuffix = new LinkedList<>();
 	private List<String> fileHeaderTemplate = new LinkedList<>();
 	private List<String> typeCommentTemplate = new LinkedList<>();
 	private boolean insertSpaces;
@@ -970,6 +973,9 @@ public class Preferences {
 		prefs.setIncludeAccessors(includeAccessors);
 		boolean includeDecompiledSources = getBoolean(configuration, JAVA_REFERENCES_INCLUDE_DECOMPILED_SOURCES, true);
 		prefs.setIncludeDecompiledSources(includeDecompiledSources);
+
+		List<String> detectSourcesJarSuffix = getList(configuration, JAVA_REFERENCES_DETECTSOURCESJARSUFFIX);
+		prefs.setDetectSourcesJarSuffix(detectSourcesJarSuffix);
 		return prefs;
 	}
 
@@ -1699,5 +1705,13 @@ public class Preferences {
 			options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, String.valueOf(tabSize));
 		}
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, insertSpaces ? JavaCore.SPACE : JavaCore.TAB);
+	}
+
+	public List<String> getDetectSourcesJarSuffix() {
+		return detectSourcesJarSuffix;
+	}
+
+	public void setDetectSourcesJarSuffix(List<String> detectSourcesJarSuffix) {
+		this.detectSourcesJarSuffix = detectSourcesJarSuffix;
 	}
 }


### PR DESCRIPTION
## More free detection of source code packages. 
> Support ["-sources.jar", "_src.jar"]
- because there are many enterprise packages with custom suffixes. Cannot find the source code for development using vscode