### PR TITLE
Ignore o.e.jdt.core.compiler.problem.missingSerialVersion by default.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -132,6 +132,7 @@ public class PreferenceManager {
 		javaCoreOptions.put(JavaCore.COMPILER_PB_UNHANDLED_WARNING_TOKEN, JavaCore.IGNORE);
 		javaCoreOptions.put(JavaCore.COMPILER_PB_REDUNDANT_SUPERINTERFACE, JavaCore.WARNING);
 		javaCoreOptions.put(JavaCore.CODEASSIST_SUBWORD_MATCH, JavaCore.DISABLED);
+		javaCoreOptions.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JavaCore.IGNORE);
 		JavaCore.setOptions(javaCoreOptions);
 	}
 

--- a/org.eclipse.jdt.ls.tests/formatter/settings.prefs
+++ b/org.eclipse.jdt.ls.tests/formatter/settings.prefs
@@ -1,1 +1,1 @@
-org.eclipse.jdt.core.compiler.problem.missingSerialVersion=ignore
+org.eclipse.jdt.core.compiler.problem.missingSerialVersion=warning

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JavaSettingsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JavaSettingsTest.java
@@ -70,9 +70,9 @@ public class JavaSettingsTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testFilePath() throws Exception {
-		assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
-		assertEquals("warning", javaProject.getOption(MISSING_SERIAL_VERSION, true));
-		testMarkers(1);
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+		testMarkers(0);
 		try {
 			Bundle bundle = Platform.getBundle(JavaLanguageServerTestPlugin.PLUGIN_ID);
 			URL settingsUrl = bundle.getEntry("/formatter/settings.prefs");
@@ -83,17 +83,17 @@ public class JavaSettingsTest extends AbstractCompilationUnitBasedTest {
 			StandardProjectsManager.configureSettings(preferences);
 			assertTrue(preferences.getSettingsAsURI().isAbsolute());
 			JobHelpers.waitForJobsToComplete();
-			assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
-			assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
-			testMarkers(0);
+			assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
+			assertEquals("warning", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+			testMarkers(1);
 		} finally {
 			JavaCore.setOptions(options);
 			preferences.setSettingsUrl(null);
 			StandardProjectsManager.configureSettings(preferences);
 		}
-		assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
 		JobHelpers.waitForJobsToComplete();
-		testMarkers(1);
+		testMarkers(0);
 	}
 
 	private void testMarkers(int count) throws JavaModelException, CoreException {
@@ -104,21 +104,21 @@ public class JavaSettingsTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testRelativeFilePath() throws Exception {
-		assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
-		assertEquals("warning", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
 		try {
 			String settingsUrl = "../../formatter/settings.prefs";
 			preferences.setSettingsUrl(settingsUrl);
 			StandardProjectsManager.configureSettings(preferences);
 			assertTrue(preferences.getSettingsAsURI().isAbsolute());
-			assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
-			assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+			assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
+			assertEquals("warning", javaProject.getOption(MISSING_SERIAL_VERSION, true));
 		} finally {
 			JavaCore.setOptions(options);
 			preferences.setSettingsUrl(null);
 			StandardProjectsManager.configureSettings(preferences);
 		}
-		assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
 	}
 
 }


### PR DESCRIPTION
- Fixes #1714

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>