### PR TITLE
Convert to static import incorrectly removes an import.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/RefactorProcessor.java
@@ -57,7 +57,6 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import org.eclipse.jdt.core.dom.Type;
@@ -86,6 +85,7 @@ import org.eclipse.jdt.internal.corext.refactoring.code.ConvertAnonymousToNested
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineConstantRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineMethodRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineTempRefactoring;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUpCore;
@@ -93,7 +93,7 @@ import org.eclipse.jdt.internal.ui.fix.LambdaExpressionsCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.corrections.proposals.ASTRewriteCorrectionProposal;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.ASTRewriteRemoveImportsCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.FixCorrectionProposal;
@@ -781,25 +781,31 @@ public class RefactorProcessor {
 
 		try {
 			ImportRewrite importRewrite = StubUtility.createImportRewrite(context.getCompilationUnit(), true);
-			ImportRewrite importRewriteReplaceAllOccurences = StubUtility.createImportRewrite(context.getCompilationUnit(), true);
 			ASTRewrite astRewrite = ASTRewrite.create(node.getAST());
 			ASTRewrite astRewriteReplaceAllOccurrences = ASTRewrite.create(node.getAST());
 
-			int[] allReferencesToDeclaringClass = new int[1];
-			allReferencesToDeclaringClass[0] = 0;
-			int[] referencesFromOtherOccurences = new int[1];
-			referencesFromOtherOccurences[0] = 0;
+			ImportRemover remover = new ImportRemover(context.getCompilationUnit().getJavaProject(), context.getASTRoot());
+			ImportRemover removerAllOccurences = new ImportRemover(context.getCompilationUnit().getJavaProject(), context.getASTRoot());
 			MethodInvocation mi = null;
 			QualifiedName qn = null;
 			if (name.getParent() instanceof MethodInvocation) {
 				mi = (MethodInvocation) name.getParent();
 				// convert the method invocation
 				astRewrite.remove(mi.getExpression(), null);
-				mi.typeArguments().forEach(type -> astRewrite.remove((Type) type, null));
+				remover.registerRemovedNode(mi.getExpression());
+				removerAllOccurences.registerRemovedNode(mi.getExpression());
+				mi.typeArguments().forEach(typeObject -> {
+					Type type = (Type) typeObject;
+					astRewrite.remove(type, null);
+					remover.registerRemovedNode(type);
+					removerAllOccurences.registerRemovedNode(type);
+				});
 			} else if (name.getParent() instanceof QualifiedName) {
 				qn = (QualifiedName) name.getParent();
 				// convert the field access
 				astRewrite.replace(qn, ASTNodeFactory.newName(node.getAST(), name.getFullyQualifiedName()), null);
+				remover.registerRemovedNode(qn);
+				removerAllOccurences.registerRemovedNode(qn);
 			} else {
 				return false;
 			}
@@ -817,21 +823,12 @@ public class RefactorProcessor {
 						String fullyQualifiedName = ((Name) methodInvocationExpression).getFullyQualifiedName();
 						if (miFinal != null && miFinal.getExpression() instanceof Name && ((Name) miFinal.getExpression()).getFullyQualifiedName().equals(fullyQualifiedName)
 								&& miFinal.getName().getIdentifier().equals(methodInvocation.getName().getIdentifier())) {
-							methodInvocation.typeArguments().forEach(type -> astRewriteReplaceAllOccurrences.remove((Type) type, null));
+							methodInvocation.typeArguments().forEach(type -> {
+								astRewriteReplaceAllOccurrences.remove((Type) type, null);
+								removerAllOccurences.registerRemovedNode((Type) type);
+							});
 							astRewriteReplaceAllOccurrences.remove(methodInvocationExpression, null);
-							allReferencesToDeclaringClass[0]++;
-						} else if (declaringClass.getName().equals(fullyQualifiedName)) {
-							allReferencesToDeclaringClass[0]++;
-							referencesFromOtherOccurences[0]++;
-						}
-					} else if (methodInvocationExpression instanceof ClassInstanceCreation) {
-						ClassInstanceCreation classInstanceCreation = (ClassInstanceCreation) methodInvocationExpression;
-						if (classInstanceCreation.getType() instanceof SimpleType) {
-							String typeName = ((SimpleType) classInstanceCreation.getType()).getName().getFullyQualifiedName();
-							if (typeName.equals(declaringClass.getName())) {
-								allReferencesToDeclaringClass[0]++;
-								referencesFromOtherOccurences[0]++;
-							}
+							removerAllOccurences.registerRemovedNode(methodInvocationExpression);
 						}
 					}
 
@@ -844,34 +841,25 @@ public class RefactorProcessor {
 				public boolean visit(QualifiedName qualifiedName) {
 					if (qnFinal != null && qualifiedName.getFullyQualifiedName().equals(qnFinal.getFullyQualifiedName())) {
 						astRewriteReplaceAllOccurrences.replace(qualifiedName, ASTNodeFactory.newName(node.getAST(), name.getFullyQualifiedName()), null);
-						allReferencesToDeclaringClass[0]++;
-					} else if (declaringClass.getName().equals(qualifiedName.getQualifier().getFullyQualifiedName())) {
-						allReferencesToDeclaringClass[0]++;
-						referencesFromOtherOccurences[0]++;
+						removerAllOccurences.registerRemovedNode(qualifiedName);
 					}
 					return super.visit(qualifiedName);
 				}
 			});
 
-			// add the static import
 			if (needImport) {
 				importRewrite.addStaticImport(binding);
-				if (allReferencesToDeclaringClass[0] == 1) { // If there are exactly 1 visits, the import can be removed
-					importRewrite.removeImport(declaringClass.getQualifiedName());
-				}
-				importRewriteReplaceAllOccurences.addStaticImport(binding);
-				if (referencesFromOtherOccurences[0] == 0) {
-					importRewriteReplaceAllOccurences.removeImport(declaringClass.getQualifiedName());
-				}
 			}
 
-			ASTRewriteCorrectionProposal proposal = new ASTRewriteCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import, CodeActionKind.Refactor, context.getCompilationUnit(), astRewrite,
+			ASTRewriteRemoveImportsCorrectionProposal proposal= new ASTRewriteRemoveImportsCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import, CodeActionKind.Refactor, context.getCompilationUnit(), astRewrite,
 					IProposalRelevance.ADD_STATIC_IMPORT);
 			proposal.setImportRewrite(importRewrite);
