### PR TITLE
Improve occurrences highlighting

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentHighlightHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentHighlightHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,75 +18,140 @@ import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.internal.core.manipulation.search.BreakContinueTargetFinder;
+import org.eclipse.jdt.internal.core.manipulation.search.ExceptionOccurrencesFinder;
 import org.eclipse.jdt.internal.core.manipulation.search.IOccurrencesFinder;
+import org.eclipse.jdt.internal.core.manipulation.search.ImplementOccurrencesFinder;
+import org.eclipse.jdt.internal.core.manipulation.search.MethodExitsFinder;
 import org.eclipse.jdt.internal.core.manipulation.search.IOccurrencesFinder.OccurrenceLocation;
 import org.eclipse.jdt.internal.core.manipulation.search.OccurrencesFinder;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 
-@SuppressWarnings("restriction")
-public class DocumentHighlightHandler{
+/**
+ * Handler for {@code textDocument/documentHighlight} requests.
+ */
+public class DocumentHighlightHandler {
 
-	private List<DocumentHighlight> computeOccurrences(ITypeRoot unit, int line, int column, IProgressMonitor monitor) {
-		if (unit != null) {
-			try {
-				int offset = JsonRpcHelpers.toOffset(unit.getBuffer(), line, column);
-				OccurrencesFinder finder = new OccurrencesFinder();
-				CompilationUnit ast = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
-				if (ast != null) {
-					String error = finder.initialize(ast, offset, 0);
-					if (error == null){
-						List<DocumentHighlight> result = new ArrayList<>();
-						OccurrenceLocation[] occurrences = finder.getOccurrences();
-						if (occurrences != null) {
-							for (OccurrenceLocation loc : occurrences) {
-								if (monitor.isCanceled()) {
-									return Collections.emptyList();
-								}
-								result.add(convertToHighlight(unit, loc));
-							}
-						}
-						return result;
-					}
-				}
-			} catch (JavaModelException e) {
-				JavaLanguageServerPlugin.logException("Problem with compute occurrences for" + unit.getElementName(), e);
-			}
+	/**
+	 * Handles a {@code textDocument/documentHighlight} request.
+	 *
+	 * @param params the position at which to find highlights
+	 * @param monitor the progress monitor
+	 * @return the document highlights for the given position
+	 */
+	public static List<DocumentHighlight> documentHighlight(TextDocumentPositionParams params, IProgressMonitor monitor) {
+		ITypeRoot typeRoot = JDTUtils.resolveTypeRoot(params.getTextDocument().getUri());
+		if (typeRoot == null || monitor.isCanceled()) {
+			return Collections.emptyList();
 		}
+		CompilationUnit ast = CoreASTProvider.getInstance().getAST(typeRoot, CoreASTProvider.WAIT_YES, monitor);
+		if (ast == null || monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		int offset = JsonRpcHelpers.toOffset(typeRoot,
+			params.getPosition().getLine(), params.getPosition().getCharacter());
+		ASTNode node = NodeFinder.perform(ast, offset, 0);
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		return findHighlights(ast, node, monitor);
+	}
+
+	/**
+	 * Finds {@link DocumentHighlight}s in a {@link CompilationUnit}.
+	 * The highlights are searched using the following {@link IOccurrencesFinder}s:
+	 * <ol>
+	 *   <li>{@link ExceptionOccurrencesFinder}</li>
+	 *   <li>{@link MethodExitsFinder}</li>
+	 *   <li>{@link BreakContinueTargetFinder}</li>
+	 *   <li>{@link ImplementOccurrencesFinder}</li>
+	 *   <li>{@link OccurrencesFinder}</li>
+	 * </ol>
+	 *
+	 * @param ast the {@link CompilationUnit}
+	 * @param node the selected {@link ASTNode} to find highlights for
+	 * @param monitor the progress monitor
+	 * @return the highlights, or an empty list if none were found
+	 */
+	private static List<DocumentHighlight> findHighlights(CompilationUnit ast, ASTNode node, IProgressMonitor monitor) {
+		IOccurrencesFinder finder;
+
+		finder = new ExceptionOccurrencesFinder();
+		if (finder.initialize(ast, node) == null) {
+			return convertToHighlights(ast, finder.getOccurrences());
+		}
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		finder = new MethodExitsFinder();
+		if (finder.initialize(ast, node) == null) {
+			return convertToHighlights(ast, finder.getOccurrences());
+		}
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		finder = new BreakContinueTargetFinder();
+		if (finder.initialize(ast, node) == null) {
+			return convertToHighlights(ast, finder.getOccurrences());
+		}
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		finder = new ImplementOccurrencesFinder();
+		if (finder.initialize(ast, node) == null) {
+			return convertToHighlights(ast, finder.getOccurrences());
+		}
+		if (monitor.isCanceled()) {
+			return Collections.emptyList();
+		}
+
+		finder = new OccurrencesFinder();
+		if (finder.initialize(ast, node) == null) {
+			return convertToHighlights(ast, finder.getOccurrences());
+		}
+
 		return Collections.emptyList();
 	}
 
-	private DocumentHighlight convertToHighlight(ITypeRoot unit, OccurrenceLocation occurrence)
-			throws JavaModelException {
-		DocumentHighlight h = new DocumentHighlight();
-		if ((occurrence.getFlags() | IOccurrencesFinder.F_WRITE_OCCURRENCE) == IOccurrencesFinder.F_WRITE_OCCURRENCE) {
-			h.setKind(DocumentHighlightKind.Write);
-		} else if ((occurrence.getFlags()
-				| IOccurrencesFinder.F_READ_OCCURRENCE) == IOccurrencesFinder.F_READ_OCCURRENCE) {
-			h.setKind(DocumentHighlightKind.Read);
+	private static List<DocumentHighlight> convertToHighlights(CompilationUnit ast, OccurrenceLocation[] locations) {
+		List<DocumentHighlight> highlights = new ArrayList<>(locations.length);
+		for (OccurrenceLocation loc : locations) {
+			highlights.add(convertToHighlight(ast, loc));
 		}
-		int[] loc = JsonRpcHelpers.toLine(unit.getBuffer(), occurrence.getOffset());
-		int[] endLoc = JsonRpcHelpers.toLine(unit.getBuffer(), occurrence.getOffset() + occurrence.getLength());
-
-		h.setRange(new Range(
-				new Position(loc[0], loc[1]),
-				new Position(endLoc[0],endLoc[1])
-				));
-		return h;
+		return highlights;
 	}
 
-	public List<? extends DocumentHighlight> documentHighlight(TextDocumentPositionParams position, IProgressMonitor monitor) {
-		ITypeRoot type = JDTUtils.resolveTypeRoot(position.getTextDocument().getUri());
-		return computeOccurrences(type, position.getPosition().getLine(),
-				position.getPosition().getCharacter(), monitor);
+	private static DocumentHighlight convertToHighlight(CompilationUnit ast, OccurrenceLocation occurrence) {
+		DocumentHighlight highlight = new DocumentHighlight();
+		if ((occurrence.getFlags() & IOccurrencesFinder.F_WRITE_OCCURRENCE) != 0) {
+			highlight.setKind(DocumentHighlightKind.Write);
+		} else {
+			// highlight kind for symbols should be either Read or Write (not Text), see
+			// https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_documentHighlight
+			highlight.setKind(DocumentHighlightKind.Read);
+		}
+
+		int[] startPos = JsonRpcHelpers.toLine(ast.getTypeRoot(), occurrence.getOffset());
+		int[] endPos = JsonRpcHelpers.toLine(ast.getTypeRoot(), occurrence.getOffset() + occurrence.getLength());
+		highlight.setRange(new Range(
+			new Position(startPos[0], startPos[1]),
+			new Position(endPos[0], endPos[1])
+		));
+		return highlight;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2020 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -620,8 +620,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams position) {
 		logInfo(">> document/documentHighlight");
-		DocumentHighlightHandler handler = new DocumentHighlightHandler();
-		return computeAsync((monitor) -> handler.documentHighlight(position, monitor));
+		return computeAsync((monitor) -> DocumentHighlightHandler.documentHighlight(position, monitor));
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxInitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxInitHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Microsoft Corporation and others.
+* Copyright (c) 2020-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -74,6 +74,9 @@ public class SyntaxInitHandler extends BaseInitHandler {
 		}
 		if (!preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
 			capabilities.setCompletionProvider(CompletionHandler.DEFAULT_COMPLETION_OPTIONS);
+		}
+		if (!preferenceManager.getClientPreferences().isDocumentHighlightDynamicRegistered()) {
+			capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		}
 		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setOpenClose(Boolean.TRUE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Microsoft Corporation and others.
+* Copyright (c) 2020-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -43,6 +43,7 @@ import org.eclipse.jdt.ls.core.internal.ServiceStatus;
 import org.eclipse.jdt.ls.core.internal.handlers.BaseDocumentLifeCycleHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionResolveHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.DocumentHighlightHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentSymbolHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.FoldingRangeHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.HoverHandler;
@@ -67,6 +68,8 @@ import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.FoldingRange;
@@ -225,6 +228,10 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 
 		if (!preferenceManager.getClientPreferences().isClientHoverProviderRegistered() && preferenceManager.getClientPreferences().isHoverDynamicRegistered()) {
 			registerCapability(Preferences.HOVER_ID, Preferences.HOVER, null);
+		}
+
+		if (preferenceManager.getClientPreferences().isDocumentHighlightDynamicRegistered()) {
+			registerCapability(Preferences.DOCUMENT_HIGHLIGHT_ID, Preferences.DOCUMENT_HIGHLIGHT);
 		}
 
 		if (preferenceManager.getClientPreferences().isWorkspaceChangeWatchedFilesDynamicRegistered()) {
@@ -408,6 +415,12 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 		logInfo(">> textDocument/semanticTokens/full");
 		return computeAsync(monitor -> SemanticTokensHandler.full(monitor, params,
 			documentLifeCycleHandler.new DocumentMonitor(params.getTextDocument().getUri())));
+	}
+
+	@Override
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams position) {
+		logInfo(">> document/documentHighlight");
+		return computeAsync((monitor) -> DocumentHighlightHandler.documentHighlight(position, monitor));
 	}
 
 	private void waitForLifecycleJobs(IProgressMonitor monitor) {

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Highlight.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/Highlight.java
@@ -1,12 +1,49 @@
 package org.sample;
 
-public class Highlight {
-	
-	public void test() {
-		String string = "";
-		string.toString();
-		string = "";
-		string.toString();
+import java.io.IOException;
+
+public class Highlight implements FooInterface {
+
+	private String str = "string";
+
+	public String getFoo() throws IOException {
+		if (str.contains("!")) {
+			throw new IOException();
+		}
+		str = "bar";
+		if (str.length() == 0) {
+			throw new RuntimeException();
+		}
+		loop: while (!str.isEmpty()) {
+			for (;;) {
+				if (str.contains("foo")) {
+					break loop;
+				}
+				continue;
+			}
+		}
+		str = String.format(str);
+		return str + "foo";
 	}
-	
+
+	public int getBar() {
+		String str = "bar";
+		return str.length();
+	}
+
+	@Override
+	public void foo() {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void bar() {
+		// TODO Auto-generated method stub
+	}
+
+}
+
+interface FooInterface {
+	public void foo();
+	public void bar();
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentHighlightHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentHighlightHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Remy Suen and others.
+ * Copyright (c) 2017-2022 Remy Suen and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -14,9 +14,12 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
 import org.eclipse.jdt.ls.core.internal.Lsp4jAssertions;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
@@ -32,32 +35,94 @@ import org.junit.Test;
 public class DocumentHighlightHandlerTest extends AbstractProjectsManagerBasedTest {
 
 	private IProject project;
-	private DocumentHighlightHandler handler;
-
-	private void assertHighlight(DocumentHighlight highlight, int expectedLine, int expectedStart, int expectedEnd, DocumentHighlightKind expectedKind) {
-		Lsp4jAssertions.assertRange(expectedLine, expectedStart, expectedEnd, highlight.getRange());
-		assertEquals(expectedKind, highlight.getKind());
-	}
 
 	@Before
 	public void setup() throws Exception {
 		importProjects("eclipse/hello");
 		project = WorkspaceHelper.getProject("hello");
-		handler = new DocumentHighlightHandler();
 	}
 
 	@Test
-	public void testDocumentHighlightHandler() throws Exception {
-		String uri = ClassFileUtil.getURI(project, "org.sample.Highlight");
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
-		TextDocumentPositionParams params = new TextDocumentPositionParams(identifier, new Position(5, 10));
+	public void testDocumentHighlight_ExceptionOccurences() throws JavaModelException {
+		List<DocumentHighlight> result = requestHighlights("org.sample.Highlight", 8, 34);
+		Iterator<DocumentHighlight> it = result.iterator();
 
-		List<? extends DocumentHighlight> highlights = handler.documentHighlight(params, monitor);
-		assertEquals(4, highlights.size());
-		assertHighlight(highlights.get(0), 5, 9, 15, DocumentHighlightKind.Write);
-		assertHighlight(highlights.get(1), 6, 2, 8, DocumentHighlightKind.Read);
-		assertHighlight(highlights.get(2), 7, 2, 8, DocumentHighlightKind.Write);
-		assertHighlight(highlights.get(3), 8, 2, 8, DocumentHighlightKind.Read);
+		assertEquals(2, result.size());
+		assertHighlight(it.next(), 8, 31, 42, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 10, 3, 8, DocumentHighlightKind.Read);
+	}
+
+	@Test
+	public void testDocumentHighlight_MethodExits() throws JavaModelException {
+		List<DocumentHighlight> result = requestHighlights("org.sample.Highlight", 8, 11);
+		Iterator<DocumentHighlight> it = result.iterator();
+
+		assertEquals(4, result.size());
+		assertHighlight(it.next(), 8, 8, 14, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 10, 3, 8, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 14, 3, 8, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 25, 2, 21, DocumentHighlightKind.Read);
+	}
+
+	@Test
+	public void testDocumentHighlight_BreakContinueTarget() throws JavaModelException {
+		List<DocumentHighlight> result = requestHighlights("org.sample.Highlight", 19, 7);
+		Iterator<DocumentHighlight> it = result.iterator();
+
+		assertEquals(2, result.size());
+		assertHighlight(it.next(), 16, 2, 6, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 23, 2, 3, DocumentHighlightKind.Read);
+	}
+
+	@Test
+	public void testDocumentHighlight_ImplementOccurrences() throws JavaModelException {
+		List<DocumentHighlight> result = requestHighlights("org.sample.Highlight", 4, 38);
+		Iterator<DocumentHighlight> it = result.iterator();
+
+		assertEquals(3, result.size());
+		assertHighlight(it.next(), 4, 34, 46, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 34, 13, 16, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 39, 13, 16, DocumentHighlightKind.Read);
+	}
+
+	@Test
+	public void testDocumentHighlight_Occurrences() throws JavaModelException {
+		List<DocumentHighlight> result = requestHighlights("org.sample.Highlight", 6, 18);
+		Iterator<DocumentHighlight> it = result.iterator();
+
+		assertEquals(9, result.size());
+		assertHighlight(it.next(), 6, 16, 19, DocumentHighlightKind.Write);
+		assertHighlight(it.next(), 9, 6, 9, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 12, 2, 5, DocumentHighlightKind.Write);
+		assertHighlight(it.next(), 13, 6, 9, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 16, 16, 19, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 18, 8, 11, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 24, 2, 5, DocumentHighlightKind.Write);
+		assertHighlight(it.next(), 24, 22, 25, DocumentHighlightKind.Read);
+		assertHighlight(it.next(), 25, 9, 12, DocumentHighlightKind.Read);
+	}
+
+	private List<DocumentHighlight> requestHighlights(String compilationUnit, int line, int character) throws JavaModelException {
+		String uri = ClassFileUtil.getURI(project, compilationUnit);
+		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
+		TextDocumentPositionParams params = new TextDocumentPositionParams(identifier, new Position(line, character));
+		List<DocumentHighlight> highlights = DocumentHighlightHandler.documentHighlight(params, monitor);
+		// Sorting the highlights to make testing easier
+		highlights.sort(Comparator.comparingInt(this::getStartLine).thenComparingInt(this::getStartCharacter));
+		return highlights;
+	}
+
+	private int getStartLine(DocumentHighlight highlight) {
+		return highlight.getRange().getStart().getLine();
+	}
+
+	private int getStartCharacter(DocumentHighlight highlight) {
+		return highlight.getRange().getStart().getCharacter();
+	}
+
+	private void assertHighlight(DocumentHighlight highlight, int expectedLine, int expectedStart, int expectedEnd, DocumentHighlightKind expectedKind) {
+		Lsp4jAssertions.assertRange(expectedLine, expectedStart, expectedEnd, highlight.getRange());
+		assertEquals(expectedKind, highlight.getKind());
 	}
 
 }


### PR DESCRIPTION
Fixes redhat-developer/vscode-java#2211
Fixes redhat-developer/vscode-java#2212
Fixes redhat-developer/vscode-java#2213
Fixes redhat-developer/vscode-java#972

---

This PR improves on the occurrence highlighting by porting the following occurrence finders from `jdt.ui`:

- `MethodExitsFinder`

![highlight-method-exits](https://user-images.githubusercontent.com/52179873/141702524-72d6a8fe-9439-473b-abcd-97e142da638f.png)

- `ExceptionOccurrencesFinder`

![highlight-exception-occurrences](https://user-images.githubusercontent.com/52179873/141702488-4e38225f-2ccd-472c-9c3b-b3fc2a0468a8.png)

- `BreakContinueTargetFinder`

![highlight-break-continue-target](https://user-images.githubusercontent.com/52179873/141702577-6acec225-068b-4c93-8e99-ae53fd2ef7cb.png)

- `ImplementOccurrencesFinder`

![highlight-implement-occurrences](https://user-images.githubusercontent.com/52179873/141702586-1201dc3a-54e2-43f7-945a-d9f99f12c5e4.png)

It also registers the document highlight capability in the syntax server.

Lastly, I fixed a bug which could cause the wrong `DocumentHighlightKind` to be set. The bug was caused by [incorrect logic when checking the bit flags set on an `OccurrenceLocation`](https://github.com/0dinD/eclipse.jdt.ls/blob/cf6358ba4c166fa7d4c45aba5b7b22ea08516524/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentHighlightHandler.java#L70). If, for example, there were no flags set (`0`), the condition would still be true, which means `DocumentHighlightKind.Write` would be set even though it shouldn't be.

---

Initially I thought these occurrence finders were available from `jdt.core.manipulation` (seeing as `OccurrencesFinder` is), but it turns out they are located in `jdt.ui`. So I copied the needed classes from there, seeing as they have no external dependencies and as such could easily be ported.

With that said, I understand that copying from `jdt.ui` is not ideal, and I think these classes should be moved to `jdt.core.manipulation`. But right now I don't have time to spend on that, especially since I'll need to learn how Gerrit works and how to set up `jdt.ui` for development.

If anyone wants to help with that to avoid copying, please go ahead. But I also think it would be valuable for me to learn how to contribute to upstream (and this seems like a fairly simple contribution to start with), so another alternative is to wait for that (might be a few more weeks until I have time though). Of course, we could also merge this PR with the copied files and then remove them later once they've been moved to `jdt.core.manipulation`.