### PR TITLE
Send $/progress Notifications

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.handlers.LogHandler;
 import org.eclipse.jdt.ls.core.internal.lsp.ExecuteCommandProposedClient;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
@@ -162,7 +163,12 @@ public class JavaClientConnection {
 	 *            The progress report to send back to the client
 	 */
 	public void sendProgressReport(ProgressReport progressReport) {
-		client.sendProgressReport(progressReport);
+		var preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
+		if (preferenceManager.getClientPreferences().isProgressReportSupported()) {
+			client.sendProgressReport(progressReport);
+		} else {
+			client.notifyProgress(progressReport.toProgressParams());
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProgressReport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProgressReport.java
@@ -14,6 +14,12 @@ package org.eclipse.jdt.ls.core.internal;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.WorkDoneProgressBegin;
+import org.eclipse.lsp4j.WorkDoneProgressEnd;
+import org.eclipse.lsp4j.WorkDoneProgressNotification;
+import org.eclipse.lsp4j.WorkDoneProgressReport;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Progress Report sent to clients.
@@ -151,4 +157,32 @@ public class ProgressReport {
 		this.subTask = subTask;
 	}
 
+	public ProgressParams toProgressParams() {
+		WorkDoneProgressNotification notification;
+		if (complete) {
+			var endNotification = new WorkDoneProgressEnd();
+			endNotification.setMessage(task);
+
+			notification = endNotification;
+		}
+		else if(workDone > 0 && workDone < totalWork) {
+			var reportNotification = new WorkDoneProgressReport();
+			reportNotification.setMessage(task);
+			reportNotification.setPercentage((int)(((double) workDone) / totalWork * 100.0));
+
+			notification = reportNotification;
+		}
+		else {
+			var beginNotification = new WorkDoneProgressBegin();
+			beginNotification.setMessage(task);
+			beginNotification.setTitle(subTask != null ? subTask : task);
+
+			notification = beginNotification;
+		}
+
+		return new ProgressParams(
+			Either.forLeft(id),
+			Either.forLeft(notification)
+		);
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
@@ -230,7 +230,7 @@ public class ProgressReporterManager extends ProgressProvider {
 		}
 
 		protected void sendStatus() {
-			if (client == null || preferenceManager == null || preferenceManager.getClientPreferences() == null || !preferenceManager.getClientPreferences().isProgressReportSupported()) {
+			if (client == null || preferenceManager == null || preferenceManager.getClientPreferences() == null) {
 				return;
 			}
 			ProgressReport progressReport = new ProgressReport(progressId);
@@ -245,7 +245,12 @@ public class ProgressReporterManager extends ProgressProvider {
 			} else {
 				progressReport.setStatus(formatMessage(task));
 			}
-			client.sendProgressReport(progressReport);
+
+			if (preferenceManager.getClientPreferences().isProgressReportSupported()) {
+				client.sendProgressReport(progressReport);
+			} else {
+				client.notifyProgress(progressReport.toProgressParams());
+			}
 		}
 
 

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -35,7 +35,7 @@
             <repository location="https://download.eclipse.org/releases/2021-09/202109151000/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.11.0/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.12.0/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
     </locations>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.ls.core.internal.ServiceStatus;
 import org.eclipse.jdt.ls.core.internal.StatusReport;
 import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.ProgressParams;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -104,6 +105,23 @@ public class ProgressReporterManagerTest {
 		assertEquals("", report.getStatus());
 		assertEquals(job.getName(), report.getTask());
 		assertTrue(report.isComplete());
+	}
+
+	@Test
+	public void testJobReporting_WithNotifyProgress() throws InterruptedException {
+		when(clientPreferences.isProgressReportSupported()).thenReturn(false);
+		manager.setReportThrottle(275);
+		Job job = new Job("Test Job") {
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				return null;
+			}
+		};
+		IProgressMonitor monitor = manager.createMonitor(job);
+		monitor.done();
+
+		ArgumentCaptor<ProgressParams> captor = ArgumentCaptor.forClass(ProgressParams.class);
+		verify(client, times(1)).notifyProgress(captor.capture());
 	}
 
 	@Test


### PR DESCRIPTION
Along with the specific event language/progressReport eclipse.jdt.ls now sends the standard Language Server Protocol event $/progress. This enables unified handling of eclipse.jdt.ls in all IDEs. For example, the fidget plugin for Neovim can rely on these events without adding code that handles eclipse.jdt.ls' specific event. Here is an example (see bottom right corner):

![output](https://user-images.githubusercontent.com/16558417/159170098-512b4f69-dc69-49b6-a9ab-0080fc1c5051.gif)

