### PR TITLE
Support excluding nested configurations

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/AbstractProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/AbstractProjectImporter.java
@@ -87,12 +87,12 @@ public abstract class AbstractProjectImporter implements IProjectImporter {
 		for (Path path : filteredPaths) {
 			if (parentDir == null) {
 				result.add(path);
-				parentDir = path.getParent();
+				parentDir = path;
 			} else if (path.startsWith(parentDir)) {
 				continue;
 			} else {
 				result.add(path);
-				parentDir = path.getParent();
+				parentDir = path;
 			}
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/EclipseProjectImporter.java
@@ -57,7 +57,7 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 
 	@Override
 	public boolean applies(Collection<IPath> buildFiles, IProgressMonitor monitor) {
-		Set<java.nio.file.Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(DESCRIPTION_FILE_NAME));
+		Collection<java.nio.file.Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(DESCRIPTION_FILE_NAME), true /*includeNested*/);
 		if (configurationDirs == null || configurationDirs.isEmpty()) {
 			return false;
 		}
@@ -74,7 +74,7 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 				});
 				return !folderIsImported;
 			})
-			.collect(Collectors.toSet());
+			.collect(Collectors.toList());
 
 		this.directories = this.directories.stream().filter(path -> (new File(path.toFile(), IJavaProject.CLASSPATH_FILE_NAME).exists())).collect(Collectors.toList());
 		return !this.directories.isEmpty();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -122,12 +122,12 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 			return false;
 		}
 
-		Set<Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(
+		Collection<Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(
 			BUILD_GRADLE_DESCRIPTOR,
 			SETTINGS_GRADLE_DESCRIPTOR,
 			BUILD_GRADLE_KTS_DESCRIPTOR,
 			SETTINGS_GRADLE_KTS_DESCRIPTOR
-		));
+		), false /*includeNested*/);
 		if (configurationDirs == null || configurationDirs.isEmpty()) {
 			return false;
 		}
@@ -146,7 +146,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 				});
 				return !folderIsImported;
 			})
-			.collect(Collectors.toSet());
+			.collect(Collectors.toList());
 
 		return !this.directories.isEmpty();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporter.java
@@ -107,7 +107,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 			return false;
 		}
 
-		Set<java.nio.file.Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(POM_FILE));
+		Collection<java.nio.file.Path> configurationDirs = findProjectPathByConfigurationName(buildFiles, Arrays.asList(POM_FILE), true /*includeNested*/);
 		if (configurationDirs == null || configurationDirs.isEmpty()) {
 			return false;
 		}
@@ -126,7 +126,7 @@ public class MavenProjectImporter extends AbstractProjectImporter {
 				});
 				return !folderIsImported;
 			})
-			.collect(Collectors.toSet());
+			.collect(Collectors.toList());
 
 		return !this.directories.isEmpty();
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/AbstractProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/AbstractProjectImporterTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.core.internal.utils.FileUtil;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter;
+import org.eclipse.jdt.ls.core.internal.managers.MavenProjectImporter;
+import org.junit.Test;
+
+public class AbstractProjectImporterTest {
+	@Test
+	public void testExcludeNestedConfigurations() {
+		ProjectImporter importer = new ProjectImporter();
+		Collection<IPath> configurationPaths = new ArrayList<>();
+		configurationPaths.add(FileUtil.toPath(new File("projects", "gradle").toPath().resolve("subprojects/project1/build.gradle").toUri()));
+		configurationPaths.add(FileUtil.toPath(new File("projects", "gradle").toPath().resolve("subprojects/project2/build.gradle").toUri()));
+		configurationPaths.add(FileUtil.toPath(new File("projects", "gradle").toPath().resolve("subprojects/build.gradle").toUri()));
+		configurationPaths.add(FileUtil.toPath(new File("projects", "gradle").toPath().resolve("subprojects/settings.gradle").toUri()));
+		
+		Collection<Path> paths = importer.findProjectPath(configurationPaths, Arrays.asList(
+			GradleProjectImporter.BUILD_GRADLE_DESCRIPTOR,
+			GradleProjectImporter.SETTINGS_GRADLE_DESCRIPTOR
+		), false);
+
+		assertTrue(paths.size() == 1);
+		for (Path path : paths) {
+			assertTrue(path.endsWith("subprojects"));
+		}
+	}
+
+	@Test
+	public void testIncludeNestedConfigurations() {
+		ProjectImporter importer = new ProjectImporter();
+		Collection<IPath> configurationPaths = new ArrayList<>();
+		configurationPaths.add(FileUtil.toPath(new File("projects", "maven").toPath().resolve("multimodule3/pom.xml").toUri()));
+		configurationPaths.add(FileUtil.toPath(new File("projects", "maven").toPath().resolve("multimodule3/module1/pom.xml").toUri()));
+		configurationPaths.add(FileUtil.toPath(new File("projects", "maven").toPath().resolve("multimodule3/module2/pom.xml").toUri()));
+		Collection<Path> paths = importer.findProjectPath(configurationPaths, Arrays.asList(
+			MavenProjectImporter.POM_FILE
+		), true);
+
+		assertTrue(paths.size() == 3);
+	}
+}
+
+class ProjectImporter extends AbstractProjectImporter {
+
+	@Override
+	public boolean applies(IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+		return false;
+	}
+
+	@Override
+	public void importToWorkspace(IProgressMonitor monitor) throws OperationCanceledException, CoreException {
+	}
+
+	@Override
+	public void reset() {
+	}
+
+	// make public for test purpose
+	public Collection<Path> findProjectPath(Collection<IPath> projectConfigurations, List<String> names, boolean includeNested) {
+		return findProjectPathByConfigurationName(projectConfigurations, names, includeNested);
+	}
+}


### PR DESCRIPTION
follow up work of #1840 

Support filtering nested folders in `applies()`.:
- For Gradle, the nested folders are ignored to align with the current logic.
- For Maven, the nested folders are included, this is because m2e will skip scanned folders.

Signed-off-by: Sheng Chen <sheche@microsoft.com>