### PR TITLE
performence improvement: completion for anonymous type constructor

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -17,11 +17,8 @@ package org.eclipse.jdt.ls.core.internal.contentassist;
 
 import java.util.Map;
 
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
 import org.eclipse.jface.text.BadLocationException;
@@ -38,12 +35,7 @@ public class AnonymousTypeCompletionProposal {
 	private int fReplacementOffset;
 	private boolean fSnippetSupport;
 
-	public AnonymousTypeCompletionProposal(ICompilationUnit cu, int replacementOffset, IType superType, String declarationSignature, boolean snippetSupport) {
-		Assert.isNotNull(cu.getJavaProject());
-		Assert.isNotNull(superType);
-		Assert.isNotNull(cu);
-		Assert.isNotNull(declarationSignature);
-
+	public AnonymousTypeCompletionProposal(ICompilationUnit cu, int replacementOffset, boolean snippetSupport) {
 		fCompilationUnit = cu;
 		fReplacementOffset = replacementOffset;
 		fSnippetSupport = snippetSupport;
@@ -52,7 +44,7 @@ public class AnonymousTypeCompletionProposal {
 	/*
 	 * @see JavaTypeCompletionProposal#updateReplacementString(IDocument,char,int,ImportRewrite)
 	 */
-	public String updateReplacementString(IDocument document, int offset, ImportRewrite impRewrite) throws CoreException, BadLocationException {
+	public String updateReplacementString(IDocument document, int offset) throws CoreException, BadLocationException {
 		// Construct empty body for performance concern
 		// See https://github.com/microsoft/language-server-protocol/issues/1032#issuecomment-648748013
 		String newBody = fSnippetSupport ? "{\n\t${0}\n}" : "{\n\n}";

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/AnonymousTypeCompletionProposal.java
@@ -15,51 +15,19 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ASTParser;
-import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
-import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
-import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.FieldDeclaration;
-import org.eclipse.jdt.core.dom.IBinding;
-import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.IVariableBinding;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
-import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-import org.eclipse.jdt.core.dom.rewrite.ITrackedNodePosition;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
-import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
-import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
-import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.text.edits.MalformedTreeException;
 
 /**
  * Generates Anonymous Class completion proposals.
@@ -68,9 +36,6 @@ public class AnonymousTypeCompletionProposal {
 
 	private ICompilationUnit fCompilationUnit;
 	private int fReplacementOffset;
-	private IType fSuperType;
-	private IJavaProject fJavaProject;
-	private String fDeclarationSignature;
 	private boolean fSnippetSupport;
 
 	public AnonymousTypeCompletionProposal(ICompilationUnit cu, int replacementOffset, IType superType, String declarationSignature, boolean snippetSupport) {
@@ -81,9 +46,6 @@ public class AnonymousTypeCompletionProposal {
 
 		fCompilationUnit = cu;
 		fReplacementOffset = replacementOffset;
-		fJavaProject = cu.getJavaProject();
-		fDeclarationSignature = declarationSignature;
-		fSuperType = superType;
 		fSnippetSupport = snippetSupport;
 	}
 
@@ -119,149 +81,6 @@ public class AnonymousTypeCompletionProposal {
 		int beginIndex = replacementString.indexOf('(');
 		replacementString = replacementString.substring(beginIndex);
 		return replacementString;
-	}
-
-	private String createNewBody(ImportRewrite importRewrite) throws CoreException {
-		if (importRewrite == null) {
-			return null;
-		}
-		ICompilationUnit workingCopy = null;
-		try {
-			String name = "Type" + System.currentTimeMillis(); //$NON-NLS-1$
-			workingCopy = fCompilationUnit.getPrimary().getWorkingCopy(null);
-			ISourceRange range = fSuperType.getSourceRange();
-			boolean sameUnit = range != null && fCompilationUnit.equals(fSuperType.getCompilationUnit());
-			String dummyClassContent = createDummyType(name);
-			StringBuffer workingCopyContents = new StringBuffer(fCompilationUnit.getSource());
-			int insertPosition;
-			if (sameUnit) {
-				insertPosition = range.getOffset() + range.getLength();
-			} else {
-				ISourceRange firstTypeRange = fCompilationUnit.getTypes()[0].getSourceRange();
-				insertPosition = firstTypeRange.getOffset();
-			}
-			if (fSuperType.isLocal()) {
-				workingCopyContents.insert(insertPosition, '{' + dummyClassContent + '}');
-				insertPosition++;
-			} else {
-				workingCopyContents.insert(insertPosition, dummyClassContent + "\n\n"); //$NON-NLS-1$
-			}
-			workingCopy.getBuffer().setContents(workingCopyContents.toString());
-			ASTParser parser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
-			parser.setResolveBindings(true);
-			parser.setStatementsRecovery(true);
-			parser.setSource(workingCopy);
-			CompilationUnit astRoot = (CompilationUnit) parser.createAST(new NullProgressMonitor());
-			ASTNode newType = NodeFinder.perform(astRoot, insertPosition, dummyClassContent.length());
-			if (!(newType instanceof AbstractTypeDeclaration)) {
-				return null;
-			}
-			AbstractTypeDeclaration declaration = (AbstractTypeDeclaration) newType;
-			ITypeBinding dummyTypeBinding = declaration.resolveBinding();
-			if (dummyTypeBinding == null) {
-				return null;
-			}
-			IMethodBinding[] bindings = StubUtility2Core.getOverridableMethods(astRoot.getAST(), dummyTypeBinding, true);
-			if (fSuperType.isInterface()) {
-				ITypeBinding[] dummySuperInterfaces = dummyTypeBinding.getInterfaces();
-				if (dummySuperInterfaces.length == 0 || dummySuperInterfaces.length == 1 && dummySuperInterfaces[0].isRawType()) {
-					bindings = new IMethodBinding[0];
-				}
-			} else {
-				ITypeBinding dummySuperclass = dummyTypeBinding.getSuperclass();
-				if (dummySuperclass == null || dummySuperclass.isRawType()) {
-					bindings = new IMethodBinding[0];
-				}
-			}
-			CodeGenerationSettings settings = PreferenceManager.getCodeGenerationSettings(fCompilationUnit);
-			IMethodBinding[] methodsToOverride = null;
-			settings.createComments = false;
-			List<IMethodBinding> result = new ArrayList<>();
-			for (int i = 0; i < bindings.length; i++) {
-				IMethodBinding curr = bindings[i];
-				if (Modifier.isAbstract(curr.getModifiers())) {
-					result.add(curr);
-				}
-			}
-			methodsToOverride = result.toArray(new IMethodBinding[result.size()]);
-			ASTNode focusNode = null;
-			IBinding contextBinding = null; // used to find @NonNullByDefault effective at that current context
-			if (fCompilationUnit.getJavaProject().getOption(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, true).equals(JavaCore.ENABLED)) {
-				focusNode = NodeFinder.perform(astRoot, fReplacementOffset + dummyClassContent.length(), 0);
-				contextBinding = getEnclosingDeclaration(focusNode);
-			}
-			ASTRewrite rewrite = ASTRewrite.create(astRoot.getAST());
-			ITrackedNodePosition trackedDeclaration = rewrite.track(declaration);
-			ListRewrite rewriter = rewrite.getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
-			for (int i = 0; i < methodsToOverride.length; i++) {
-				boolean snippetSupport = i == methodsToOverride.length-1 ? fSnippetSupport : false;
-				IMethodBinding curr = methodsToOverride[i];
-				MethodDeclaration stub = StubUtility2Core.createImplementationStubCore(workingCopy, rewrite, importRewrite, null, curr, dummyTypeBinding, settings, dummyTypeBinding.isInterface(), focusNode, snippetSupport);
-				rewriter.insertFirst(stub, null);
-			}
-			IDocument document = new Document(workingCopy.getSource());
-			try {
-				rewrite.rewriteAST().apply(document);
-				int bodyStart = trackedDeclaration.getStartPosition() + dummyClassContent.indexOf('{');
-				int bodyEnd = trackedDeclaration.getStartPosition() + trackedDeclaration.getLength();
-				return document.get(bodyStart, bodyEnd - bodyStart);
-			} catch (MalformedTreeException exception) {
-				JavaLanguageServerPlugin.logException(exception.getMessage(), exception);
-			} catch (BadLocationException exception) {
-				JavaLanguageServerPlugin.logException(exception.getMessage(), exception);
-			}
-			return null;
-		} finally {
-			if (workingCopy != null) {
-				workingCopy.discardWorkingCopy();
-			}
-		}
-	}
-
-	// TODO Remove this by addressing https://bugs.eclipse.org/bugs/show_bug.cgi?id=531511
-	private IBinding getEnclosingDeclaration(ASTNode node) {
-		while (node != null) {
-			if (node instanceof AbstractTypeDeclaration) {
-				return ((AbstractTypeDeclaration) node).resolveBinding();
-			} else if (node instanceof AnonymousClassDeclaration) {
-				return ((AnonymousClassDeclaration) node).resolveBinding();
-			} else if (node instanceof MethodDeclaration) {
-				return ((MethodDeclaration) node).resolveBinding();
-			} else if (node instanceof FieldDeclaration) {
-				List<?> fragments = ((FieldDeclaration) node).fragments();
-				if (fragments.size() > 0) {
-					return ((VariableDeclarationFragment) fragments.get(0)).resolveBinding();
-				}
-			} else if (node instanceof VariableDeclarationFragment) {
-				IVariableBinding variableBinding = ((VariableDeclarationFragment) node).resolveBinding();
-				if (variableBinding.getDeclaringMethod() != null || variableBinding.getDeclaringClass() != null) {
-					return variableBinding;
-					// workaround for incomplete wiring of DOM bindings: keep searching when variableBinding is unparented
-				}
-			}
-			node = node.getParent();
-		}
-		return null;
-	}
-
-	private String createDummyType(String name) throws JavaModelException {
-		StringBuffer buffer = new StringBuffer();
-		buffer.append("abstract class "); //$NON-NLS-1$
-		buffer.append(name);
-		if (fSuperType.isInterface()) {
-			buffer.append(" implements "); //$NON-NLS-1$
-		} else {
-			buffer.append(" extends "); //$NON-NLS-1$
-		}
-		if (fDeclarationSignature != null) {
-			buffer.append(Signature.toString(fDeclarationSignature));
-		} else {
-			buffer.append(fSuperType.getFullyQualifiedParameterizedName());
-		}
-		buffer.append(" {"); //$NON-NLS-1$
-		buffer.append("\n"); //$NON-NLS-1$
-		buffer.append("}"); //$NON-NLS-1$
-		return buffer.toString();
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -86,6 +86,7 @@ public class CompletionProposalReplacementProvider {
 	private ImportRewrite importRewrite;
 	private final ClientPreferences client;
 	private Preferences preferences;
+	private String anonymousTypeNewBody;
 
 	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset, Preferences preferences, ClientPreferences clientPrefs) {
 		super();
@@ -216,9 +217,12 @@ public class CompletionProposalReplacementProvider {
 			}
 			int offset = proposal.getReplaceStart();
 
-			//Below two lines: calculate and format an empty new body
-			AnonymousTypeCompletionProposal overrider = new AnonymousTypeCompletionProposal(compilationUnit, offset, client.isCompletionSnippetsSupported());
-			String replacement = overrider.updateReplacementString(document, offset);
+			if (this.anonymousTypeNewBody == null) {
+				// calculate and format an empty new body
+				AnonymousTypeCompletionProposal overrider = new AnonymousTypeCompletionProposal(compilationUnit, offset, client.isCompletionSnippetsSupported());
+				this.anonymousTypeNewBody = overrider.updateReplacementString(document, offset);
+			}
+			String replacement = this.anonymousTypeNewBody;
 
 			if (document.getLength() > offset && range != null) {
 				if (proposal.getKind() == CompletionProposal.ANONYMOUS_CLASS_DECLARATION) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -214,10 +214,12 @@ public class CompletionProposalReplacementProvider {
 			if (!(element instanceof IType)) {
 				return;
 			}
-			IType type = (IType) element;
 			int offset = proposal.getReplaceStart();
-			AnonymousTypeCompletionProposal overrider = new AnonymousTypeCompletionProposal(compilationUnit, offset, type, String.valueOf(proposal.getDeclarationSignature()), client.isCompletionSnippetsSupported());
-			String replacement = overrider.updateReplacementString(document, offset, importRewrite);
+
+			//Below two lines: calculate and format an empty new body
+			AnonymousTypeCompletionProposal overrider = new AnonymousTypeCompletionProposal(compilationUnit, offset, client.isCompletionSnippetsSupported());
+			String replacement = overrider.updateReplacementString(document, offset);
+
 			if (document.getLength() > offset && range != null) {
 				if (proposal.getKind() == CompletionProposal.ANONYMOUS_CLASS_DECLARATION) {
 					// update replacement range


### PR DESCRIPTION
See #1836 

This PR includes 3 commits. It's clearer to review changes commit by commit.

Class `AnonymousTypeCompletionProposal` is used to construct and format new body of an annoymous type constructor. 
**Commit 1**. I remove some dead code, i.e. private methods which are not called.
**Commit 2**. I remove parameters that are not used at all. 

Now I find content of "new body" is determined by compilation unit and offset, which are same among all candidates. For a completion request (e.g. `new Lis^`), all the anonymous type constructor candidates will have the same "new body", but this expensive operation is repeatedly performed for every candidate. 
So in **Commit 3**, I cached content of the "new body". 
