### PR TITLE
Introduce syntaxServerExitsOnShutdown as an extended capability.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -263,6 +263,10 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("actionableRuntimeNotificationSupport", "false").toString());
 	}
 
+	public boolean isSyntaxServerExitsOnShutdown() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("syntaxServerExitsOnShutdown", "false").toString());
+	}
+
 	public boolean isGradleChecksumWrapperPromptSupport() {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("gradleChecksumWrapperPromptSupport", "false").toString());
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
@@ -137,6 +137,17 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 		return computeAsync((monitor) -> {
 			shutdownJob.schedule();
 			shutdownReceived = true;
+			if (preferenceManager.getClientPreferences().isSyntaxServerExitsOnShutdown()) {
+				exit();
+				try {
+					/*
+					 * Suppress annoying error message in client, by encouraging
+					 * syntax server to exit before shutdown() can respond to client.
+					 */
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+				}
+			}
 			return new Object();
 		});
 	}


### PR DESCRIPTION
- In languageclient 7.x, the client fails to send the necessary exit()
  once a shutdown() response is received from the language server
- When client defines syntaxServerExitsOnShutdown as true, the language
  server will exit immediately after the shutdown request

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>