### PR TITLE
Fix class literal keyword semantic token

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/SemanticTokensVisitor.java
@@ -183,9 +183,12 @@ public class SemanticTokensVisitor extends ASTVisitor {
 	@Override
 	public boolean visit(TypeLiteral node) {
 		acceptNode(node.getType());
-		// The last 5 characters of a TypeLiteral are the "class" keyword
-		int offset = node.getStartPosition() + node.getLength() - 5;
-		addToken(offset, 5, TokenType.KEYWORD, 0);
+		// Don't add "class" keyword token for recovered type literals
+		if ((node.getFlags() & ASTNode.RECOVERED) == 0) {
+			// The last 5 characters of a TypeLiteral are the "class" keyword
+			int offset = node.getStartPosition() + node.getLength() - 5;
+			addToken(offset, 5, TokenType.KEYWORD, 0);
+		}
 		return false;
 	}
 

--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/ClassLiterals.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/ClassLiterals.java
@@ -1,0 +1,14 @@
+package foo;
+
+public class ClassLiterals {
+
+	Class<?> c = String.class;
+
+	public static void main(String[] args) {
+		Class<?> clazz = ClassLiterals.class;
+		if (clazz.) {
+
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/SemanticTokensCommandTest.java
@@ -364,6 +364,14 @@ public class SemanticTokensCommandTest extends AbstractProjectsManagerBasedTest 
 		.endAssertion();
 	}
 
+	@Test
+	public void testSemanticTokens_ClassLiterals() throws JavaModelException {
+		TokenAssertionHelper.beginAssertion(getURI("ClassLiterals.java"), "keyword")
+			.assertNextToken("class", "keyword")
+			.assertNextToken("class", "keyword")
+		.endAssertion();
+	}
+
 	private String getURI(String compilationUnitName) {
 		return JDTUtils.toURI(fooPackage.getCompilationUnit(compilationUnitName));
 	}


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#1921

The cause of the issue is that some expressions with a period after them are recovered as `TypeLiteral`s, which causes the semantic token visitor to put a `keyword` semantic token there. To fix this, I added a check to avoid adding the `keyword` token for recovered `TypeLiteral`s.