### PR TITLE
Java LS with vscode-pde rebuilds workspace for every restart

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -998,7 +998,9 @@ public class Preferences {
 									if (v instanceof Boolean) {
 										runtime.setDefault((Boolean) v);
 									}
-									hasDefault[0] = true;
+									if (runtime.isDefault()) {
+										hasDefault[0] = true;
+									}
 								}
 								break;
 							default:


### PR DESCRIPTION
Fixes #1960 

Both, VS Code PDE and Java LS set default JVMs.
See 
- https://git.eclipse.org/c/pde/eclipse.pde.ui.git/tree/ui/org.eclipse.pde.core/src/org/eclipse/pde/core/target/LoadTargetDefinitionJob.java?h=R3_8_maintenance&id=2ece9c75272658af52e62ec8eb4e759ee8ed916f#n227
- https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java#L98
- https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java#L186

If those JVMs are different, Java LS will update all projects.
The issue can't be reproduced when starting VS Code with JDK 11 and without java.configuration.runtimes.

The PR adds the java.ls.doNotSetDefaultJVM property. Java LS won't set a default JVM if it is started with -Djava.ls.doNotSetDefaultJVM=true.

Test vsix: https://github.com/snjeza/vscode-test/raw/master/java-1.2.4.vsix
Test project: https://github.com/eclipse/eclipse.jdt.ls
Test vmargs:
```
"java.jdt.ls.vmargs": "-Djava.ls.doNotSetDefaultJVM=true <YOUR_VMARGS>",
```

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>