### PR TITLE
Add support for month, day, hour, minute variables in typeComment.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
@@ -13,6 +13,11 @@
 
 package org.eclipse.jdt.ls.core.internal.preferences;
 
+import java.util.Calendar;
+
+import org.eclipse.jface.text.templates.SimpleTemplateVariableResolver;
+import org.eclipse.jface.text.templates.TemplateContext;
+
 public class CodeTemplatePreferences {
     private static final String CODETEMPLATES_PREFIX = "org.eclipse.jdt.ui.text.codetemplates."; //$NON-NLS-1$
 	public static final String COMMENT_SUFFIX = "comment"; //$NON-NLS-1$
@@ -191,4 +196,47 @@ public class CodeTemplatePreferences {
 	 */
 	public static final String CODETEMPLATE_RECORDSNIPPET_PUBLIC = "${package_header}/**\n * ${type_name}\n */\npublic record ${type_name}(${cursor}) {\n}";
 
+	public static class Month extends SimpleTemplateVariableResolver {
+		public Month() {
+			super("month", "Current month"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		@Override
+		protected String resolve(TemplateContext context) {
+			return String.format("%02d", Calendar.getInstance().get(Calendar.MONTH) + 1);
+		}
+	}
+
+	public static class Day extends SimpleTemplateVariableResolver {
+		public Day() {
+			super("day", "Current day of month"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		@Override
+		protected String resolve(TemplateContext context) {
+			return String.format("%02d", Calendar.getInstance().get(Calendar.DAY_OF_MONTH));
+		}
+	}
+
+	public static class Hour extends SimpleTemplateVariableResolver {
+		public Hour() {
+			super("hour", "Current hour of day"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		@Override
+		protected String resolve(TemplateContext context) {
+			return String.format("%02d", Calendar.getInstance().get(Calendar.HOUR_OF_DAY));
+		}
+	}
+
+	public static class Minute extends SimpleTemplateVariableResolver {
+		public Minute() {
+			super("minute", "Current minute"); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+
+		@Override
+		protected String resolve(TemplateContext context) {
+			return String.format("%02d", Calendar.getInstance().get(Calendar.MINUTE));
+		}
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.StatusFactory;
 import org.eclipse.jface.text.templates.Template;
+import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.text.templates.ContextTypeRegistry;
 import org.eclipse.text.templates.TemplatePersistenceData;
@@ -103,6 +104,13 @@ public class PreferenceManager {
 		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.CLASSSNIPPET_CONTEXTTYPE));
 		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.INTERFACESNIPPET_CONTEXTTYPE));
 		registry.addContextType(new CodeTemplateContextType(CodeTemplatePreferences.RECORDSNIPPET_CONTEXTTYPE));
+
+		// These should be upstreamed into CodeTemplateContextType & GlobalVariables
+		TemplateContextType tmp = registry.getContextType(CodeTemplateContextType.TYPECOMMENT_CONTEXTTYPE);
+		tmp.addResolver(new CodeTemplatePreferences.Month());
+		tmp.addResolver(new CodeTemplatePreferences.Day());
+		tmp.addResolver(new CodeTemplatePreferences.Hour());
+		tmp.addResolver(new CodeTemplatePreferences.Minute());
 
 		JavaManipulation.setCodeTemplateContextRegistry(registry);
 


### PR DESCRIPTION
- Fixes redhat-developer/vscode-java#2052

I don't mind leaving this for after the release.

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>