### PR TITLE
Add Generate Constructor to Show Fixes for type declaration

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeGenerationUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeGenerationUtils.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.SourceField;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
 import org.eclipse.lsp4j.Range;
@@ -40,7 +41,7 @@ public class CodeGenerationUtils {
 		} else if (Objects.equals(insertionLocation, INSERT_BEFORE_CURSOR)) {
 			return findElementAtPosition(type, cursor);
 		}
-		
+
 		return findElementAfterPosition(type, cursor);
 	}
 
@@ -51,8 +52,28 @@ public class CodeGenerationUtils {
 		} else if (Objects.equals(insertionLocation, INSERT_BEFORE_CURSOR)) {
 			return findElementAtPosition(type, currentOffset);
 		}
-		
+
 		return findElementAfterPosition(type, currentOffset);
+	}
+
+	public static IJavaElement findInsertElementAfterLastField(IType type) {
+		int lastOffset = 0;
+		try {
+			IJavaElement[] members = type.getChildren();
+			for (IJavaElement member : members) {
+				if (member instanceof SourceField) {
+					ISourceRange sourceRange = ((IMember) member).getSourceRange();
+					int offset = sourceRange.getOffset() + sourceRange.getLength();
+					if (offset > lastOffset) {
+						lastOffset = offset;
+					}
+				}
+			}
+			return findElementAfterPosition(type, lastOffset);
+		} catch (JavaModelException e) {
+			// do nothing.
+		}
+		return null;
 	}
 
 	private static IJavaElement findElementAtPosition(IType type, int currentOffset) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -112,9 +112,12 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 		Assert.assertNotNull(codeActions);
 		Assert.assertTrue(codeActions.size() >= 3);
-		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
-		Assert.assertEquals(codeActions.get(1).getRight().getKind(), CodeActionKind.QuickFix);
-		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
+		List<Either<Command, CodeAction>> quickAssistActions = findActions(codeActions, CodeActionKind.QuickFix);
+		Assert.assertNotNull(quickAssistActions);
+		Assert.assertTrue(quickAssistActions.size() >= 2);
+		List<Either<Command, CodeAction>> organizeImportActions = findActions(codeActions, CodeActionKind.SourceOrganizeImports);
+		Assert.assertNotNull(organizeImportActions);
+		Assert.assertEquals(1, organizeImportActions.size());
 		Command c = codeActions.get(0).getRight().getCommand();
 		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
 	}
@@ -475,9 +478,12 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 		Assert.assertNotNull(codeActions);
 		Assert.assertTrue(codeActions.size() >= 3);
-		Assert.assertEquals(codeActions.get(0).getRight().getKind(), CodeActionKind.QuickFix);
-		Assert.assertEquals(codeActions.get(1).getRight().getKind(), CodeActionKind.QuickFix);
-		Assert.assertEquals(codeActions.get(2).getRight().getKind(), CodeActionKind.SourceOrganizeImports);
+		List<Either<Command, CodeAction>> quickAssistActions = findActions(codeActions, CodeActionKind.QuickFix);
+		Assert.assertNotNull(quickAssistActions);
+		Assert.assertTrue(quickAssistActions.size() >= 2);
+		List<Either<Command, CodeAction>> organizeImportActions = findActions(codeActions, CodeActionKind.SourceOrganizeImports);
+		Assert.assertNotNull(organizeImportActions);
+		Assert.assertEquals(1, organizeImportActions.size());
 		Command c = codeActions.get(0).getRight().getCommand();
 		Assert.assertEquals(CodeActionHandler.COMMAND_ID_APPLY_EDIT, c.getCommand());
 	}
@@ -615,7 +621,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	public static boolean commandExists(List<Either<Command, CodeAction>> codeActions, String command) {
-		if (codeActions.isEmpty()) {
+		if (codeActions == null || codeActions.isEmpty()) {
 			return false;
 		}
 		for (Either<Command, CodeAction> codeAction : codeActions) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
@@ -86,6 +86,7 @@ public class GenerateConstructorsActionTest extends AbstractCompilationUnitBased
 				"}"
 				, true, null);
 		//@formatter:on
+		// test for field declaration
 		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "String name");
 		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
 		Assert.assertNotNull(codeActions);
@@ -94,6 +95,12 @@ public class GenerateConstructorsActionTest extends AbstractCompilationUnitBased
 		Command constructorCommand = CodeActionHandlerTest.getCommand(constructorAction);
 		Assert.assertNotNull(constructorCommand);
 		Assert.assertEquals(SourceAssistProcessor.COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT, constructorCommand.getCommand());
+		// test for type declaration
+		params = CodeActionUtil.constructCodeActionParams(unit, "A");
+		codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertTrue(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT));
 	}
 
 	@Test


### PR DESCRIPTION
![constructor](https://user-images.githubusercontent.com/45906942/141077531-7b9815e6-7c51-4173-9cd9-434cc6545998.gif)

Part of https://github.com/redhat-developer/vscode-java/issues/2057

If the quick fix is triggered in type declaration, the generated code will be after the last field declaration.

Signed-off-by: Shi Chen <chenshi@microsoft.com>