+			proposal.setImportRemover(remover);
 			proposals.add(proposal);
-			ASTRewriteCorrectionProposal proposalReplaceAllOccurrences = new ASTRewriteCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import_replace_all, CodeActionKind.Refactor, context.getCompilationUnit(),
-					astRewriteReplaceAllOccurrences, IProposalRelevance.ADD_STATIC_IMPORT);
-			proposalReplaceAllOccurrences.setImportRewrite(importRewriteReplaceAllOccurences);
+			ASTRewriteRemoveImportsCorrectionProposal proposalReplaceAllOccurrences= new ASTRewriteRemoveImportsCorrectionProposal(CorrectionMessages.QuickAssistProcessor_convert_to_static_import_replace_all, CodeActionKind.Refactor, context.getCompilationUnit(), astRewriteReplaceAllOccurrences,
+					IProposalRelevance.ADD_STATIC_IMPORT);
+			proposalReplaceAllOccurrences.setImportRewrite(importRewrite);
+			proposalReplaceAllOccurrences.setImportRemover(removerAllOccurences);
 			proposals.add(proposalReplaceAllOccurrences);
 		} catch (IllegalArgumentException e) {
 			// Wrong use of ASTRewrite or ImportRewrite API, see bug 541586

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ASTRewriteRemoveImportsCorrectionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/ASTRewriteRemoveImportsCorrectionProposal.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corrections.proposals;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
+
+public class ASTRewriteRemoveImportsCorrectionProposal extends ASTRewriteCorrectionProposal {
+
+	private ImportRemover fImportRemover;
+
+	public ASTRewriteRemoveImportsCorrectionProposal(String name, String kind, ICompilationUnit cu, ASTRewrite rewrite, int relevance) {
+		super(name, kind, cu, rewrite, relevance);
+	}
+
+	public void setImportRemover(ImportRemover remover) {
+		fImportRemover = remover;
+	}
+
+	@Override
+	protected ASTRewrite getRewrite() throws CoreException {
+		ASTRewrite rewrite = super.getRewrite();
+		ImportRewrite importRewrite = getImportRewrite();
+		if (fImportRemover != null && importRewrite != null) {
+			fImportRemover.applyRemoves(importRewrite);
+		}
+		return rewrite;
+	}
+
+}


### PR DESCRIPTION
- Fixes #1203
- Fixed upstream at https://eclip.se/542653

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>