### PR TITLE
Add "Convert to Switch Expression" code assist proposal

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
@@ -228,6 +228,7 @@ public interface IProposalRelevance {
 	public static final int RETURN_ALLOCATED_OBJECT= 2;
 	public static final int REMOVE_BLOCK_FIX= 2;
 	public static final int CONVERT_TO_ANONYMOUS_CLASS_CREATION= 2;
+	public static final int CONVERT_TO_SWITCH_EXPRESSION = 2;
 
 	public static final int JOIN_VARIABLE_DECLARATION= 1;
 	public static final int INVERT_EQUALS= 1;

--- a/org.eclipse.jdt.ls.product/languageServer.product
+++ b/org.eclipse.jdt.ls.product/languageServer.product
@@ -31,7 +31,7 @@
       <plugin id="org.eclipse.core.filesystem"/>
       <plugin id="org.eclipse.core.jobs"/>
       <plugin id="org.eclipse.core.net"/>
-      <plugin id="org.eclipse.core.net.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.core.net.linux" fragment="true"/>
       <plugin id="org.eclipse.core.net.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.core.resources"/>
       <plugin id="org.eclipse.core.runtime"/>
@@ -42,7 +42,7 @@
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
       <plugin id="org.eclipse.equinox.security"/>
-      <plugin id="org.eclipse.equinox.security.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.linux" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.jdt.apt.pluggable.core"/>

--- a/org.eclipse.jdt.ls.product/syntaxServer.product
+++ b/org.eclipse.jdt.ls.product/syntaxServer.product
@@ -30,7 +30,7 @@
       <plugin id="org.eclipse.core.filesystem"/>
       <plugin id="org.eclipse.core.jobs"/>
       <plugin id="org.eclipse.core.net"/>
-      <plugin id="org.eclipse.core.net.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.core.net.linux" fragment="true"/>
       <plugin id="org.eclipse.core.net.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.core.resources"/>
       <plugin id="org.eclipse.core.runtime"/>
@@ -41,7 +41,7 @@
       <plugin id="org.eclipse.equinox.preferences"/>
       <plugin id="org.eclipse.equinox.registry"/>
       <plugin id="org.eclipse.equinox.security"/>
-      <plugin id="org.eclipse.equinox.security.linux.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.equinox.security.linux" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.macosx" fragment="true"/>
       <plugin id="org.eclipse.equinox.security.win32.x86_64" fragment="true"/>
       <plugin id="org.eclipse.jdt.compiler.apt" fragment="true"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -30,7 +30,7 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2021-12/202112081000/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds/I20220105-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertSwitchExpressionQuickAssistTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertSwitchExpressionQuickAssistTest.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.ls.core.internal.CodeActionUtil;
+import org.eclipse.lsp4j.Range;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConvertSwitchExpressionQuickAssistTest extends AbstractQuickFixTest {
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject = newEmptyProject();
+		Map<String, String> options14 = new HashMap<>(fJProject.getOptions(false));
+		JavaModelUtil.setComplianceOptions(options14, JavaCore.VERSION_14);
+		fJProject.setOptions(options14);
+		fSourceFolder = fJProject.getPackageFragmentRoot(fJProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testConvertToSwitchExpression1() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("	public int foo(Day day) {\n");
+		buf.append("		// return variable\n");
+		buf.append("		int i;\n");
+		buf.append("		switch (day) {\n");
+		buf.append("			case SATURDAY:\n");
+		buf.append("			case SUNDAY: i = 5; break;\n");
+		buf.append("			case MONDAY:\n");
+		buf.append("			case TUESDAY, WEDNESDAY: i = 7; break;\n");
+		buf.append("			case THURSDAY:\n");
+		buf.append("			case FRIDAY: i = 14; break;\n");
+		buf.append("			default :\n");
+		buf.append("				i = 22;\n");
+		buf.append("				break;\n");
+		buf.append("		}\n");
+		buf.append("		return i;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("enum Day {\n");
+		buf.append("    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("	public int foo(Day day) {\n");
+		buf.append("		// return variable\n");
+		buf.append("		int i = switch (day) {\n");
+		buf.append("			case SATURDAY, SUNDAY -> 5;\n");
+		buf.append("			case MONDAY, TUESDAY, WEDNESDAY -> 7;\n");
+		buf.append("			case THURSDAY, FRIDAY -> 14;\n");
+		buf.append("			default -> 22;\n");
+		buf.append("		};\n");
+		buf.append("		return i;\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("enum Day {\n");
+		buf.append("    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;\n");
+		buf.append("}\n");
+
+		Expected e = new Expected("Convert to switch expression", buf.toString());
+		Range selection = CodeActionUtil.getRange(cu, "switch");
+		assertCodeActions(cu, selection, e);
+	}
+
+	@Test
+	public void testNoConvertToSwitchExpression1() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("	static int i;\n");
+		buf.append("	static {\n");
+		buf.append("		// var comment\n");
+		buf.append("		int j = 4;\n");
+		buf.append("		// logic comment\n");
+		buf.append("		switch (j) {\n");
+		buf.append("			case 0: break; // no statements\n");
+		buf.append("			case 1: i = 5; break;\n");
+		buf.append("			case 2:\n");
+		buf.append("			case 3:\n");
+		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
+		buf.append("			case 5:\n");
+		buf.append("			case 6: i = 14; break;\n");
+		buf.append("			default: i = 22; break;\n");
+		buf.append("		}\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		Range selection = CodeActionUtil.getRange(cu, "switch");
+		assertCodeActionNotExists(cu, selection, "Convert to switch expression");
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

![convert-to-switch-expr](https://user-images.githubusercontent.com/1417342/141030913-901dae7c-6d0f-4022-ab4d-1cb9489aa644.gif)

There's a few issues that need to resolved regarding the API.

* [x] Some methods can be moved upstream so we don't need to copy as much
* [x] We're using `SwitchExpressionsFixCore.createCleanUp(CompilationUnit)` but that will apply the fix to the entire source file, and we only want to apply it to the selected switch expression. To do that we need to open up the visibility of the constructor upstream.