### PR TITLE
Always show Organize imports in Quick Fixes for import declaration

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ReorgCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ReorgCorrectionsSubProcessor.java
@@ -157,18 +157,5 @@ public class ReorgCorrectionsSubProcessor {
 				JavaLanguageServerPlugin.log(e);
 			}
 		}
-
-		final ICompilationUnit cu= context.getCompilationUnit();
-		String name= CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description;
-		CUCorrectionProposal proposal = new CUCorrectionProposal(name, CodeActionKind.QuickFix, cu, null, IProposalRelevance.ORGANIZE_IMPORTS) {
-
-			@Override
-			protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
-				CompilationUnit astRoot = context.getASTRoot();
-				OrganizeImportsOperation op = new OrganizeImportsOperation(cu, astRoot, true, false, true, null);
-				editRoot.addChild(op.createTextEdit(null));
-			}
-		};
-		proposals.add(proposal);
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.GenerateGetterSetterOperation;
@@ -72,10 +71,10 @@ public class GenerateAccessorsHandler {
 			CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 			if (astRoot != null && cursor != null) {
 				ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-				declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
+				declarationNode = SourceAssistProcessor.getTypeDeclarationNode(node);
 			}
 			// If cursor position is not specified, then insert to the last by default.
-			IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);
+			IJavaElement insertPosition = (declarationNode != null) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);
 			GenerateGetterSetterOperation operation = new GenerateGetterSetterOperation(type, null, generateComments, insertPosition);
 			return operation.createTextEdit(null, accessors);
 		} catch (OperationCanceledException | CoreException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateAccessorsHandler.java
@@ -72,7 +72,7 @@ public class GenerateAccessorsHandler {
 			CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 			if (astRoot != null && cursor != null) {
 				ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-				declarationNode = SourceAssistProcessor.getDeclarationNode(node);
+				declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
 			}
 			// If cursor position is not specified, then insert to the last by default.
 			IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
@@ -165,7 +165,7 @@ public class GenerateConstructorsHandler {
 				ASTNode declarationNode = null;
 				if (cursor != null) {
 					ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-					declarationNode = SourceAssistProcessor.getDeclarationNode(node);
+					declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
 				}
 				// If cursor position is not specified, then insert to the last by default.
 				IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElementAfterLastField(type) : CodeGenerationUtils.findInsertElement(type, cursor);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsHandler.java
@@ -35,7 +35,6 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.corext.codemanipulation.AddCustomConstructorOperation;
@@ -165,10 +164,10 @@ public class GenerateConstructorsHandler {
 				ASTNode declarationNode = null;
 				if (cursor != null) {
 					ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-					declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
+					declarationNode = SourceAssistProcessor.getTypeDeclarationNode(node);
 				}
 				// If cursor position is not specified, then insert to the last by default.
-				IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElementAfterLastField(type) : CodeGenerationUtils.findInsertElement(type, cursor);
+				IJavaElement insertPosition = (declarationNode != null) ? CodeGenerationUtils.findInsertElementAfterLastField(type) : CodeGenerationUtils.findInsertElement(type, cursor);
 
 				Map<String, IVariableBinding> fieldBindings = new HashMap<>();
 				for (IVariableBinding binding : typeBinding.getDeclaredFields()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.corext.codemanipulation.tostringgeneration.GenerateToStringOperation;
 import org.eclipse.jdt.internal.corext.codemanipulation.tostringgeneration.ToStringGenerationSettingsCore;
@@ -99,10 +98,10 @@ public class GenerateToStringHandler {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 		if (astRoot != null && range != null) {
 			ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), range), DiagnosticsHelper.getLength(type.getCompilationUnit(), range));
-			declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
+			declarationNode = SourceAssistProcessor.getTypeDeclarationNode(node);
 		}
 		// If cursor position is not specified, then insert to the last by default.
-		IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);
+		IJavaElement insertPosition = (declarationNode != null) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);
 		TextEdit edit = generateToString(type, params.fields, insertPosition, monitor);
 		return (edit == null) ? null : SourceAssistProcessor.convertToWorkspaceEdit(type.getCompilationUnit(), edit);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
@@ -99,7 +99,7 @@ public class GenerateToStringHandler {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 		if (astRoot != null && range != null) {
 			ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), range), DiagnosticsHelper.getLength(type.getCompilationUnit(), range));
