### PR TITLE
Java LS sometimes hangs while loading a gradle project

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JobHelpers.java
@@ -222,6 +222,10 @@ public final class JobHelpers {
 		waitForJobs(BuildJobOffMatcher.INSTANCE, maxTimeMillis);
 	}
 
+	public static void waitForProjectRegistryRefreshJob() {
+		waitForJobs(ProjectRegistryRefreshJobMatcher.INSTANCE, MAX_TIME_MILLIS);
+	}
+
 	interface IJobMatcher {
 
 		boolean matches(Job job);
@@ -247,6 +251,17 @@ public final class JobHelpers {
 		@Override
 		public boolean matches(Job job) {
 			return job.getClass().getName().matches("(.*\\.AutoBuildOff.*)");
+		}
+
+	}
+
+	static class ProjectRegistryRefreshJobMatcher implements IJobMatcher {
+
+		public static final IJobMatcher INSTANCE = new BuildJobMatcher();
+
+		@Override
+		public boolean matches(Job job) {
+			return job.getClass().getName().matches("org.eclipse.m2e.core.internal.project.registry.ProjectRegistryRefreshJob");
 		}
 
 	}


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/2088

The issue happens when BuildSupportManager.obtainBuildSupports starts the m2e and buildship plugins that sometimes freezes the workspace.
A stack trace: https://github.com/redhat-developer/vscode-java/issues/2088#issuecomment-918589591 and https://gist.github.com/snjeza/b02b8461499cf025a9b664442dd51ede

A solution is to start these plugins separately before initializing Java LS.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>