### PR TITLE
Update tycho to 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<base.name>JDT Language Server</base.name>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<tycho-version>2.3.0</tycho-version>
+		<tycho-version>2.5.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/eclipse.jdt.ls.git</tycho.scmUrl>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>


### PR DESCRIPTION
so you can build jdt.ls with a Java 17 JDK. See #1976.

Signed-off-by: Fred Bricon <fbricon@gmail.com>
