### PR TITLE
Standard language server should also be able to exit on shutdown.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -381,6 +381,9 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		return computeAsync((monitor) -> {
 			shutdownJob.schedule();
 			shutdownReceived = true;
+			if (preferenceManager.getClientPreferences().shouldLanguageServerExitOnShutdown()) {
+				Executors.newSingleThreadScheduledExecutor().schedule(() -> exit(), 1, TimeUnit.SECONDS);
+			}
 			return new Object();
 		});
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -263,8 +263,8 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("actionableRuntimeNotificationSupport", "false").toString());
 	}
 
-	public boolean isSyntaxServerExitsOnShutdown() {
-		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("syntaxServerExitsOnShutdown", "false").toString());
+	public boolean shouldLanguageServerExitOnShutdown() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("shouldLanguageServerExitOnShutdown", "false").toString());
 	}
 
 	public boolean isGradleChecksumWrapperPromptSupport() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
@@ -137,7 +137,7 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 		return computeAsync((monitor) -> {
 			shutdownJob.schedule();
 			shutdownReceived = true;
-			if (preferenceManager.getClientPreferences().isSyntaxServerExitsOnShutdown()) {
+			if (preferenceManager.getClientPreferences().shouldLanguageServerExitOnShutdown()) {
 				exit();
 				try {
 					/*


### PR DESCRIPTION
The standard language server has the same issue the syntax server did. It doesn't exit immediately on shutdown request. It relies on the parent process watcher, but I believe that can take up to 30s in the worst case.

- "syntaxServerExitsOnShutdown" -> "shouldLanguageServerExitOnShutdown"
- Shut down the standard language server on shutdown() similar to the
  syntax server, when "shouldLanguageServerExitOnShutdown" extended
  capability is enabled
- Unlike the syntax server shutdown, the standard server has no issues
  if shutdown() returns to the client, before exit() completes

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>