### PR TITLE
Adopt CompletionProposal new API to ignored types before creating certain proposals

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -440,4 +440,9 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		}
 	}
 
+	@Override
+	public boolean isIgnored(char[] fullTypeName) {
+		return fullTypeName != null && TypeFilter.isFiltered(fullTypeName);
+	}
+
 }


### PR DESCRIPTION
This is a follow-up of https://github.com/eclipse/eclipse.jdt.ls/pull/2022#issuecomment-1067465448. 
See https://bugs.eclipse.org/bugs/show_bug.cgi?id=578817 for performance data.

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>