### PR TITLE
Javadoc @param description lost when retrieved from inheriting class.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavadocContentAccess2.java
@@ -1899,6 +1899,7 @@ public class JavadocContentAccess2 {
 			}
 		}
 		fBuf.append(BLOCK_TAG_END);
+		fBuf.append(BlOCK_TAG_ENTRY_END);
 	}
 
 	private void handleThrowsTag(TagElement tag) {
@@ -1934,6 +1935,7 @@ public class JavadocContentAccess2 {
 			String name = parameterNames.get(i);
 			if (name != null) {
 				fBuf.append(BLOCK_TAG_START);
+				fBuf.append(BlOCK_TAG_ENTRY_START);
 				fBuf.append(PARAM_NAME_START);
 				if (isTypeParameters) {
 					fBuf.append("&lt;"); //$NON-NLS-1$
@@ -1946,9 +1948,12 @@ public class JavadocContentAccess2 {
 				if (description != null) {
 					fBuf.append(description);
 				}
+				fBuf.append(BlOCK_TAG_ENTRY_END);
 				fBuf.append(BLOCK_TAG_END);
 			}
 		}
+
+		fBuf.append(BlOCK_TAG_ENTRY_END);
 	}
 
 	private void handleParamTag(TagElement tag) {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Bar.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Bar.java
@@ -20,7 +20,7 @@ public class Bar extends Foo {
     public void somethingElseFromLombok(){}
    
     @Override
-    public void foo() {
-      super.foo();
+    public void foo(String input) {
+      super.foo("lombok");
     }
 }

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Foo.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/java/Foo.java
@@ -11,6 +11,7 @@ public class Foo {
 	
 	/**
 	 * This method comes from Foo
+	 * @param input an input String
 	 */
-	public void foo() {}
+	public void foo(String input) {}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeLensHandlerTest.java
@@ -150,7 +150,7 @@ public class CodeLensHandlerTest extends AbstractProjectsManagerBasedTest {
 		cl = result.get(1);
 		r = cl.getRange();
 		// CodeLens on foo method
-		assertRange(14, 13, 16, r);
+		assertRange(15, 13, 16, r);
 
 		cl = result.get(2);
 		r = cl.getRange();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HoverHandlerTest.java
@@ -299,7 +299,8 @@ public class HoverHandlerTest extends AbstractProjectsManagerBasedTest {
 		// then
 		assertNotNull(hover);
 		String result = hover.getContents().getLeft().get(1).getLeft();//
-		assertEquals("Unexpected hover ", "This method comes from Foo", result);
+		String expected = "This method comes from Foo\n" + "\n" + " *  **Parameters:**\n" + "    \n" + "     *  **input** an input String";
+		assertEquals("Unexpected hover ", expected, result);
 	}
 
 	@Test


### PR DESCRIPTION
- Surround javadoc @param entry with a block tag entry.
- Fixes #1732
- Adjust existing testcase to handle @param description

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>