### PR TITLE
Update eclipse-jarsigner-plugin to 1.3.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 				<plugin>
 					<groupId>org.eclipse.cbi.maven.plugins</groupId>
 					<artifactId>eclipse-jarsigner-plugin</artifactId>
-					<version>1.1.3</version>
+					<version>1.3.2</version>
 					<executions>
 						<execution>
 							<id>sign</id>
@@ -257,7 +257,6 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.4</version>
 						<executions>
 							<execution>
 								<id>sign</id>


### PR DESCRIPTION
See https://ci.eclipse.org/ls/job/jdt-ls-master/1136/consoleFull. We started failing due to https://www.eclipse.org/lists/cross-project-issues-dev/msg18545.html.

- Update to >= 1.3.0 as required by Eclipse infrastructure
- Version not required to be listed if specified in pluginManagement

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>