### PR TITLE
Remove version constraints from .launch files

### DIFF
--- a/launch/jdt.ls.remote.server.launch
+++ b/launch/jdt.ls.remote.server.launch
@@ -39,11 +39,11 @@
 <setEntry value="ch.qos.logback.classic@default:default"/>
 <setEntry value="ch.qos.logback.core@default:default"/>
 <setEntry value="ch.qos.logback.slf4j@default:default"/>
-<setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
+<setEntry value="com.google.gson@default:default"/>
 <setEntry value="com.google.guava@default:default"/>
 <setEntry value="javax.inject@default:default"/>
 <setEntry value="org.apache.ant@default:default"/>
-<setEntry value="org.apache.commons.io*2.6.0.v20190123-2029@default:default"/>
+<setEntry value="org.apache.commons.io@default:default"/>
 <setEntry value="org.apache.commons.lang3@default:default"/>
 <setEntry value="org.apache.felix.scr@1:true"/>
 <setEntry value="org.apache.log4j@default:default"/>

--- a/launch/jdt.ls.socket-stream.syntaxserver.launch
+++ b/launch/jdt.ls.socket-stream.syntaxserver.launch
@@ -38,7 +38,7 @@
 <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
 <setAttribute key="selected_features"/>
 <setAttribute key="selected_target_bundles">
-<setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
+<setEntry value="com.google.gson@default:default"/>
 <setEntry value="com.google.guava@default:default"/>
 <setEntry value="javax.inject@default:default"/>
 <setEntry value="org.apache.commons.lang3@default:default"/>


### PR DESCRIPTION
Fixes #1754.

Even though I only needed to remove the version constraint for `com.google.gson` to fix the issue, I also removed the one for `org.apache.commons.io`. Unless I've missed something these version constraints are unnecessary and will just lead to future problems when libraries/target platforms are updated.