### PR TITLE
Update TP to I20220216-0600

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -30,7 +30,7 @@
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds/I20220203-0300/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.23-I-builds/I20220216-0600/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -36,12 +36,12 @@
 			<id>lombok</id>
 			<activation>
 				<property>
-					<name>jdt.ls.lombok.disabled</name>
-					<value>!true</value>
+					<name>jdt.ls.lombok.enabled</name>
+					<value>true</value>
 				</property>
 			</activation>
 			<properties>
-				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.20.jar</lombokArgs>
+				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.22.jar</lombokArgs>
 			</properties>
 			<build>
 				<plugins>
@@ -53,7 +53,7 @@
 								<artifactItem>
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
-									<version>1.18.20</version>
+									<version>1.18.22</version>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.22</version>
         </dependency>
     </dependencies>
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/SerialVersionQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/SerialVersionQuickFixTest.java
@@ -69,9 +69,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("public class Test5 {\n");
 		buf.append("    public void test() {\n");
 		buf.append("        class X implements Serializable, Cloneable, Runnable {\n");
-		buf.append("            /**\n");
-		buf.append("             *\n");
-		buf.append("             */\n");
 		buf.append("            private static final long serialVersionUID = 1L;\n");
 		buf.append("            private static final int x= 1;\n");
 		buf.append("            private Object y;\n");
@@ -91,9 +88,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("public class Test5 {\n");
 		buf.append("    public void test() {\n");
 		buf.append("        class X implements Serializable, Cloneable, Runnable {\n");
-		buf.append("            /**\n");
-		buf.append("             *\n");
-		buf.append("             */\n");
 		buf.append("            private static final long serialVersionUID = -4564939359985118485L;\n");
 		buf.append("            private static final int x= 1;\n");
 		buf.append("            private Object y;\n");
@@ -136,9 +130,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("    protected int var2;\n");
 		buf.append("    public void test() {\n");
 		buf.append("        Serializable var3= new Serializable() {\n");
-		buf.append("            /**\n");
-		buf.append("             *\n");
-		buf.append("             */\n");
 		buf.append("            private static final long serialVersionUID = 1L;\n");
 		buf.append("            int var4; \n");
 		buf.append("        };\n");
@@ -155,9 +146,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("    protected int var2;\n");
 		buf.append("    public void test() {\n");
 		buf.append("        Serializable var3= new Serializable() {\n");
-		buf.append("            /**\n");
-		buf.append("             *\n");
-		buf.append("             */\n");
 		buf.append("            private static final long serialVersionUID = -868523843598659436L;\n");
 		buf.append("            int var4; \n");
 		buf.append("        };\n");
@@ -195,9 +183,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("    protected int var1;\n");
 		buf.append("    protected int var2;\n");
 		buf.append("    protected class Test1 implements Serializable {\n");
-		buf.append("        /**\n");
-		buf.append("         *\n");
-		buf.append("         */\n");
 		buf.append("        private static final long serialVersionUID = 1L;\n");
 		buf.append("        public long var3;\n");
 		buf.append("    }\n");
@@ -213,9 +198,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("    protected int var1;\n");
 		buf.append("    protected int var2;\n");
 		buf.append("    protected class Test1 implements Serializable {\n");
-		buf.append("        /**\n");
-		buf.append("         *\n");
-		buf.append("         */\n");
 		buf.append("        private static final long serialVersionUID = -4023230086280104302L;\n");
 		buf.append("        public long var3;\n");
 		buf.append("    }\n");
@@ -241,9 +223,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.Serializable;\n");
 		buf.append("public class Test1 implements Serializable {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = 1L;\n");
 		buf.append("    protected int var1;\n");
 		buf.append("    protected int var2;\n");
@@ -254,9 +233,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test1;\n");
 		buf.append("import java.io.Serializable;\n");
 		buf.append("public class Test1 implements Serializable {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = -2242798150684569765L;\n");
 		buf.append("    protected int var1;\n");
 		buf.append("    protected int var2;\n");
@@ -293,9 +269,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test3;\n");
 		buf.append("import java.util.EventObject;\n");
 		buf.append("public class Test4 extends EventObject {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = 1L;\n");
 		buf.append("    private static final int x;\n");
 		buf.append("    private static Class[] a2;\n");
@@ -317,9 +290,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package test3;\n");
 		buf.append("import java.util.EventObject;\n");
 		buf.append("public class Test4 extends EventObject {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = -7476608308201363525L;\n");
 		buf.append("    private static final int x;\n");
 		buf.append("    private static Class[] a2;\n");
@@ -358,9 +328,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package a.b.c;\n");
 		buf.append("import java.io.Serializable;\n");
 		buf.append("public class Test1 implements Serializable {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = 1L;\n");
 		buf.append("    protected int var1;\n");
 		buf.append("    class Test1Inner {}\n");
@@ -371,9 +338,6 @@ public class SerialVersionQuickFixTest extends AbstractQuickFixTest {
 		buf.append("package a.b.c;\n");
 		buf.append("import java.io.Serializable;\n");
 		buf.append("public class Test1 implements Serializable {\n");
-		buf.append("    /**\n");
-		buf.append("     *\n");
-		buf.append("     */\n");
 		buf.append("    private static final long serialVersionUID = -3715240305486851194L;\n");
 		buf.append("    protected int var1;\n");
 		buf.append("    class Test1Inner {}\n");


### PR DESCRIPTION
Fixes #1899 

Related eclipse bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=576482
I have had to disable the lombok agent because of failing some tests. See https://github.com/eclipse/eclipse.jdt.ls/issues/1782
You can reproduce it using the following command:
```
./mvnw clean verify -Djdt.ls.lombok.enabled=true
```
I think the issue in lombok is caused by http://git.eclipse.org/c/jdt/eclipse.jdt.ui.git/commit/?id=64a3b5b9cfb663e786ba9a9ad3f8deddc3c85ea2 (https://bugs.eclipse.org/bugs/show_bug.cgi?id=5753300)
I can't reproduce it in VS Code because ClientPreferences.isResolveCodeActionSupported() returns true (it is false in the tests)

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>