### PR TITLE
Better handling type filtering on method completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -369,19 +369,27 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			return true;
 		}
 		// Only filter types and constructors from completion.
-		// Methods from already imported types and packages can still be proposed.
-		// See https://github.com/eclipse/eclipse.jdt.ls/issues/1212
 		switch (proposal.getKind()) {
 			case CompletionProposal.CONSTRUCTOR_INVOCATION:
 			case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
 			case CompletionProposal.JAVADOC_TYPE_REF:
 			case CompletionProposal.PACKAGE_REF:
-			case CompletionProposal.TYPE_REF: {
-				char[] declaringType = getDeclaringType(proposal);
-				return declaringType != null && TypeFilter.isFiltered(declaringType);
-			}
+			case CompletionProposal.TYPE_REF: 
+				return isTypeFiltered(proposal);
+			case CompletionProposal.METHOD_REF:
+				// Methods from already imported types and packages can still be proposed.
+				// Whether the expected type is resolved or not can be told from the required proposal.
+				// When the type is missing, an additional proposal could be found.
+				if (proposal.getRequiredProposals() != null) {
+					return isTypeFiltered(proposal);
+				}
 		}
 		return false;
+	}
+
+	protected boolean isTypeFiltered(CompletionProposal proposal) {
+		char[] declaringType = getDeclaringType(proposal);
+		return declaringType != null && TypeFilter.isFiltered(declaringType);
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -374,7 +374,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
 			case CompletionProposal.JAVADOC_TYPE_REF:
 			case CompletionProposal.PACKAGE_REF:
-			case CompletionProposal.TYPE_REF: 
+			case CompletionProposal.TYPE_REF:
 				return isTypeFiltered(proposal);
 			case CompletionProposal.METHOD_REF:
 				// Methods from already imported types and packages can still be proposed.

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -2990,6 +2990,58 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testCompletion_FilterTypesKeepMethods2() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
+		//@formatter:off
+				"package org.sample;\n"
+			+	"import java.util.List;"
+			+	"public class Test {\n\n"
+			+	"	void test() {\n\n"
+			+	"		List l; \n"
+			+	"		l.clea \n"
+			+	"	}\n"
+			+	"}\n");
+		//@formatter:on
+		try {
+			List<String> filteredTypes = new ArrayList<>();
+			filteredTypes.add("java.util.*");
+			PreferenceManager.getPrefs(null).setFilteredTypes(filteredTypes);
+
+			CompletionList list = requestCompletions(unit, "l.clea");
+			assertNotNull(list);
+			assertEquals("Missing completion", 1, list.getItems().size());
+			assertEquals("clear() : void", list.getItems().get(0).getLabel());
+		} finally {
+			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
+		}
+	}
+
+	@Test
+	public void testCompletion_FilterMethodsWhenTypeIsMissing() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
+		//@formatter:off
+				"package org.sample;\n"
+			+	"public class Test {\n\n"
+			+	"	void test() {\n\n"
+			+	"		List l; \n"
+			+	"		l.clea \n"
+			+	"	}\n"
+			+	"}\n");
+		//@formatter:on
+		try {
+			List<String> filteredTypes = new ArrayList<>();
+			filteredTypes.add("java.util.*");
+			PreferenceManager.getPrefs(null).setFilteredTypes(filteredTypes);
+
+			CompletionList list = requestCompletions(unit, "l.clea");
+			assertNotNull(list);
+			assertEquals(0, list.getItems().size());
+		} finally {
+			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
+		}
+	}
+
+	@Test
 	public void testCompletion_InvalidJavadoc() throws Exception {
 		importProjects("maven/aspose");
 		IProject project = null;


### PR DESCRIPTION
- when the expected type can be resolved, always show the completion
  result.
- If the expected type is missing, honor the type filter setting.

fix https://github.com/redhat-developer/vscode-java/issues/2279

Signed-off-by: Sheng Chen <sheche@microsoft.com>