### PR TITLE
Boost loading performance of eclipse.jdt.ls project itself

### DIFF
--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -36,7 +36,6 @@
 				<version>2.1.1</version>
 				<executions>
 					<execution>
-						<?m2e execute onConfiguration?>
 						<phase>generate-resources</phase>
 						<goals>
 							<goal>execute</goal>

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -36,6 +36,7 @@
 				<version>2.1.1</version>
 				<executions>
 					<execution>
+						<?m2e ignore?>
 						<phase>generate-resources</phase>
 						<goals>
 							<goal>execute</goal>


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

See discussion at https://github.com/eclipse/eclipse.jdt.ls/pull/1948#issuecomment-979635839, when developing eclipse.jdt.ls project in VS Code, skipping loading gradleChecksums job can improve import performance a lot.