-			declarationNode = SourceAssistProcessor.getDeclarationNode(node);
+			declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
 		}
 		// If cursor position is not specified, then insert to the last by default.
 		IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.GenerateHashCodeEqualsOperation;
@@ -118,9 +117,9 @@ public class HashCodeEqualsHandler {
 				codeGenSettings.createComments = generateComments;
 				codeGenSettings.overrideAnnotation = true;
 				ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-				ASTNode declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
+				ASTNode declarationNode = SourceAssistProcessor.getTypeDeclarationNode(node);
 				// If cursor position is not specified, then insert to the last by default.
-				IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);
+				IJavaElement insertPosition = (declarationNode != null) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);
 				GenerateHashCodeEqualsOperation operation = new GenerateHashCodeEqualsOperation(typeBinding, variableBindings, astRoot, insertPosition, codeGenSettings, useInstanceof, useJava7Objects, regenerate, false, false);
 				operation.setUseBlocksForThen(useBlocks);
 				operation.run(null);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
@@ -118,7 +118,7 @@ public class HashCodeEqualsHandler {
 				codeGenSettings.createComments = generateComments;
 				codeGenSettings.overrideAnnotation = true;
 				ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), cursor), DiagnosticsHelper.getLength(type.getCompilationUnit(), cursor));
-				ASTNode declarationNode = SourceAssistProcessor.getDeclarationNode(node);
+				ASTNode declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
 				// If cursor position is not specified, then insert to the last by default.
 				IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, cursor);
 				GenerateHashCodeEqualsOperation operation = new GenerateHashCodeEqualsOperation(typeBinding, variableBindings, astRoot, insertPosition, codeGenSettings, useInstanceof, useJava7Objects, regenerate, false, false);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
@@ -51,7 +51,7 @@ public class OverrideMethodsHandler {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 		if (astRoot != null && range != null) {
 			ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), range), DiagnosticsHelper.getLength(type.getCompilationUnit(), range));
-			declarationNode = SourceAssistProcessor.getDeclarationNode(node);
+			declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
 		}
 		// If cursor position is not specified, then insert to the last by default.
 		IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OverrideMethodsHandler.java
