### PR TITLE
Defer constant/default value calculation to completionResolve request instead of completion request

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2018 Red Hat Inc. and others.
+ * Copyright (c) 2016-2021 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -28,24 +28,17 @@ import org.eclipse.jdt.core.CompletionRequestor;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.ISourceRange;
-import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.core.SourceRange;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResolveHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResponses;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
-import org.eclipse.jface.text.Region;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionItemTag;
@@ -235,48 +228,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		$.setData(data);
 		this.descriptionProvider.updateDescription(proposal, $);
 		$.setSortText(SortTextHelper.computeSortText(proposal));
-		if (proposal.getKind() == CompletionProposal.FIELD_REF) {
-			try {
-				IField field = JDTUtils.resolveField(proposal, unit.getJavaProject());
-				Region nameRegion = null;
-				if (field != null) {
-					ITypeRoot typeRoot = field.getTypeRoot();
-					ISourceRange nameRange = ((ISourceReference) field).getNameRange();
-					if (SourceRange.isAvailable(nameRange)) {
-						nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
-					}
-					String constantValue = JDTUtils.getConstantValue(field, typeRoot, nameRegion);
-					if (constantValue != null) {
-						String label = $.getLabel();
-						$.setLabel(label + " = " + constantValue);
-						data.put(CompletionResolveHandler.DATA_FIELD_CONSTANT_VALUE, constantValue);
-					}
-				}
-			} catch (JavaModelException e) {
-				JavaLanguageServerPlugin.log(e);
-			}
-		}
-		if (proposal.getKind() == CompletionProposal.METHOD_REF || proposal.getKind() == CompletionProposal.ANNOTATION_ATTRIBUTE_REF) {
-			try {
-				IMethod method = JDTUtils.resolveMethod(proposal, unit.getJavaProject());
-				Region nameRegion = null;
-				if (method != null) {
-					ITypeRoot typeRoot = method.getTypeRoot();
-					ISourceRange nameRange = ((ISourceReference) method).getNameRange();
-					if (SourceRange.isAvailable(nameRange)) {
-						nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
-					}
-					String defaultValue = JDTUtils.getAnnotationMemberDefaultValue(method, typeRoot, nameRegion);
-					if (defaultValue != null) {
-						String label = $.getLabel();
-						$.setLabel(label + " (Default: " + defaultValue + ")");
-						data.put(CompletionResolveHandler.DATA_METHOD_DEFAULT_VALUE, defaultValue);
-					}
-				}
-			} catch (JavaModelException e) {
-				JavaLanguageServerPlugin.log(e);
-			}
-		}
 		proposalProvider.updateReplacement(proposal, $, '\0');
 		// Make sure `filterText` matches `textEdit`
 		// See https://github.com/eclipse/eclipse.jdt.ls/issues/1348

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -2916,7 +2916,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals(3, list.getItems().size());
 		CompletionItem ci = list.getItems().get(0);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
-		assertEquals("ONE : int = 1", ci.getLabel());
+		assertEquals("ONE : int", ci.getLabel());
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
 		assertEquals(CompletionItemKind.Constant, resolvedItem.getKind());
 		String documentation = resolvedItem.getDocumentation().getLeft();
@@ -2924,14 +2924,14 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 		ci = list.getItems().get(1);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
-		assertEquals("TEST : double = 107.1921", ci.getLabel());
+		assertEquals("TEST : double", ci.getLabel());
 
 		list = requestCompletions(unit, "@IConstantDefault(");
 		assertNotNull(list);
 		assertEquals(1, list.getItems().size());
 		ci = list.getItems().get(0);
 		assertEquals(CompletionItemKind.Text, ci.getKind());
-		assertEquals("someMethod : String (Default: \"test\")", ci.getLabel());
+		assertEquals("someMethod : String", ci.getLabel());
 		resolvedItem = server.resolveCompletionItem(ci).join();
 		assertEquals(CompletionItemKind.Text, resolvedItem.getKind());
 		documentation = resolvedItem.getDocumentation().getLeft();


### PR DESCRIPTION
Fixes #1835. The approach we used to resolve the field constant needs create ASTTree and resolve binding, which is quite expensive for some large file. This PR will defer the calculation to the completionResolve request.

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>
