### PR TITLE
Java LS doesn't apply java.settings.url

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
@@ -76,10 +76,19 @@ public interface IProjectsManager {
 	/**
 	 * Register listeners.
 	 */
-	void registerListeners();
+	default void registerListeners() {
+		// do nothing
+	};
 
 	/**
 	 * Handle the file change event.
 	 */
 	void fileChanged(String uriString, CHANGE_TYPE changeType);
+
+	/**
+	 * Unregister listeners.
+	 */
+	default void unregisterListeners() {
+		// do nothing
+	};
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -529,6 +529,7 @@ public class StandardProjectsManager extends ProjectsManager {
 
 	@Override
 	public void registerListeners() {
+		configureSettings(preferenceManager.getPreferences());
 		if (this.preferenceChangeListener == null) {
 			this.preferenceChangeListener = new IPreferencesChangeListener() {
 				@Override
@@ -558,6 +559,20 @@ public class StandardProjectsManager extends ProjectsManager {
 		buildSupports().forEach(p -> {
 			try {
 				p.registerPreferencesChangeListener(this.preferenceManager);
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException(e.getMessage(), e);
+			}
+		});
+	}
+
+	@Override
+	public void unregisterListeners() {
+		if (this.preferenceChangeListener == null) {
+			this.preferenceManager.removePreferencesChangeListener(this.preferenceChangeListener);
+		}
+		buildSupports().forEach(p -> {
+			try {
+				p.unregisterPreferencesChangeListener(this.preferenceManager);
 			} catch (CoreException e) {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -1343,15 +1343,19 @@ public class Preferences {
 		if (url == null || url.isBlank()) {
 			return null;
 		}
+		URI uri = null;
 		try {
-			URI uri = new URI(ResourceUtils.toClientUri(url));
+			uri = new URI(ResourceUtils.toClientUri(url));
 			if (!uri.isAbsolute()) {
-				return getURI(url);
+				uri = getURI(url);
 			}
-			return uri;
 		} catch (URISyntaxException e1) {
-			return getURI(url);
+			uri = getURI(url);
 		}
+		if (uri == null) {
+			JavaLanguageServerPlugin.logInfo("Cannot resolve '" + url + "'.");
+		}
+		return uri;
 	}
 
 	private URI getURI(String path) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxProjectsManager.java
@@ -193,11 +193,6 @@ public class SyntaxProjectsManager extends ProjectsManager {
 	}
 
 	@Override
-	public void registerListeners() {
-		// do nothing
-	}
-
-	@Override
 	public void fileChanged(String uriString, CHANGE_TYPE changeType) {
 		if (uriString == null) {
 			return;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JavaSettingsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JavaSettingsTest.java
@@ -220,4 +220,32 @@ public class JavaSettingsTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("warning", javaProject.getOption(STATIC_ACCESS_RECEIVER, true));
 	}
 
+	@Test
+	public void testSettings() throws Exception {
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("warning", JavaCore.getOption(STATIC_ACCESS_RECEIVER));
+		assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+		assertEquals("warning", javaProject.getOption(STATIC_ACCESS_RECEIVER, true));
+		try {
+			String settingsUrl = "../../formatter/settings2.prefs";
+			preferences.setSettingsUrl(settingsUrl);
+			projectsManager.registerListeners();
+			waitForBackgroundJobs();
+			assertEquals("warning", JavaCore.getOption(MISSING_SERIAL_VERSION));
+			assertEquals("ignore", JavaCore.getOption(STATIC_ACCESS_RECEIVER));
+			assertEquals("warning", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+			assertEquals("ignore", javaProject.getOption(STATIC_ACCESS_RECEIVER, true));
+		} finally {
+			JavaCore.setOptions(options);
+			preferences.setSettingsUrl(null);
+			StandardProjectsManager.configureSettings(preferences);
+			projectsManager.unregisterListeners();
+			waitForBackgroundJobs();
+		}
+		assertEquals("ignore", JavaCore.getOption(MISSING_SERIAL_VERSION));
+		assertEquals("warning", JavaCore.getOption(STATIC_ACCESS_RECEIVER));
+		assertEquals("ignore", javaProject.getOption(MISSING_SERIAL_VERSION, true));
+		assertEquals("warning", javaProject.getOption(STATIC_ACCESS_RECEIVER, true));
+	}
+
 }


### PR DESCRIPTION
Fixes #1892 

Steps to reproduce:

- import [hello.zip](https://github.com/eclipse/eclipse.jdt.ls/files/7261958/hello.zip)
- open Hello.java
Expected:
Warning: The serializable class Hello does not declare a static final serialVersionUID field of type long
Current:
No warning

The issue has been introduced by https://github.com/eclipse/eclipse.jdt.ls/pull/1853

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>