### PR TITLE
fix: Get correct Java project in multi-module case

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.core.internal.utils.FileUtil;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -271,9 +271,8 @@ public class ProjectCommand {
 		}
 
 		// For multi-module scenario
-		IPath inputPath = FileUtil.toPath(new URI(uri));
 		Arrays.sort(containers, (Comparator<IContainer>) (IContainer a, IContainer b) -> {
-			return inputPath.makeRelativeTo(a.getLocation()).segmentCount() - inputPath.makeRelativeTo(b.getLocation()).segmentCount();
+			return a.getFullPath().segmentCount() - b.getFullPath().segmentCount();
 		});
 
 		IJavaElement targetElement = null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -18,11 +18,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.core.resources.IContainer;
@@ -270,13 +270,17 @@ public class ProjectCommand {
 		}
 
 		// For multi-module scenario
-		Arrays.sort(containers, (Comparator<IContainer>) (IContainer a, IContainer b) -> {
-			return a.getFullPath().toPortableString().length() - b.getFullPath().toPortableString().length();
-		});
+		IProject[] projects = Arrays.stream(containers).map((container) -> {
+			return container.getProject();
+		}).filter(Objects::nonNull)
+		.sorted((IProject a, IProject b) -> {
+			// inner comes first
+			return b.getFullPath().toPortableString().length() - a.getFullPath().toPortableString().length();
+		}).toArray(IProject[]::new);
 
 		IJavaElement targetElement = null;
-		for (IContainer container : containers) {
-			targetElement = JavaCore.create(container.getProject());
+		for (IProject project : projects) {
+			targetElement = JavaCore.create(project);
 			if (targetElement != null) {
 				break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommand.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.eclipse.core.internal.utils.FileUtil;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse</groupId>
+    <artifactId>multimodule3</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse</groupId>
+  <artifactId>this_is_a_very_long_module_name</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>this_is_a_very_long_module_name</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/src/main/java/org/eclipse/App.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/src/main/java/org/eclipse/App.java
@@ -1,0 +1,9 @@
+package org.eclipse;
+
+public class App {
+    public static final String GREETING = "Hello World!";
+
+    public static void main(String[] args) {
+        System.out.println(GREETING);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/src/test/java/org/eclipse/AppTest.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/module3/src/test/java/org/eclipse/AppTest.java
@@ -1,0 +1,12 @@
+package org.eclipse;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AppTest {
+    @Test
+    public void testApp() {
+        assertTrue(true);
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/multimodule3/pom.xml
@@ -11,6 +11,7 @@
   <modules>
     <module>module1</module>
     <module>module2</module>
+    <module>module3</module>
   </modules>
   
   <build>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -131,6 +131,19 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
     }
 
     @Test
+    public void testGetMultiModuleMavenProjectFromUri() throws Exception {
+        importProjects("maven/multimodule3");
+        IProject project = WorkspaceHelper.getProject("this_is_a_very_long_module_name");
+        String javaSource = project.getFile("src/main/org/eclipse/App.java").getLocationURI().toString();
+        IJavaProject javaProject = ProjectCommand.getJavaProjectFromUri(javaSource);
+        assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
+
+        String projectUri = project.getLocationURI().toString();
+        javaProject = ProjectCommand.getJavaProjectFromUri(projectUri);
+        assertEquals("this_is_a_very_long_module_name", javaProject.getElementName());
+    }
+
+    @Test
     public void testGetInvisibleProjectFromUri() throws Exception {
         IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
         String linkedFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK).getLocationURI().toString();


### PR DESCRIPTION
This PR fixes a bug that reported in the stack trace in #2093.

> Note: #2093 is about GTD not working. While this fix could not solve that problem but fix another one that we found in #2093 accidentally.

Here is the root cause:

When user opens a Java file, the status bar will show information like Language Level and VM installation path. Given a URI of a project, calling `findContainersForLocationURI()` will returns an array, for example:

![捕获](https://user-images.githubusercontent.com/6193897/131969594-a7fc9225-b6a5-4640-b26b-ed843122219d.PNG)

Here we need the second one to get the `JavaProject` via `javaCore.create()`. but the previous sorting logic didn't handle the case correctly.

The new change will get all the project instance and sort them according to the fs path to get the most inner containing project.

Signed-off-by: sheche <sheche@microsoft.com>