### PR TITLE
Provide more alias for code snippets

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/CodeSnippetTemplate.java
@@ -28,7 +28,13 @@ public enum CodeSnippetTemplate {
 	IF(TemplatePreferences.IF_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.IF_CONTENT, TemplatePreferences.IF_DESCRIPTION),
 	IFELSE(TemplatePreferences.IFELSE_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.IFELSE_CONTENT, TemplatePreferences.IFELSE_DESCRIPTION),
 	IFNULL(TemplatePreferences.IFNULL_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.IFNULL_CONTENT, TemplatePreferences.IFNULL_DESCRIPTION),
-	IFNOTNULL(TemplatePreferences.IFNOTNULL_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.IFNOTNULL_CONTENT, TemplatePreferences.IFNOTNULL_DESCRIPTION);
+	IFNOTNULL(TemplatePreferences.IFNOTNULL_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.IFNOTNULL_CONTENT, TemplatePreferences.IFNOTNULL_DESCRIPTION),
+	
+	// the following snippets are the same as above but with different alias, since users may not easily find them if they come from different IDEs.
+	SOUT(TemplatePreferences.SOUT_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSOUT_CONTENT, TemplatePreferences.SYSOUT_DESCRIPTION),
+	SERR(TemplatePreferences.SERR_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSERR_CONTENT, TemplatePreferences.SYSERR_DESCRIPTION),
+	SOUTM(TemplatePreferences.SOUTM_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.SYSTRACE_CONTENT, TemplatePreferences.SYSTRACE_DESCRIPTION),
+	ITER(TemplatePreferences.ITER_ID, JavaContextType.ID_STATEMENTS, TemplatePreferences.FOREACH_CONTENT, TemplatePreferences.FOREACH_DESCRIPTION);
 	//@formatter:on
 
 	private final String templateId;
@@ -55,9 +61,13 @@ public enum CodeSnippetTemplate {
 class TemplatePreferences {
 	// IDs
 	public static final String SYSOUT_ID = "org.eclipse.jdt.ls.templates.sysout";
+	public static final String SOUT_ID = "org.eclipse.jdt.ls.templates.sout";
 	public static final String SYSERR_ID = "org.eclipse.jdt.ls.templates.syserr";
+	public static final String SERR_ID = "org.eclipse.jdt.ls.templates.serr";
 	public static final String SYSTRACE_ID = "org.eclipse.jdt.ls.templates.systrace";
+	public static final String SOUTM_ID = "org.eclipse.jdt.ls.templates.soutm";
 	public static final String FOREACH_ID = "org.eclipse.jdt.ls.templates.for_array";
+	public static final String ITER_ID = "org.eclipse.jdt.ls.templates.iter";
 	public static final String FORI_ID = "org.eclipse.jdt.ls.templates.for_iterable";
 	public static final String WHILE_ID = "org.eclipse.jdt.ls.templates.while_condition";
 	public static final String DOWHILE_ID = "org.eclipse.jdt.ls.templates.do";

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -993,6 +993,34 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSnippet_sout() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod() {\n" +
+			"		sout" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "sout");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		for (CompletionItem item : items) {
+			if (CompletionItemKind.Snippet.equals(item.getKind()) && "sout".equals(item.getLabel())) {
+				String insertText = item.getInsertText();
+		assertEquals("System.out.println(${0});", insertText);
+				return;
+			}
+		}
+		fail("Failed to find snippet: 'sout'.");
+	}
+
+	@Test
 	public void testSnippet_syserr() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = getWorkingCopy(
@@ -1017,6 +1045,34 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSnippet_serr() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod() {\n" +
+			"		serr" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "serr");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		for (CompletionItem item : items) {
+			if (CompletionItemKind.Snippet.equals(item.getKind()) && "serr".equals(item.getLabel())) {
+				String insertText = item.getInsertText();
+				assertEquals("System.err.println(${0});", insertText);
+				return;
+			}
+		}
+		fail("Failed to find snippet: 'serr'.");
+	}
+
+	@Test
 	public void testSnippet_systrace() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = getWorkingCopy(
@@ -1036,6 +1092,33 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = new ArrayList<>(list.getItems());
 		CompletionItem item = items.get(0);
 		assertEquals("systrace", item.getLabel());
+		String insertText = item.getInsertText();
+		assertEquals("System.out.println(\"${enclosing_type}.${enclosing_method}()\");", insertText);
+		CompletionItem resolved = server.resolveCompletionItem(item).join();
+		assertNotNull(resolved.getTextEdit());
+		assertEquals("System.out.println(\"Test.testMethod()\");", resolved.getTextEdit().getLeft().getNewText());
+	}
+
+	@Test
+	public void testSnippet_soutm() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod() {\n" +
+			"		soutm" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "soutm");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("soutm", item.getLabel());
 		String insertText = item.getInsertText();
 		assertEquals("System.out.println(\"${enclosing_type}.${enclosing_method}()\");", insertText);
 		CompletionItem resolved = server.resolveCompletionItem(item).join();
@@ -1096,6 +1179,38 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		CompletionItem resolved = server.resolveCompletionItem(item).join();
 		assertNotNull(resolved.getTextEdit());
 		assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t$TM_SELECTED_TEXT${0}\n}", resolved.getTextEdit().getLeft().getNewText());
+	}
+
+	@Test
+	public void testSnippet_list_iter() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"import java.util.List;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(List<String> args) {\n" +
+			"		iter" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "iter");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		for (CompletionItem item : items) {
+			if (CompletionItemKind.Snippet.equals(item.getKind()) && "iter".equals(item.getLabel())) {
+				String insertText = item.getInsertText();
+				assertEquals("for (${1:iterable_type} ${2:iterable_element} : ${3:iterable}) {\n\t$TM_SELECTED_TEXT${0}\n}", insertText);
+				CompletionItem resolved = server.resolveCompletionItem(item).join();
+				assertNotNull(resolved.getTextEdit());
+				assertEquals("for (${1:String} ${2:string} : ${3:args}) {\n\t$TM_SELECTED_TEXT${0}\n}", resolved.getTextEdit().getLeft().getNewText());
+				return;
+			}
+		}
+		fail("Failed to find snippet: 'iter'.");
 	}
 
 	@Test


### PR DESCRIPTION
We received a lot users feedback that they need code snippets like `sout`, `serr`, etc... Actually we have those snippets supported but with different labels.

To help users easily find those features no matter which IDEs they are used to, this PR adds those mentioned alias to the completion list.

The following alias are added: 
- sysout -> sout
- syserr -> serr
- systrace -> soutm
- foreach -> iter

require: https://github.com/redhat-developer/vscode-java/pull/2314

Signed-off-by: Sheng Chen <sheche@microsoft.com>