@@ -21,7 +21,6 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.NodeFinder;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.OverrideMethodsOperation;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.OverrideMethodsOperation.OverridableMethod;
@@ -51,10 +50,10 @@ public class OverrideMethodsHandler {
 		CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(type.getCompilationUnit(), CoreASTProvider.WAIT_YES, monitor);
 		if (astRoot != null && range != null) {
 			ASTNode node = NodeFinder.perform(astRoot, DiagnosticsHelper.getStartOffset(type.getCompilationUnit(), range), DiagnosticsHelper.getLength(type.getCompilationUnit(), range));
-			declarationNode = SourceAssistProcessor.getBodyDeclarationNode(node);
+			declarationNode = SourceAssistProcessor.getTypeDeclarationNode(node);
 		}
 		// If cursor position is not specified, then insert to the last by default.
-		IJavaElement insertPosition = (declarationNode instanceof TypeDeclaration) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);
+		IJavaElement insertPosition = (declarationNode != null) ? CodeGenerationUtils.findInsertElement(type, null) : CodeGenerationUtils.findInsertElement(type, range);
 		TextEdit edit = OverrideMethodsOperation.addOverridableMethods(type, params.overridableMethods, insertPosition, monitor);
 		if (edit == null) {
 			return null;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -592,7 +592,7 @@ public class SourceAssistProcessor {
 		return JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
 	}
 
-	public static ASTNode getBodyDeclarationNode(ASTNode node) {
+	public static ASTNode getTypeDeclarationNode(ASTNode node) {
 		if (node == null) {
 			return null;
 		}
@@ -602,7 +602,7 @@ public class SourceAssistProcessor {
 		while (node != null && !(node instanceof BodyDeclaration) && !(node instanceof Statement)) {
 			node = node.getParent();
 		}
-		return node;
+		return node instanceof TypeDeclaration ? node : null;
 	}
 
 	private static ASTNode getImportDeclarationNode(ASTNode node) {
@@ -612,7 +612,7 @@ public class SourceAssistProcessor {
 		while (node != null && !(node instanceof ImportDeclaration) && !(node instanceof Statement)) {
 			node = node.getParent();
 		}
-		return node;
+		return node instanceof ImportDeclaration ? node : null;
 	}
 
 	private static boolean isInTypeDeclaration(IInvocationContext context) {
@@ -620,8 +620,7 @@ public class SourceAssistProcessor {
 		if (node == null) {
 			node = context.getCoveringNode();
 		}
-		ASTNode declarationNode = getBodyDeclarationNode(node);
-		return declarationNode instanceof TypeDeclaration;
+		return getTypeDeclarationNode(node) != null;
 	}
 
 	private static boolean isInImportDeclaration(IInvocationContext context) {
@@ -629,7 +628,6 @@ public class SourceAssistProcessor {
 		if (node == null) {
 			node = context.getCoveringNode();
 		}
-		ASTNode importDeclarationNode = getImportDeclarationNode(node);
-		return importDeclarationNode instanceof ImportDeclaration;
+		return getImportDeclarationNode(node) != null;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
@@ -103,6 +104,7 @@ public class SourceAssistProcessor {
 		ICompilationUnit cu = context.getCompilationUnit();
 		IType type = getSelectionType(context);
 		boolean isInTypeDeclaration = isInTypeDeclaration(context);
+		boolean isInImportDeclaration = isInImportDeclaration(context);
 
 		try {
 			// Generate Constructor QuickAssist
@@ -120,16 +122,29 @@ public class SourceAssistProcessor {
 
 		// Organize Imports
 		if (preferenceManager.getClientPreferences().isAdvancedOrganizeImportsSupported()) {
-			Optional<Either<Command, CodeAction>> organizeImports = getOrganizeImportsAction(params);
-			addSourceActionCommand($, params.getContext(), organizeImports);
+			// Generate QuickAssist
+			if (isInImportDeclaration) {
+				Optional<Either<Command, CodeAction>> quickAssistOrganizeImports = getOrganizeImportsAction(params, JavaCodeActionKind.QUICK_ASSIST);
+				addSourceActionCommand($, params.getContext(), quickAssistOrganizeImports);
+			}
+			// Generate Source Action
+			Optional<Either<Command, CodeAction>> sourceOrganizeImports = getOrganizeImportsAction(params, CodeActionKind.SourceOrganizeImports);
+			addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 		} else {
 			CodeActionProposal organizeImportsProposal = (pm) -> {
 				TextEdit edit = getOrganizeImportsProposal(context, pm);
 				return convertToWorkspaceEdit(cu, edit);
 			};
-			Optional<Either<Command, CodeAction>> organizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
+			// Generate QuickAssist
+			if (isInImportDeclaration) {
+				Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
+					JavaCodeActionKind.QUICK_ASSIST, organizeImportsProposal);
+				addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
+			}
+			// Generate Source Action
+			Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
 					CodeActionKind.SourceOrganizeImports, organizeImportsProposal);
-			addSourceActionCommand($, params.getContext(), organizeImports);
+			addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 		}
 
 		if (!UNSUPPORTED_RESOURCES.contains(cu.getResource().getName())) {
@@ -248,12 +263,12 @@ public class SourceAssistProcessor {
 		return null;
 	}
 
-	private Optional<Either<Command, CodeAction>> getOrganizeImportsAction(CodeActionParams params) {
+	private Optional<Either<Command, CodeAction>> getOrganizeImportsAction(CodeActionParams params, String kind) {
 		Command command = new Command(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description, COMMAND_ID_ACTION_ORGANIZEIMPORTS, Collections.singletonList(params));
 		CodeAction codeAction = new CodeAction(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description);
-		codeAction.setKind(CodeActionKind.SourceOrganizeImports);
+		codeAction.setKind(kind);
 		codeAction.setCommand(command);
-		codeAction.setDiagnostics(Collections.EMPTY_LIST);
+		codeAction.setDiagnostics(Collections.emptyList());
 		return Optional.of(Either.forRight(codeAction));
 
 	}
@@ -577,7 +592,7 @@ public class SourceAssistProcessor {
 		return JDTUtils.resolveCompilationUnit(params.getTextDocument().getUri());
 	}
 
-	public static ASTNode getDeclarationNode(ASTNode node) {
+	public static ASTNode getBodyDeclarationNode(ASTNode node) {
 		if (node == null) {
 			return null;
 		}
@@ -590,12 +605,31 @@ public class SourceAssistProcessor {
 		return node;
 	}
 
+	private static ASTNode getImportDeclarationNode(ASTNode node) {
+		if (node == null) {
+			return null;
+		}
+		while (node != null && !(node instanceof ImportDeclaration) && !(node instanceof Statement)) {
+			node = node.getParent();
+		}
+		return node;
+	}
+
 	private static boolean isInTypeDeclaration(IInvocationContext context) {
 		ASTNode node = context.getCoveredNode();
 		if (node == null) {
 			node = context.getCoveringNode();
 		}
-		ASTNode declarationNode = getDeclarationNode(node);
+		ASTNode declarationNode = getBodyDeclarationNode(node);
 		return declarationNode instanceof TypeDeclaration;
+	}
+
+	private static boolean isInImportDeclaration(IInvocationContext context) {
+		ASTNode node = context.getCoveredNode();
+		if (node == null) {
+			node = context.getCoveringNode();
+		}
+		ASTNode importDeclarationNode = getImportDeclarationNode(node);
+		return importDeclarationNode instanceof ImportDeclaration;
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -115,7 +115,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertTrue(codeActions.size() >= 3);
 		List<Either<Command, CodeAction>> quickAssistActions = findActions(codeActions, CodeActionKind.QuickFix);
 		Assert.assertNotNull(quickAssistActions);
-		Assert.assertTrue(quickAssistActions.size() >= 2);
+		Assert.assertTrue(quickAssistActions.size() >= 1);
 		List<Either<Command, CodeAction>> organizeImportActions = findActions(codeActions, CodeActionKind.SourceOrganizeImports);
 		Assert.assertNotNull(organizeImportActions);
 		Assert.assertEquals(1, organizeImportActions.size());
@@ -505,7 +505,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertTrue(codeActions.size() >= 3);
 		List<Either<Command, CodeAction>> quickAssistActions = findActions(codeActions, CodeActionKind.QuickFix);
 		Assert.assertNotNull(quickAssistActions);
-		Assert.assertTrue(quickAssistActions.size() >= 2);
+		Assert.assertTrue(quickAssistActions.size() >= 1);
 		List<Either<Command, CodeAction>> organizeImportActions = findActions(codeActions, CodeActionKind.SourceOrganizeImports);
 		Assert.assertNotNull(organizeImportActions);
 		Assert.assertEquals(1, organizeImportActions.size());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.codemanipulation.AbstractSourceTestCase;
 import org.eclipse.jdt.ls.core.internal.correction.AbstractQuickFixTest;
+import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
 import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CodeAction;
@@ -173,6 +174,30 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		for (Either<Command, CodeAction> codeAction : codeActions) {
 			Assert.assertTrue("Unexpected kind:" + codeAction.getRight().getKind(), codeAction.getRight().getKind().startsWith(CodeActionKind.SourceOrganizeImports));
 		}
+	}
+
+	@Test
+	public void testCodeAction_organizeImportsQuickFix() throws Exception {
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"import java.util.List;\n"+
+				"public class Foo {\n"+
+				"	void foo() {\n"+
+				"		String bar = \"astring\";"+
+				"	}\n"+
+				"}\n");
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "util");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+
+		Assert.assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertTrue(CodeActionHandlerTest.commandExists(quickAssistActions, CodeActionHandler.COMMAND_ID_APPLY_EDIT, CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description));
+		// Test if the quick assist exists only for type declaration
+		params = CodeActionUtil.constructCodeActionParams(unit, "String bar");
+		codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertFalse(CodeActionHandlerTest.commandExists(quickAssistActions, CodeActionHandler.COMMAND_ID_APPLY_EDIT, CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description));
 	}
 
 	@Test


### PR DESCRIPTION
![organizeimport](https://user-images.githubusercontent.com/45906942/141069217-fe356005-ec14-4004-acee-e4fb75cf2ce2.gif)

Part of https://github.com/redhat-developer/vscode-java/issues/2057

Signed-off-by: Shi Chen <chenshi@microsoft.com>