### PR TITLE
Guard against null binding of unresolved method reference.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistProcessor.java
@@ -323,7 +323,7 @@ public class QuickAssistProcessor {
 		}
 
 		IMethodBinding functionalMethod = targetTypeBinding.getFunctionalInterfaceMethod();
-		if (functionalMethod.isSynthetic()) {
+		if (functionalMethod != null && functionalMethod.isSynthetic()) {
 			functionalMethod = Bindings.findOverriddenMethodInType(functionalMethod.getDeclaringClass(), functionalMethod);
 		}
 		return functionalMethod;


### PR DESCRIPTION
- Fixes #1885

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

I tried writing a test for this on the JDT side and for some reason couldn't trigger the NPE as the type binding resolved directly above was always null in the test environment, which is checked. `getFunctionalInterfaceMethod` clearly states that it may return null though.