### PR TITLE
Postpone the capability registration until the service is ready

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
@@ -198,8 +198,6 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 		} catch (OperationCanceledException | InterruptedException e) {
 			logException(e.getMessage(), e);
 		}
-		this.client.sendStatus(ServiceStatus.Started, "LightWeightServiceReady");
-		logInfo(">> initialization job finished");
 
 		PreferenceManager preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 		if (preferenceManager.getClientPreferences().isCompletionDynamicRegistered()) {
@@ -237,6 +235,9 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 		if (preferenceManager.getClientPreferences().isWorkspaceChangeWatchedFilesDynamicRegistered()) {
 			projectsManager.registerWatchers();
 		}
+
+		this.client.sendStatus(ServiceStatus.Started, "LightWeightServiceReady");
+		logInfo(">> initialization job finished");
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandlerTest.java
@@ -207,7 +207,6 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
 		when(mockCapabilies.isDocumentSymbolDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isWorkspaceSymbolDynamicRegistered()).thenReturn(Boolean.TRUE);
-		when(mockCapabilies.isDocumentSymbolDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isCodeActionDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isDefinitionDynamicRegistered()).thenReturn(Boolean.TRUE);
 		when(mockCapabilies.isHoverDynamicRegistered()).thenReturn(Boolean.TRUE);
@@ -218,6 +217,7 @@ public class InitHandlerTest extends AbstractProjectsManagerBasedTest {
 		InitializeResult result = initialize(true);
 		assertNull(result.getCapabilities().getDocumentSymbolProvider());
 		server.initialized(new InitializedParams());
+		waitForBackgroundJobs();
 		verify(client, times(9)).registerCapability(any());
 		waitForBackgroundJobs();
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -29,6 +29,8 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
@@ -117,6 +119,13 @@ public class JDTLanguageServerTest {
 		map.put(Preferences.JAVA_FORMAT_ON_TYPE_ENABLED_KEY, true);
 		DidChangeConfigurationParams params = new DidChangeConfigurationParams(map);
 
+		// If initialized jobs are not finished, won't register capabilities
+		server.didChangeConfiguration(params);
+		verify(client, times(0)).registerCapability(any());
+
+		reset(client);
+		server.initialized(null);
+		JobHelpers.waitForJobsToComplete(new NullProgressMonitor());
 		server.didChangeConfiguration(params);
 		verify(client, times(6)).registerCapability(any());
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
@@ -126,6 +127,7 @@ public class JDTLanguageServerTest {
 		reset(client);
 		server.initialized(null);
 		JobHelpers.waitForJobsToComplete(new NullProgressMonitor());
+		waitForInitializeJobs();
 		server.didChangeConfiguration(params);
 		verify(client, times(6)).registerCapability(any());
 
@@ -186,4 +188,12 @@ public class JDTLanguageServerTest {
 		when(clientPreferences.isOnTypeFormattingDynamicRegistrationSupported()).thenReturn(enable);
 	}
 
+	private void waitForInitializeJobs() throws InterruptedException {
+		Job[] jobs = Job.getJobManager().find(null);
+		for(int i = 0; i < jobs.length; i++ ) {
+			if ("Initialize workspace".equals(jobs[i].getName())) {
+				jobs[i].join();
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR postpone the capability registration until the service is ready.

If we do the registration before LS is ready, the client will start sending request to server, while the server won't be able to handle them in time. A side effect for that is: the client snippet become unusable because VS Code will wait the result from server and render the list together for once.

Also see: https://github.com/redhat-developer/vscode-java/pull/2240#issuecomment-992293711

Signed-off-by: Sheng Chen <sheche@microsoft.com>