### PR TITLE
Add a timeout to waitForInitializeJobs()

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
@@ -162,7 +162,11 @@ public final class JobHelpers {
 	}
 
 	public static void waitForInitializeJobs() {
-		waitForJobs(InitializeJobMatcher.INSTANCE, MAX_TIME_MILLIS);
+		waitForInitializeJobs(MAX_TIME_MILLIS);
+	}
+
+	public static void waitForInitializeJobs(int maxTimeMillis) {
+		waitForJobs(InitializeJobMatcher.INSTANCE, maxTimeMillis);
 	}
 
 	public static void waitForDownloadSourcesJobs(int maxTimeMillis) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -243,7 +243,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public void initialized(InitializedParams params) {
 		logInfo(">> initialized");
 		try {
-			JobHelpers.waitForInitializeJobs();
+			JobHelpers.waitForInitializeJobs(60 * 60 * 1000); // 1 hour
 		} catch (OperationCanceledException e) {
 			logException(e.getMessage(), e);
 		}


### PR DESCRIPTION
The previous implementation of waitForInitializeJobs() will just wait for 5 minutes, which is not enough for first-time import of a large project.

I change it to 1 hour, which should cover the most cases.