### PR TITLE
delay resolve TextEdit of completion item

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -558,10 +558,11 @@ public class CompletionProposalDescriptionProvider {
 
 	private void createPackageProposalLabel(CompletionProposal proposal, CompletionItem item) {
 		Assert.isTrue(proposal.getKind() == CompletionProposal.PACKAGE_REF || proposal.getKind() == CompletionProposal.MODULE_REF || proposal.getKind() == CompletionProposal.MODULE_DECLARATION);
-		item.setLabel(String.valueOf(proposal.getDeclarationSignature()));
+		String signature = String.valueOf(proposal.getDeclarationSignature());
+		item.setLabel(signature);
 		StringBuilder detail = new StringBuilder();
 		detail.append(proposal.getKind() == CompletionProposal.PACKAGE_REF ? "(package) " : "(module) ");
-		detail.append(String.valueOf(proposal.getDeclarationSignature()));
+		detail.append(signature);
 		item.setDetail(detail.toString());
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -229,16 +229,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		$.setData(data);
 		this.descriptionProvider.updateDescription(proposal, $);
 		$.setSortText(SortTextHelper.computeSortText(proposal));
-		proposalProvider.updateReplacement(proposal, $, '\0');
-		// Make sure `filterText` matches `textEdit`
-		// See https://github.com/eclipse/eclipse.jdt.ls/issues/1348
-		if ($.getTextEdit() != null) {
-			String newText = $.getTextEdit().isLeft() ? $.getTextEdit().getLeft().getNewText() : $.getTextEdit().getRight().getNewText();
-			Range range = $.getTextEdit().isLeft() ? $.getTextEdit().getLeft().getRange() : ($.getTextEdit().getRight().getInsert() != null ? $.getTextEdit().getRight().getInsert() : $.getTextEdit().getRight().getReplace());
-			if (proposal.getKind() == CompletionProposal.TYPE_REF && range != null && newText != null) {
-				$.setFilterText(newText);
-			}
-		}
 		return $;
 	}
 

--- a/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
@@ -299,13 +299,7 @@ public class SyntaxServerTest extends AbstractSyntaxProjectsManagerBasedTest {
 			assertTrue(StringUtils.isNotBlank(item.getLabel()));
 			assertNotNull(item.getKind());
 			assertTrue(StringUtils.isNotBlank(item.getSortText()));
-			//text edits are set during calls to "completion"
-			assertNotNull(item.getTextEdit());
 			assertTrue(StringUtils.isNotBlank(item.getInsertText()));
-			assertNotNull(item.getFilterText());
-			assertFalse(item.getFilterText().contains(" "));
-			assertTrue(item.getLabel().startsWith(item.getInsertText()));
-			assertTrue(item.getFilterText().startsWith("Objec"));
 			//Check contains data used for completionItem resolution
 			@SuppressWarnings("unchecked")
 			Map<String,String> data = (Map<String, String>) item.getData();
@@ -313,6 +307,14 @@ public class SyntaxServerTest extends AbstractSyntaxProjectsManagerBasedTest {
 			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_URI)));
 			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID)));
 			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID)));
+
+			//text edits are set during calls to "resolve"
+			CompletionItem resolved = server.resolveCompletionItem(item).join();
+			assertNotNull(resolved.getTextEdit());
+			assertNotNull(resolved.getFilterText());
+			assertFalse(resolved.getFilterText().contains(" "));
+			assertTrue(resolved.getLabel().startsWith(resolved.getInsertText()));
+			assertTrue(resolved.getFilterText().startsWith("Objec"));
 		}
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/Lsp4jAssertions.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/Lsp4jAssertions.java
@@ -15,6 +15,8 @@ package org.eclipse.jdt.ls.core.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
+import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -50,4 +52,9 @@ public final class Lsp4jAssertions {
 
 	}
 
+	public static void assertTextEditAfterResolve(JDTLanguageServer server, int expectedLine, int expectedStart, int expectedEnd, String expectedText, CompletionItem ci){
+		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
+		assertNotNull(resolvedItem);
+		assertTextEdit(expectedLine, expectedStart, expectedEnd, expectedText, resolvedItem.getTextEdit().getLeft());
+	}
 }


### PR DESCRIPTION
This PR defer calculation of TextEdit to resolve stage, providing a systematic way to solve performance issues like  #1864 .


