### PR TITLE
Update org.jsoup 1.9.2 to 1.14.2

### DIFF
--- a/org.eclipse.jdt.ls.core/.classpath
+++ b/org.eclipse.jdt.ls.core/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.9.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.14.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/remark-1.2.0.jar"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -59,7 +59,7 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.syntaxserver;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver",
  org.eclipse.jdt.ls.core.internal.text.correction;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.internal.gradle.checksums;x-friends:="org.eclipse.jdt.ls.tests"
-Bundle-ClassPath: lib/jsoup-1.9.2.jar,
+Bundle-ClassPath: lib/jsoup-1.14.2.jar,
  lib/remark-1.2.0.jar,
  .
 Bundle-Vendor: %Bundle-Vendor

--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -3,7 +3,7 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/jsoup-1.9.2.jar,\
+               lib/jsoup-1.14.2.jar,\
                lib/remark-1.2.0.jar,\
                lifecycle-mapping-metadata.xml,\
                logback.xml,\

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -25,7 +25,7 @@
 						<artifactItem>
 							<groupId>org.jsoup</groupId>
 							<artifactId>jsoup</artifactId>
-							<version>1.9.2</version>
+							<version>1.14.2</version>
 						</artifactItem>
 					</artifactItems>
 				</configuration>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/HtmlToPlainText.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/HtmlToPlainText.java
@@ -23,7 +23,7 @@
  */
 package org.eclipse.jdt.ls.core.internal.javadoc;
 
-import org.jsoup.helper.StringUtil;
+import org.jsoup.internal.StringUtil;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
@@ -46,8 +46,7 @@ public class HtmlToPlainText {
 	 */
 	public String getPlainText(Element element) {
 		FormattingVisitor formatter = new FormattingVisitor();
-		NodeTraversor traversor = new NodeTraversor(formatter);
-		traversor.traverse(element); // walk the DOM, and call .head() and .tail() for each node
+		NodeTraversor.traverse(formatter, element); // walk the DOM, and call .head() and .tail() for each node
 
 		return formatter.toString();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/javadoc/JavaDoc2MarkdownConverter.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Field;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.jsoup.safety.Cleaner;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 import com.overzealous.remark.Options;
 import com.overzealous.remark.Options.Tables;
@@ -47,13 +47,13 @@ public class JavaDoc2MarkdownConverter extends AbstractJavaDocConverter {
 
 			Cleaner c = (Cleaner) cleanerField.get(remark);
 
-			Field whitelistField = Cleaner.class.getDeclaredField("whitelist");
-			whitelistField.setAccessible(true);
+			Field safelistField = Cleaner.class.getDeclaredField("safelist");
+			safelistField.setAccessible(true);
 
-			Whitelist w = (Whitelist) whitelistField.get(c);
+			Safelist s = (Safelist) safelistField.get(c);
 
-			w.addProtocols("a", "href", "file", "jdt");
-			w.addProtocols("img", "src", "file");
+			s.addProtocols("a", "href", "file", "jdt");
+			s.addProtocols("img", "src", "file");
 		} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 			JavaLanguageServerPlugin.logException("Unable to modify jsoup to include file and jdt protocols", e);
 		}


### PR DESCRIPTION
- StringUtil moved from helper to inernal package
- Changes in NodeTraversor API
- Changes to internal field of Cleanup

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This addresses https://nvd.nist.gov/vuln/detail/CVE-2021-37714 & we'll need a CQ.