### PR TITLE
Add a preference to control the severity of not covered maven plugin execution

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -122,7 +122,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 		JavaLanguageServerPlugin.logInfo(IMPORTING_MAVEN_PROJECTS);
 		MavenConfigurationImpl configurationImpl = (MavenConfigurationImpl)MavenPlugin.getMavenConfiguration();
 		configurationImpl.setDownloadSources(JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isMavenDownloadSources());
-		configurationImpl.setNotCoveredMojoExecutionSeverity(ProblemSeverity.ignore.toString());
+		configurationImpl.setNotCoveredMojoExecutionSeverity(JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getMavenNotCoveredPluginExecutionSeverity());
 		SubMonitor subMonitor = SubMonitor.convert(monitor, 105);
 		subMonitor.setTaskName(IMPORTING_MAVEN_PROJECTS);
 		Set<MavenProjectInfo> files = getMavenProjectInfo(subMonitor.split(5));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -261,6 +261,8 @@ public class Preferences {
 	 */
 	public static final String MAVEN_GLOBAL_SETTINGS_KEY = "java.configuration.maven.globalSettings";
 
+	public static final String MAVEN_NOT_COVERED_PLUGIN_EXECUTION_SEVERITY = "java.configuration.maven.notCoveredPluginExecutionSeverity";
+
 	/**
 	 * Preference key to enable/disable the 'completion'.
 	 */
@@ -501,6 +503,7 @@ public class Preferences {
 
 	private String mavenUserSettings;
 	private String mavenGlobalSettings;
+	private String mavenNotCoveredPluginExecutionSeverity;
 
 	private List<String> javaCompletionFavoriteMembers;
 	private List<?> gradleWrapperList;
@@ -734,6 +737,7 @@ public class Preferences {
 		includeSourceMethodDeclarations = false;
 		insertSpaces = true;
 		tabSize = DEFAULT_TAB_SIZE;
+		mavenNotCoveredPluginExecutionSeverity = "ignore";
 	}
 
 	/**
@@ -896,6 +900,9 @@ public class Preferences {
 
 		String mavenGlobalSettings = getString(configuration, MAVEN_GLOBAL_SETTINGS_KEY, null);
 		prefs.setMavenGlobalSettings(mavenGlobalSettings);
+
+		String mavenNotCoveredPluginExecution = getString(configuration, MAVEN_NOT_COVERED_PLUGIN_EXECUTION_SEVERITY, "ignore");
+		prefs.setMavenNotCoveredPluginExecutionSeverity(mavenNotCoveredPluginExecution);
 
 		String sortOrder = getString(configuration, MEMBER_SORT_ORDER, null);
 		prefs.setMembersSortOrder(sortOrder);
@@ -1523,6 +1530,14 @@ public class Preferences {
 
 	public String getMavenGlobalSettings() {
 		return mavenGlobalSettings;
+	}
+
+	public String getMavenNotCoveredPluginExecutionSeverity() {
+		return mavenNotCoveredPluginExecutionSeverity;
+	}
+
+	public void setMavenNotCoveredPluginExecutionSeverity(String mavenNotCoveredPluginExecutionSeverity) {
+		this.mavenNotCoveredPluginExecutionSeverity = mavenNotCoveredPluginExecutionSeverity;
 	}
 
 	public String[] getImportOrder() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/StandardPreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/StandardPreferenceManager.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.embedder.IMavenConfiguration;
 import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.internal.preferences.MavenConfigurationImpl;
 import org.eclipse.m2e.core.internal.preferences.MavenPreferenceConstants;
 import org.eclipse.m2e.core.internal.preferences.ProblemSeverity;
 
@@ -87,6 +88,15 @@ public class StandardPreferenceManager extends PreferenceManager {
 			}
 		}
 
+		String newMavenNotCoveredExecutionSeverity = preferences.getMavenNotCoveredPluginExecutionSeverity();
+		String oldMavenNotCoveredExecutionSeverity = getMavenConfiguration().getNotCoveredMojoExecutionSeverity();
+		if (!Objects.equals(newMavenNotCoveredExecutionSeverity, oldMavenNotCoveredExecutionSeverity)) {
+			try {
+				((MavenConfigurationImpl) getMavenConfiguration()).setNotCoveredMojoExecutionSeverity(newMavenNotCoveredExecutionSeverity);
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("failed to set not covered Maven plugin execution severity", e);
+			}
+		}
 		updateParallelBuild(preferences.getMaxConcurrentBuilds());
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -51,6 +51,7 @@ public class PreferenceManagerTest {
 	public void setUp() {
 		preferenceManager = new StandardPreferenceManager();
 		preferenceManager.setMavenConfiguration(mavenConfig);
+		when(mavenConfig.getNotCoveredMojoExecutionSeverity()).thenReturn("ignore");
 	}
 
 	@Test
@@ -64,12 +65,14 @@ public class PreferenceManagerTest {
 		//check setting the same path doesn't call Maven's config update
 		reset(mavenConfig);
 		when(mavenConfig.getUserSettingsFile()).thenReturn(path);
+		when(mavenConfig.getNotCoveredMojoExecutionSeverity()).thenReturn("ignore");
 		preferenceManager.update(preferences);
 		verify(mavenConfig, never()).setUserSettingsFile(anyString());
 
 		//check setting null is allowed
 		reset(mavenConfig);
 		when(mavenConfig.getUserSettingsFile()).thenReturn(path);
+		when(mavenConfig.getNotCoveredMojoExecutionSeverity()).thenReturn("ignore");
 		preferences.setMavenUserSettings(null);
 		preferenceManager.update(preferences);
 		verify(mavenConfig).setUserSettingsFile(null);
@@ -85,12 +88,14 @@ public class PreferenceManagerTest {
 		//check setting the same path doesn't call Maven's config update
 		reset(mavenConfig);
 		when(mavenConfig.getGlobalSettingsFile()).thenReturn(path);
+		when(mavenConfig.getNotCoveredMojoExecutionSeverity()).thenReturn("ignore");
 		preferenceManager.update(preferences);
 		verify(mavenConfig, never()).setGlobalSettingsFile(anyString());
 
 		//check setting null is allowed
 		reset(mavenConfig);
 		when(mavenConfig.getGlobalSettingsFile()).thenReturn(path);
+		when(mavenConfig.getNotCoveredMojoExecutionSeverity()).thenReturn("ignore");
 		preferences.setMavenGlobalSettings(null);
 		preferenceManager.update(preferences);
 		verify(mavenConfig).setGlobalSettingsFile(null);


### PR DESCRIPTION
If the client does not define this preference, the server will use the default value of "ignore". This ensures that existing clients are not broken.