### PR TITLE
When version is unknown, text document identifier version should be null

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ChangeUtil.java
@@ -282,7 +282,7 @@ public class ChangeUtil {
 				root.setDocumentChanges(changes);
 			}
 
-			VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, 0);
+			VersionedTextDocumentIdentifier identifier = new VersionedTextDocumentIdentifier(uri, null);
 			TextDocumentEdit documentEdit = new TextDocumentEdit(identifier, textEdits);
 			changes.add(Either.forLeft(documentEdit));
 		} else {


### PR DESCRIPTION
- A TextDocumentEdit's 'textDocument' field is an
  OptionalVersionedTextDocumentIdentifier whose version can be null to
  indicate that the version is not known
- Fixes #1695

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>