### PR TITLE
Update Target Platform to 4.22 (2021-12) release.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -31,7 +31,7 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.22-I-builds/I20211116-1800/"/>
+            <repository location="https://download.eclipse.org/releases/2021-12/202112081000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Interestingly, the repo has a folder `202112081000` (December 8th 2021) which would be the GA, so I'm guessing we won't need to update this once again.