### PR TITLE
Run test without setting lombok agent

### DIFF
--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -20,7 +20,7 @@
 					<artifactId>tycho-surefire-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
-						<argLine>${tycho.testArgLine} ${os.testArgs}</argLine>
+						<argLine>${tycho.testArgLine} ${os.testArgs} ${lombokArgs}</argLine>
 						<runOrder>random</runOrder>
 						<providerProperties>
 							<excludegroups>org.eclipse.jdt.ls.tests.Unstable</excludegroups>
@@ -32,6 +32,35 @@
 		</pluginManagement>
 	</build>
 	<profiles>
+		<profile>
+			<id>lombok</id>
+			<activation>
+				<property>
+					<name>jdt.ls.lombok.disabled</name>
+					<value>!true</value>
+				</property>
+			</activation>
+			<properties>
+				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.20.jar</lombokArgs>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.projectlombok</groupId>
+									<artifactId>lombok</artifactId>
+									<version>1.18.20</version>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>macosx-jvm-flags</id>
 			<activation>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 		<sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
 		<!-- To handle OSX-specific settings -->
 		<os.testArgs></os.testArgs>
+		<lombokArgs></lombokArgs>
 		<!-- skip for local builds, set it to true on Eclipse.org infrastructure -->
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
 		<generateSourceRef>true</generateSourceRef>


### PR DESCRIPTION
Fixes #1782 

You can disable lombok with:

```
./mvnw clean verify -Djdt.ls.lombok.disabled=true
```

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>