### PR TITLE
Add semantic tokens for records and constructors

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/semantictokens/TokenType.java
@@ -37,7 +37,10 @@ public enum TokenType {
 
 	// Custom token types
 	ANNOTATION("annotation"),
-	ANNOTATION_MEMBER("annotationMember");
+	ANNOTATION_MEMBER("annotationMember"),
+	RECORD("record"),
+	RECORD_COMPONENT("recordComponent");
+
 
 	/**
 	 * This is the name of the token type given to the client, so it
@@ -79,6 +82,9 @@ public enum TokenType {
 				if (variableBinding.isEnumConstant()) {
 					return TokenType.ENUM_MEMBER;
 				}
+				if (variableBinding.isRecordComponent()) {
+					return TokenType.RECORD_COMPONENT;
+				}
 				if (variableBinding.isField()) {
 					return TokenType.PROPERTY;
 				}
@@ -89,6 +95,9 @@ public enum TokenType {
 			}
 			case IBinding.METHOD: {
 				IMethodBinding methodBinding = (IMethodBinding) binding;
+				if (methodBinding.isConstructor()) {
+					return getApplicableType(methodBinding.getDeclaringClass());
+				}
 				if (methodBinding.isAnnotationMember()) {
 					return TokenType.ANNOTATION_MEMBER;
 				}
@@ -102,14 +111,17 @@ public enum TokenType {
 				if (typeBinding.isAnnotation()) {
 					return TokenType.ANNOTATION;
 				}
-				if (typeBinding.isClass()) {
-					return TokenType.CLASS;
+				if (typeBinding.isRecord()) {
+					return TokenType.RECORD;
 				}
 				if (typeBinding.isInterface()) {
 					return TokenType.INTERFACE;
 				}
 				if (typeBinding.isEnum()) {
 					return TokenType.ENUM;
+				}
+				if (typeBinding.isClass()) {
+					return TokenType.CLASS;
 				}
 				return TokenType.TYPE;
 			}

--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Constructors.java
@@ -8,8 +8,27 @@ public class Constructors {
 		Constructors.InnerClass i1 = new Constructors.InnerClass();
 		Constructors.InnerClass i2 = new @SomeAnnotation Constructors.InnerClass();
 		Constructors.InnerClass<String> i3 = new Constructors.InnerClass<String>();
+		InnerClass<Integer> i4 = new InnerClass<>();
+		GenericConstructor g1 = new <String>GenericConstructor();
+		Constructors.InnerRecord r1 = new Constructors.InnerRecord("foo", 0);
+		new InnerRecord();
 	}
 
 	protected class InnerClass<T> {}
+	private class GenericConstructor {
+		protected <T> GenericConstructor() {}
+	}
+
+	public enum InnerEnum {
+		FOO("bar");
+
+		InnerEnum(String string) {}
+	}
+
+	private record InnerRecord(String string, int integer) {
+		protected InnerRecord() {
+			this("bar", 0);
+		}
+	}
 
 }

--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Fields.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Fields.java
@@ -14,4 +14,11 @@ public class Fields {
 		SECOND
 	}
 
+	record SomeRecord(Integer i, Float f) {
+		void foo(Object foo) {
+			foo(i);
+			foo(f);
+		}
+	}
+
 }

--- a/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Types.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/semantic-tokens/src/main/java/foo/Types.java
@@ -17,5 +17,6 @@ public class Types {
 	interface SomeInterface {}
 	enum SomeEnum {}
 	@interface SomeAnnotation {}
+	record SomeRecord() {}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SemanticTokensHandlerTest.java
@@ -66,7 +66,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	private void setOptions() {
 		Hashtable<String, String> options = TestOptions.getDefaultOptions();
-		JavaCore.setComplianceOptions("11", options); // Otherwise we can't test module-info.java
+		JavaCore.setComplianceOptions("16", options);
 		semanticTokensProject.setOptions(options);
 	}
 
@@ -117,7 +117,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("main", "method", "public", "static", "declaration")
 			.assertNextToken("String", "class", "public", "readonly")
 			.assertNextToken("Methods", "class", "public")
-			.assertNextToken("Methods", "method", "public")
+			.assertNextToken("Methods", "class", "public", "constructor")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
 			.assertNextToken("foo1", "method", "public", "generic")
 			.assertNextToken("foo2", "method", "private")
@@ -136,47 +136,86 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("public", "modifier")
 			.assertNextToken("Constructors", "class", "public", "declaration")
 			.assertNextToken("private", "modifier")
-			.assertNextToken("Constructors", "method", "private", "declaration")
+			.assertNextToken("Constructors", "class", "private", "constructor", "declaration")
 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("c1", "variable", "declaration")
-			.assertNextToken("Constructors", "method", "private")
+			.assertNextToken("Constructors", "class", "private", "constructor")
 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("c2", "variable", "declaration")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
-			.assertNextToken("Constructors", "method", "private")
+			.assertNextToken("Constructors", "class", "private", "constructor")
 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("InnerClass", "class", "protected")
 			.assertNextToken("i1", "variable", "declaration")
 			.assertNextToken("Constructors", "class", "public")
-			.assertNextToken("InnerClass", "method", "protected")
+			.assertNextToken("InnerClass", "class", "protected", "constructor")
 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("InnerClass", "class", "protected")
 			.assertNextToken("i2", "variable", "declaration")
 			.assertNextToken("SomeAnnotation", "annotation", "public")
 			.assertNextToken("Constructors", "class", "public")
-			.assertNextToken("InnerClass", "method", "protected")
+			.assertNextToken("InnerClass", "class", "protected", "constructor")
 
 			.assertNextToken("Constructors", "class", "public")
 			.assertNextToken("InnerClass", "class", "protected", "generic")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
 			.assertNextToken("i3", "variable", "declaration")
 			.assertNextToken("Constructors", "class", "public")
-			.assertNextToken("InnerClass", "method", "protected", "generic")
+			.assertNextToken("InnerClass", "class", "protected", "generic", "constructor")
 			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
+
+			.assertNextToken("InnerClass", "class", "protected", "generic")
+			.assertNextToken("Integer", "class", "public", "readonly", "typeArgument")
+			.assertNextToken("i4", "variable", "declaration")
+			.assertNextToken("InnerClass", "class", "protected", "generic", "constructor")
+
+			.assertNextToken("GenericConstructor", "class", "private")
+			.assertNextToken("g1", "variable", "declaration")
+			.assertNextToken("String", "class", "public", "readonly", "typeArgument")
+			.assertNextToken("GenericConstructor", "class", "protected", "generic", "constructor")
+
+			.assertNextToken("Constructors", "class", "public")
+			.assertNextToken("InnerRecord", "record", "private", "static", "readonly")
+			.assertNextToken("r1", "variable", "declaration")
+			.assertNextToken("Constructors", "class", "public")
+			.assertNextToken("InnerRecord", "record", "private", "constructor")
+
+			.assertNextToken("InnerRecord", "record", "protected", "constructor")
 
 			.assertNextToken("protected", "modifier")
 			.assertNextToken("InnerClass", "class", "protected", "generic", "declaration")
 			.assertNextToken("T", "typeParameter", "declaration")
+
+			.assertNextToken("private", "modifier")
+			.assertNextToken("GenericConstructor", "class", "private", "declaration")
+			.assertNextToken("protected", "modifier")
+			.assertNextToken("T", "typeParameter", "declaration")
+			.assertNextToken("GenericConstructor", "class", "protected", "generic", "constructor", "declaration")
+
+			.assertNextToken("public", "modifier")
+			.assertNextToken("InnerEnum", "enum", "public", "static", "readonly", "declaration")
+			.assertNextToken("FOO", "enumMember", "public", "static", "readonly", "declaration")
+			.assertNextToken("InnerEnum", "enum", "private", "constructor", "declaration")
+			.assertNextToken("String", "class", "public", "readonly")
+			.assertNextToken("string", "parameter", "declaration")
+
+			.assertNextToken("private", "modifier")
+			.assertNextToken("InnerRecord", "record", "private", "static", "readonly", "declaration")
+			.assertNextToken("String", "class", "public", "readonly")
+			.assertNextToken("string", "recordComponent", "declaration")
+			.assertNextToken("integer", "recordComponent", "declaration")
+			.assertNextToken("protected", "modifier")
+			.assertNextToken("InnerRecord", "record", "protected", "constructor", "declaration")
 		.endAssertion();
 	}
 
 	@Test
-	public void testSemanticTokens_Properties() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Fields.java"), "property", "enumMember")
+	public void testSemanticTokens_Fields() throws JavaModelException {
+		TokenAssertionHelper.beginAssertion(getURI("Fields.java"), "property", "enumMember", "recordComponent")
 			.assertNextToken("bar1", "property", "public", "declaration")
 			.assertNextToken("bar2", "property", "private", "declaration")
 			.assertNextToken("bar3", "property", "protected", "declaration")
@@ -186,6 +225,10 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("bar6", "property", "public", "static", "readonly", "declaration")
 			.assertNextToken("FIRST", "enumMember", "public", "static", "readonly", "declaration")
 			.assertNextToken("SECOND", "enumMember", "public", "static", "readonly", "declaration")
+			.assertNextToken("i", "recordComponent", "declaration")
+			.assertNextToken("f", "recordComponent", "declaration")
+			.assertNextToken("i", "property", "private", "readonly")
+			.assertNextToken("f", "property", "private", "readonly")
 		.endAssertion();
 	}
 
@@ -203,7 +246,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 
 	@Test
 	public void testSemanticTokens_Types() throws JavaModelException {
-		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "typeParameter", "keyword")
+		TokenAssertionHelper.beginAssertion(getURI("Types.java"), "class", "interface", "enum", "annotation", "record", "typeParameter", "keyword")
 			.assertNextToken("Types", "class", "public", "declaration")
 			.assertNextToken("String", "class", "public", "readonly")
 
@@ -226,6 +269,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("SomeInterface", "interface", "static", "declaration")
 			.assertNextToken("SomeEnum", "enum", "static", "readonly", "declaration")
 			.assertNextToken("SomeAnnotation", "annotation", "static", "declaration")
+			.assertNextToken("SomeRecord", "record", "static", "readonly", "declaration")
 		.endAssertion();
 	}
 
@@ -266,6 +310,7 @@ public class SemanticTokensHandlerTest extends AbstractProjectsManagerBasedTest 
 			.assertNextToken("string", "property", "public", "declaration")
 			.assertNextToken("java", "namespace")
 			.assertNextToken("lang", "namespace")
+			.assertNextToken("String", "class", "public", "constructor")
 		.endAssertion();
 	}
 


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#2124
Fixes redhat-developer/vscode-java#2125

### New semantic token types

- `record` ([Record Classes](https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10))
- `recordComponent` ([Record Components](https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.10.1))

### New semantic token modifiers

- `constructor` (Constructors)
  - The token type of constructors has also been changed from `method` to `class`, `enum`, `record` etc.

---

I also refactored the code for checking and setting the modifier bits, to make it more clear and concise. The reason for splitting it up into multiple different `check*` methods is that we don't always need to check everything.

CC: @Eskibear