### PR TITLE
Make the debounce adaptive for validation job

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MovingAverage.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MovingAverage.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+public class MovingAverage {
+	public long n = 1;
+	public long value;
+
+	public MovingAverage() {
+		this(400);
+	}
+
+	public MovingAverage(long value) {
+		this.value = value;
+	}
+
+	public MovingAverage update(long value) {
+		this.value = this.value + (value - this.value) / this.n;
+		this.n += 1;
+		return this;
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MovingAverageTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MovingAverageTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class MovingAverageTest {
+
+	@Test
+	public void testUpdate() {
+		MovingAverage average = new MovingAverage();
+
+		// initialize to 400 at first
+		assertEquals(400, average.value);
+
+		average.update(200);
+		// the first input value takes over the initial value
+		assertEquals(200, average.value);
+
+		average.update(100);
+		// (200 + 100) / 2
+		assertEquals(150, average.value);
+	}
+}


### PR DESCRIPTION
## TL;DR

This PR makes the debounce time of `performValidation()` adaptive. This change won't affect the perf for a specific scenario, like the time to calculate the completion list, but it can significantly boost the overall throughput of the JDT Language Server, and the more powerful the machine is, the more perf boost it will get.

## 400ms debounce is too large

The current 400ms debounce time looks too large for the validation job. I added some logs to see how long it takes for `performValidation()` job.

Randomly writing some code in a java file with 4000+ lines and 400+ methods:

| Windows, i7@2.9GHz, 32GB Mem | MacOS, i5@2.9GHz, 8GB Mem |
|---|---|
| 7.04ms | 48.97ms |

If we check the time of `JDTLanguageServer.waitForLifeCycleJobs()`, you can see threads take lot of time just wait for the document lifecycle jobs

#### Windows
![image](https://user-images.githubusercontent.com/6193897/145742171-f7668183-1006-42c8-9a54-769e0f87ab89.png)

#### MacOS
![image](https://user-images.githubusercontent.com/6193897/145742198-562140ff-7423-4828-95da-bdca7c801aa8.png)

## Use Adaptive Debounce
I used a moving average window to make the debounce time adaptive and make sure the largest debounce time is `400ms`.

## Average Time Cost per LSP Request
To check the impact of this change, let's see the average time cost to resolve each LSP request. We can get the time for each request calculate from the trace:
![image](https://user-images.githubusercontent.com/6193897/145742506-8df3ef6f-aef5-49fa-8ac7-4f3090fbb8ab.png)

### Windows (Unit: ms)
|  | Cut Top & Bottom 5% | Cut Top & Bottom 10% |
|---|---|---|
| 400ms Debounce | 229.36 | 176.05 |
| Adaptive Debounce | **125.53** | **99.98** |

### MacOS (Unit: ms)
|  | Cut Top & Bottom 5% | Cut Top & Bottom 10% |
|---|---|---|
| 400ms Debounce | **1206.7** | 1143.27 |
| Adaptive Debounce | 1214.51 | **1073.7** |

> Note: When coding, some of the LSP request will take plenty of time to calculate (i.e. complete types with `S` for the first time), thus impacting the following LSP requests because we only dispatch one request each time. So the data in the table above, I sorted all the time data, and cut some lowest and highest data. (Considered them as abnormal data).

## Throughput
We can convert the above table to throughput, the unit is number of LSP request handled per second

### Windows
|  | Cut Top & Bottom 5% | Cut Top & Bottom 10% |
|---|---|---|
| 400ms Debounce | 4.36 | 5.68 |
| Adaptive Debounce | **7.97** | **10** |

### MacOS
|  | Cut Top & Bottom 5% | Cut Top & Bottom 10% |
|---|---|---|
| 400ms Debounce | **0.83** | 0.87 |
| Adaptive Debounce | 0.82 | **0.93** |

Below are two videos illustrate the impact when we have a higher throughput, please note that the time it costs to semantic highlighting variable `aaa`. A higher throughput makes the semantic highlighting faster (And for other kind of requests as well 😃).

### 400ms debounce

https://user-images.githubusercontent.com/6193897/145743726-d3af886a-c8de-4afa-90a8-e853b169be05.mp4

### Adaptive debounce

https://user-images.githubusercontent.com/6193897/145743737-5560ea73-31e4-44bc-ace3-56850b7dd231.mp4

Signed-off-by: Sheng Chen <sheche@microsoft.com>