### PR TITLE
Improve the signature help

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
@@ -1,0 +1,708 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Stack;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ConstructorInvocation;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodRef;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+
+/**
+ * The context used to resolve the signature help.
+ */
+public class SignatureHelpContext {
+	/**
+	 * The offset used to trigger the completion
+	 */
+	private int completionOffset = -1;
+
+	/**
+	 * Since there is no concrete rules about triggering completion at which
+	 * place could get the signature help. The secondary completion offset will be
+	 * be used if the <code>completionOffset</code> does not work.
+	 */
+	private int secondaryCompletionOffset = -1;
+	/**
+	 * The ranges of each arguments from the code.
+	 * Note: this is parsed from user's actual code, not the ranges of the AST arguments.
+	 */
+	private List<int[]> argumentRanges = new ArrayList<>();
+	/**
+	 * The method name used to collect the signature from the completion result
+	 */
+	private String methodName;
+
+	/**
+	 * The declaring type name of the method invocation. It's used to filter methods from
+	 * different types but with same names that provided by the completion engine.
+	 */
+	private List<String> declaringTypeNames;
+	/**
+	 * The argument nodes parsed from AST.
+	 */
+	private List<Expression> arguments;
+	/**
+	 * The parameter type names from {@link IMethod}.
+	 */
+	private String[] parameterTypes;
+	/**
+	 * The parameter type names resolved from {@link IMethodBinding}.
+	 * Since the completion engine will return different results when it comes to
+	 * generic types. For example:
+	 * <pre>
+	 *     Arrays.asList(foo);
+	 * </pre>
+	 * The signature from completion engine is <code>(T... a)</code>.
+	 * While for:
+	 * <pre>
+	 *     HashMap.put("", "");
+	 * </pre>
+	 * The signature from completion engine is <code>(String key, String value)</code>.
+	 *
+	 * So two versions of parameter types are saved here to make sure we won't miss a match.
+	 */
+	private String[] parameterTypesFromBinding;
+	/**
+	 * The method-like AST node. It might be one of the following type:
+	 *     {@link ClassInstanceCreation},
+	 *     {@link ConstructorInvocation},
+	 *     {@link SuperConstructorInvocation},
+	 *     {@link MethodInvocation},
+	 *     {@link SuperMethodInvocation},
+	 *     {@link MethodRef}.
+	 * <code>null</code> means no valid node could be found from AST.
+	 */
+	private ASTNode targetNode;
+
+	/**
+	 * Resolve the context.
+	 * @param triggerOffset the offset where signature help is triggered
+	 * @param unit compilation unit
+	 * @param monitor progress monitor
+	 * @throws JavaModelException
+	 */
+	public void resolve(int triggerOffset, ICompilationUnit unit, IProgressMonitor monitor) throws JavaModelException {
+		CompilationUnit root = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
+		if (root == null || monitor.isCanceled()) {
+			return;
+		}
+		findTargetNode(root, unit, triggerOffset);
+		resolveMethodName(this.targetNode);
+		resolveDeclaringTypeName(this.targetNode);
+		this.arguments = resolveArguments(this.targetNode);
+		resolveParameterTypes(this.targetNode);
+		guessCompletionOffset(this.targetNode, unit);
+		guessArgumentRanges(unit, this.completionOffset);
+	}
+
+	/**
+	 * Find the target method-like AST node.
+	 * @param root
+	 * @param unit
+	 * @param triggerOffset
+	 * @return an method-like AST node, or <code>null</code> if no such node is found.
+	 * @throws JavaModelException
+	 */
+	private void findTargetNode(ASTNode root, ICompilationUnit unit, int triggerOffset) throws JavaModelException {
+		if (root == null) {
+			return;
+		}
+
+		String source = unit.getSource();
+		if (source == null) {
+			return;
+		}
+
+		int searchOffset = triggerOffset;
+		while (searchOffset > 0) {
+			char cur = source.charAt(searchOffset);
+			char prev = source.charAt(searchOffset - 1);
+			// Keep decrease the offset until we meet a character, or ';' (make sure not going to
+			// the previous method expression).
+			if (Character.isWhitespace(cur) && prev != ';') {
+				searchOffset--;
+			// for case like: 'foo(bar, |)', the parsed AST node for foo() will only have one
+			// argument. If we don't decrease the offset, the AST node found will be a Block.
+			} else if (cur == ')' && (Character.isWhitespace(prev) || prev == ',')) {
+				searchOffset--;
+			} else {
+				break;
+			}
+		}
+		searchOffset = searchOffset <= 0 ? triggerOffset : searchOffset;
+
+		ASTNode node = findMethodLikeNode(root, searchOffset);
+		if (node == null) {
+			return;
+		}
+
+		this.targetNode = findEnclosingMethodNode(node, source, searchOffset);
+	}
+
+	/**
+	 * Traverse up until a method-like AST node is found.
+	 * @param root
+	 * @param offset
+	 */
+	private ASTNode findMethodLikeNode(ASTNode root, int offset) {
+		ASTNode node = NodeFinder.perform(root, offset, 0);
+		while (node != null && !(node instanceof Block)) {
+			if (isMethodLikeNode(node)) {
+				return node;
+			}
+			node = node.getParent();
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check whether the given node is one of:
+	 *     {@link ClassInstanceCreation},
+	 *     {@link ConstructorInvocation},
+	 *     {@link SuperConstructorInvocation},
+	 *     {@link MethodInvocation},
+	 *     {@link SuperMethodInvocation},
+	 *     {@link MethodRef}.
+	 *
+	 * @param node
+	 */
+	private boolean isMethodLikeNode(ASTNode node) {
+		return node instanceof MethodInvocation || node instanceof ClassInstanceCreation ||
+				node instanceof SuperConstructorInvocation || node instanceof ConstructorInvocation ||
+				node instanceof SuperMethodInvocation || node instanceof MethodRef;
+	}
+
+	/**
+	 * Find the method-like node which encloses the offset.
+	 * When there are multiple valid node enclosing the offset, the inner-most one
+	 * will return only when the offset is in its arguments. For example:
+	 *
+	 * <pre>
+	 *     System.out.println(new String(""|))
+	 * </pre>
+	 * 
+	 * In the above case, the inner class instance creation node will return.
+	 *
+	 *  <pre>
+	 *     System.out.println(new |String(""))
+	 * </pre>
+	 * 
+	 * In the above case, the outer method invocation node will return.
+	 *
+	 * @param node method-like AST node
+	 * @param source source code
+	 * @param offset offset
+	 */
+	private ASTNode findEnclosingMethodNode(ASTNode node, String source, int offset) {
+		if (isInArgumentList(node, source, offset)) {
+			return node;
+		}
+
+		for (ASTNode parent = node.getParent(); parent != null && !(parent instanceof Block);
+				parent = parent.getParent()) {
+			if (!isMethodLikeNode(parent)) {
+				continue;
+			}
+
+			if (isInArgumentList(parent, source, offset)) {
+				return parent;
+			}
+		}
+
+		return node;
+	}
+
+	/**
+	 * Check whether the offset is enclosed in the input node arguments.
+	 * @param node method-like AST node
+	 * @param source source code
+	 * @param offset offset
+	 */
+	private boolean isInArgumentList(ASTNode node, String source, int offset) {
+		int[] argumentRange = findArgumentRange(node, source);
+		if (argumentRange == null || argumentRange.length < 2) {
+			return false;
+		}
+
+		return argumentRange[0] <= offset && argumentRange[1] >= offset;
+	}
+
+	/**
+	 * Find the argument range of the method-like node. The range will not include the
+	 * start and end brackets.
+	 * @param node
+	 * @param source
+	 * @return an int array with length 2, where the first element denotes the start offset
+	 *         and the second element denotes the end offset.
+	 */
+	private int[] findArgumentRange(ASTNode node, String source) {
+		List<Expression> arguments = resolveArguments(node);
+		if (arguments == null) {
+			return null;
+		}
+
+		if (arguments.size() > 0) {
+			Expression firstArg = arguments.get(0);
+			Expression lastArg = arguments.get(arguments.size() - 1);
+			return new int[]{ firstArg.getStartPosition(), lastArg.getStartPosition() + lastArg.getLength() };
+		} else {
+			ASTNode simpleNameNode = null;
+			if (node instanceof MethodInvocation) {
+				simpleNameNode = ((MethodInvocation) node).getName();
+			} else if (node instanceof ClassInstanceCreation) {
+				simpleNameNode = ((ClassInstanceCreation) node).getType();
+			} else if (node instanceof SuperMethodInvocation) {
+				simpleNameNode = ((SuperMethodInvocation) node).getName();
+			} else if (node instanceof MethodRef) {
+				simpleNameNode = ((MethodRef) node).getName();
+			} else if (node instanceof ConstructorInvocation) {
+				simpleNameNode = node;
+			} else if (node instanceof SuperConstructorInvocation) {
+				simpleNameNode = node;
+			}
+	
+			if (simpleNameNode == null) {
+				return null;
+			}
+			int i = simpleNameNode.getStartPosition() + simpleNameNode.getLength();
+			while (i < node.getStartPosition() + node.getLength()) {
+				if (source.charAt(i) == '(') {
+					return new int[]{ i + 1, node.getStartPosition() + node.getLength() - 1 };
+				}
+				i++;
+			}
+			return null;
+		}
+	}
+
+	/**
+	 * Get the method name string of the input method-like node.
+	 * @param node
+	 */
+	private void resolveMethodName(ASTNode node) {
+		if (node == null) {
+			return;
+		}
+
+		if (node instanceof MethodInvocation) {
+			this.methodName = ((MethodInvocation) node).getName().getIdentifier();
+		} else if (node instanceof ClassInstanceCreation) {
+			ITypeBinding binding = ((ClassInstanceCreation) node).getType().resolveBinding();
+			if (binding != null) {
+				this.methodName = binding.getName();
+			}
+		} else if (node instanceof SuperMethodInvocation) {
+			this.methodName = ((SuperMethodInvocation) node).getName().getIdentifier();
+		} else if (node instanceof MethodRef) {
+			this.methodName = ((MethodRef) node).getName().getIdentifier();
+		} else if (node instanceof ConstructorInvocation) {
+			IMethodBinding binding = ((ConstructorInvocation) node).resolveConstructorBinding();
+			if (binding != null) {
+				this.methodName = binding.getDeclaringClass().getName();
+			}
+		} else if (node instanceof SuperConstructorInvocation) {
+			IMethodBinding binding = ((SuperConstructorInvocation) node).resolveConstructorBinding();
+			if (binding != null) {
+				this.methodName = binding.getDeclaringClass().getName();
+			}
+		}
+	}
+
+	/**
+	 * Get the declaring type names of the method-like node. Following names will be added:
+	 *   <ul>
+	 *     <li> The declaring type</li>
+	 *     <li> All the super types</li>
+	 *     <li> All the interfaces</li>
+	 *   </ul>
+	 *
+	 * @param node
+	 */
+	private void resolveDeclaringTypeName(ASTNode node) {
+		if (node == null) {
+			return;
+		}
+
+		IMethodBinding methodBinding = null;
+		if (node instanceof MethodInvocation) {
+			methodBinding = ((MethodInvocation) node).resolveMethodBinding();
+		} else if (node instanceof ClassInstanceCreation) {
+			methodBinding = ((ClassInstanceCreation) node).resolveConstructorBinding();
+		} else if (node instanceof SuperMethodInvocation) {
+			methodBinding = ((SuperMethodInvocation) node).resolveMethodBinding();
+		} else if (node instanceof SuperConstructorInvocation) {
+			methodBinding = ((SuperConstructorInvocation) node).resolveConstructorBinding();
+		} else if (node instanceof ConstructorInvocation) {
+			methodBinding = ((ConstructorInvocation) node).resolveConstructorBinding();
+		}
+
+		if (methodBinding != null) {
+			ITypeBinding declaringType = methodBinding.getDeclaringClass();
+			List<String> typeNames = new ArrayList<>();
+			for (ITypeBinding mInterface : declaringType.getInterfaces()) {
+				String unqualifiedName = mInterface.getName().replaceAll("<.*>", "").replace(";", "");
+				typeNames.add(unqualifiedName);
+			}
+			while (declaringType != null) {
+				String unqualifiedName = declaringType.getName().replaceAll("<.*>", "").replace(";", "");
+				typeNames.add(unqualifiedName);
+				declaringType = declaringType.getSuperclass();
+			}
+			this.declaringTypeNames = typeNames;
+		}
+	}
+
+	/**
+	 * Get the argument list of the input method-like node.
+	 * @param node
+	 */
+	private List<Expression> resolveArguments(ASTNode node) {
+		if (node == null) {
+			return null;
+		}
+
+		if (node instanceof MethodInvocation) {
+			return ((MethodInvocation) node).arguments();
+		} else if (node instanceof ClassInstanceCreation) {
+			return ((ClassInstanceCreation) node).arguments();
+		} else if (node instanceof SuperMethodInvocation) {
+			return ((SuperMethodInvocation) node).arguments();
+		} else if (node instanceof MethodRef) {
+			return ((MethodRef) node).parameters();
+		} else if (node instanceof SuperConstructorInvocation) {
+			return ((SuperConstructorInvocation) node).arguments();
+		} else if (node instanceof ConstructorInvocation) {
+			return ((ConstructorInvocation) node).arguments();
+		}
+
+		return null;
+	}
+
+	/**
+	 * The signatures of the argument types resolved from the method binding.
+	 * @param node
+	 */
+	private void resolveParameterTypes(ASTNode node) {
+		if (node == null) {
+			return;
+		}
+
+		IBinding binding = null;
+		if (node instanceof MethodInvocation) {
+			binding = ((MethodInvocation) node).resolveMethodBinding();
+		} else if (node instanceof ClassInstanceCreation) {
+			binding = ((ClassInstanceCreation) node).resolveConstructorBinding();
+		} else if (node instanceof SuperMethodInvocation) {
+			binding = ((SuperMethodInvocation) node).resolveMethodBinding();
+		} else if (node instanceof MethodRef) {
+			binding = ((MethodRef) node).resolveBinding();
+		} else if (node instanceof SuperConstructorInvocation) {
+			binding = ((SuperConstructorInvocation) node).resolveConstructorBinding();
+		} else if (node instanceof ConstructorInvocation) {
+			binding = ((ConstructorInvocation) node).resolveConstructorBinding();
+		}
+
+		if (binding == null) {
+			return;
+		}
+
+		if (binding instanceof IMethodBinding) {
+			IMethodBinding methodBinding = ((IMethodBinding) binding);
+			if (methodBinding.isDefaultConstructor()) {
+				// default constructor won't have IJavaElement
+				this.parameterTypes = new String[0];
+				return;
+			}
+
+			this.parameterTypesFromBinding = Arrays.stream(methodBinding.getParameterTypes()).map(type -> {
+				String unqualifiedName = type.getName();
+				return unqualifiedName.replaceAll("<.*>", "").replace(";", "");
+			}).toArray(String[]::new);
+		}
+
+		IMethod method = (IMethod) binding.getJavaElement();
+		if (method != null) {
+			this.parameterTypes = Arrays.stream(method.getParameterTypes()).map(signature -> {
+				return SignatureHelpUtils.getSimpleTypeName(signature);
+			}).toArray(String[]::new);
+		}
+	}
+
+	/**
+	 * Guess the offset to trigger the completion.
+	 * @param node
+	 * @param unit
+	 * @throws JavaModelException
+	 */
+	private void guessCompletionOffset(ASTNode node, ICompilationUnit unit) throws JavaModelException {
+		IBuffer buffer = unit.getBuffer();
+		if (node == null || buffer == null) {
+			this.completionOffset = -1;
+			return;
+		}
+
+		int startPosition = node.getStartPosition();
+		int endPosition = startPosition + node.getLength();
+		startPosition += getOptionalExpressionLength(node);
+		for (int i = startPosition; i < endPosition; i++) {
+			if (buffer.getChar(i) == '(') {
+				// sometimes completion results from completion engine is not stable/predictable, so
+				// we have a secondary choice here (outside bracket and inside bracket).
+				if (node instanceof MethodInvocation || node instanceof SuperMethodInvocation || node instanceof MethodRef) {
+					this.completionOffset = i;
+					this.secondaryCompletionOffset = i + 1;
+					return;
+				} else if (node instanceof ClassInstanceCreation || node instanceof ConstructorInvocation ||
+						node instanceof SuperConstructorInvocation) {
+					this.completionOffset = i + 1;
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	 * The optional expression length. It's used to remove the prior method node when
+	 * it's a invocation chian. For example:
+	 *
+	 * <pre>
+	 *     assertThat(foo).isEqualTo(|);
+	 * </pre>
+	 *
+	 * In this case <code>assertThat(foo)</code> need to be excluded to get an accurate
+	 * argument range.
+	 * @param node
+	 */
+	private int getOptionalExpressionLength(ASTNode node) {
+		Expression optionalExpression = null;
+		if (node instanceof MethodInvocation) {
+			optionalExpression = ((MethodInvocation) node).getExpression();
+		} else if (node instanceof ClassInstanceCreation) {
+			optionalExpression = ((ClassInstanceCreation) node).getExpression();
+		} else if (node instanceof SuperConstructorInvocation) {
+			optionalExpression = ((SuperConstructorInvocation) node).getExpression();
+		}
+		if (optionalExpression == null) {
+			return 0;
+		}
+
+		return optionalExpression.getLength();
+	}
+
+	/**
+	 * Guess the argument ranges according to the actual code.
+	 * @param unit
+	 * @param completionOffset
+	 * @throws JavaModelException
+	 */
+	private void guessArgumentRanges(ICompilationUnit unit, int completionOffset) throws JavaModelException {
+		IBuffer buffer = unit.getBuffer();
+		if (buffer == null || completionOffset == -1) {
+			return;
+		}
+
+		int argumentStartPosition = completionOffset;
+		// Make sure we will start inside argument left bracket.
+		if (buffer.getChar(argumentStartPosition) == '(') {
+			argumentStartPosition++;
+		}
+
+		String argumentLiterals = buffer.getText(argumentStartPosition, buffer.getLength() - argumentStartPosition);
+		List<int[]> list = new ArrayList<>();
+		int[] argumentRange = new int[]{argumentStartPosition, argumentStartPosition};
+		Stack<Character> stack = new Stack<>();
+		boolean hasArgument = false;
+		for (int i = 0; i < argumentLiterals.length(); i++) {
+			char c = argumentLiterals.charAt(i);
+			if (!hasArgument && isArgumentChar(c)) {
+				hasArgument = true;
+			}
+			switch (c) {
+				case ',':
+					if (stack.isEmpty()) {
+						argumentRange[1] = argumentStartPosition + i;
+						list.add(argumentRange);
+						argumentRange = new int[]{argumentStartPosition + i + 1, argumentStartPosition + i + 1};
+					}
+					break;
+				case '\'':
+					i++;
+					while (i < argumentLiterals.length()) {
+						c = argumentLiterals.charAt(i);
+						if (c == '\'') {
+							break;
+						} else if (c == '\\') {
+							i += 2;
+						} else {
+							i++;
+						}
+					}
+					break;
+				case '"':
+					String textBlockStart = argumentLiterals.substring(i, i + 3);
+					// ignore all the characters in text block
+					if (textBlockStart.equals("\"\"\"")) {
+						int endIndex = argumentLiterals.indexOf("\"\"\"", i + 3);
+						// in case we have \""" inside a text block
+						while (endIndex > 0 && argumentLiterals.charAt(endIndex - 1) == '\\') {
+							endIndex = argumentLiterals.indexOf("\"\"\"", endIndex + 3);
+						}
+						if (endIndex > 0) {
+							i = endIndex + 2;
+						} else {
+							i = argumentLiterals.length() - 1;
+						}
+					} else {
+						i++;
+						while (i < argumentLiterals.length()) {
+							c = argumentLiterals.charAt(i);
+							if (c == '"') {
+								break;
+							} else if (c == '\\') {
+								i += 2;
+							} else {
+								i++;
+							}
+						}
+					}
+					break;
+				case '(':
+					stack.add(c);
+					break;
+				case ')':
+					if (!stack.isEmpty() && stack.peek() == '(') {
+						stack.pop();
+					} else {
+						if (hasArgument) {
+							argumentRange[1] = argumentStartPosition + i;
+							list.add(argumentRange);
+						}
+						this.argumentRanges = list;
+						return;
+					}
+					break;
+				case '[':
+					stack.add(c);
+					break;
+				case ']':
+					if (!stack.isEmpty() && stack.peek() == '[') {
+						stack.pop();
+					} else {
+						if (hasArgument) {
+							argumentRange[1] = argumentStartPosition + i;
+							list.add(argumentRange);
+						}
+						this.argumentRanges = list;
+						return;
+					}
+					break;
+				case '{':
+					stack.add(c);
+					break;
+				case '}':
+					if (!stack.isEmpty() && stack.peek() == '{') {
+						stack.pop();
+					} else {
+						if (hasArgument) {
+							argumentRange[1] = argumentStartPosition + i;
+							list.add(argumentRange);
+						}
+						this.argumentRanges = list;
+						return;
+					}
+					break;
+				case '<':
+					i++;
+					while (i < argumentLiterals.length()) {
+						c = argumentLiterals.charAt(i);
+						if (c == '>') {
+							break;
+						}
+						i++;
+					}
+					break;
+				default:
+					break;
+			}
+		}
+		if (hasArgument) {
+			argumentRange[1] = argumentStartPosition + argumentLiterals.length() - 1;
+			list.add(argumentRange);
+		}
+		this.argumentRanges = list;
+	}
+
+	private boolean isArgumentChar(char c) {
+		return !Character.isWhitespace(c) &&
+			c != ')' && c != ']' && c != '}' & c != ';';
+	}
+
+	public int completionOffset() {
+		return completionOffset;
+	}
+
+	public int secondaryCompletionOffset() {
+		return secondaryCompletionOffset;
+	}
+
+	public List<int[]> argumentRanges() {
+		return argumentRanges;
+	}
+
+	public String methodName() {
+		return methodName;
+	}
+
+	public List<String> declaringTypeNames() {
+		return declaringTypeNames;
+	}
+
+	public List<Expression> arguments() {
+		return arguments;
+	}
+
+	public String[] parameterTypes() {
+		return parameterTypes;
+	}
+
+	public String[] parameterTypesFromBinding() {
+		return parameterTypesFromBinding;
+	}
+
+	public ASTNode targetNode() {
+		return targetNode;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpUtils.java
@@ -1,0 +1,263 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.internal.codeassist.InternalCompletionProposal;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.SignatureHelpRequestor;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureInformation;
+
+public class SignatureHelpUtils {
+	private SignatureHelpUtils() {}
+
+	/**
+	 * Try to get signature help from the AST node. According to how the user code looks like,
+	 * there is possibility that we can not get a valid AST node. In that case, <code>null</code>
+	 * will returned.
+	 * @param unit compilation unit
+	 * @param triggerOffset offset where signature help is triggered
+	 * @param monitor the progress monitor
+	 */
+	public static SignatureHelp getSignatureHelpFromASTNode(ICompilationUnit unit, int triggerOffset, IProgressMonitor monitor) {
+		try {
+			SignatureHelpContext context = new SignatureHelpContext();
+			context.resolve(triggerOffset, unit, monitor);
+			if (context.targetNode() == null) {
+				return null;
+			}
+
+			SignatureHelpRequestor collector = new SignatureHelpRequestor(unit, context.methodName(), context.declaringTypeNames());
+			SignatureHelp help = new SignatureHelp();
+			unit.codeComplete(context.completionOffset(), collector, monitor);
+			help = collector.getSignatureHelp(monitor);
+			if (help.getSignatures().isEmpty() && context.secondaryCompletionOffset() > -1) {
+				unit.codeComplete(context.secondaryCompletionOffset(), collector, monitor);
+				help = collector.getSignatureHelp(monitor);
+			}
+			if (help.getSignatures().isEmpty() && (context.targetNode() instanceof ClassInstanceCreation)) {
+				fix2097(help, context.targetNode(), collector, context.completionOffset());
+			}
+			List<SignatureInformation> infos = help.getSignatures();
+			if (infos.isEmpty()) {
+				return help;
+			}
+			for (int i = 0; i < infos.size(); i++) {
+				SignatureInformation signatureInformation = infos.get(i);
+				CompletionProposal proposal = collector.getInfoProposals().get(signatureInformation);
+				boolean isMatched = isMatched(proposal, signatureInformation, context);
+				if (isMatched) {
+					help.setActiveSignature(i);
+					int activeParameter = getActiveParameter(triggerOffset, proposal , context);
+					help.setActiveParameter(activeParameter);
+					break;
+				}
+			}
+			return help;
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.logException(e);
+		}
+		return null;
+	}
+
+	/**
+	 * Check if the completion proposal matches the user's actual code.
+	 * @param proposal
+	 * @param information
+	 * @param context
+	 */
+	private static boolean isMatched(CompletionProposal proposal, SignatureInformation information, SignatureHelpContext context) {
+		boolean isVarargs = Flags.isVarargs(proposal.getFlags());
+		if (information.getParameters().size() < context.argumentRanges().size() && !isVarargs) {
+			return false;
+		}
+		String[] parameterTypes = Signature.getParameterTypes(String.valueOf(proposal.getSignature()));
+		
+		// since the signature information are sorted by the parameter numbers, if the user's code does not
+		// contain argument right now, we can say this is a match.
+		if (context.arguments().size() == 0) {
+			return true;
+		}
+
+		int paramNum = 0;
+		if (context.parameterTypes() != null) {
+			paramNum = context.parameterTypes().length;
+		} else if (context.parameterTypesFromBinding() != null) {
+			paramNum = context.parameterTypesFromBinding().length;
+		}
+		int matchedNumber = 0;
+		int startIndex = 0;
+		for (int i = 0; i < context.arguments().size() && i < paramNum; i++) {
+			int j = startIndex;
+			// find out the current resolved argument belongs to which parameter. For example, a code written as
+			// 'foo(, bar)' will only contains one argument from the AST, but the variable 'bar' should be compared
+			// with the second parameter.
+			for (; j < context.argumentRanges().size(); j++) {
+				int startPosition = context.arguments().get(i).getStartPosition();
+				if (startPosition >= context.argumentRanges().get(j)[0] && startPosition <= context.argumentRanges().get(j)[1]) {
+					startIndex = j + 1;
+					break;
+				}
+			}
+
+			if (j >= parameterTypes.length) {
+				break;
+			}
+
+			String proposedTypeSimpleName = getSimpleTypeName(parameterTypes[j]);
+			if (context.parameterTypes() != null) {
+				if (Objects.equals(proposedTypeSimpleName, context.parameterTypes()[i])) {
+					matchedNumber++;
+					continue;
+				}
+			}
+
+			if (context.parameterTypesFromBinding() != null) {
+				if (Objects.equals(proposedTypeSimpleName, context.parameterTypesFromBinding()[i])) {
+					matchedNumber++;
+					continue;
+				}
+			}
+		}
+		// if the matched number equals to the resolved parameters, then we say this is a match signature.
+		return matchedNumber == Math.min(paramNum, context.arguments().size());
+	}
+
+	/**
+	 * Try to find the active parameter index from the input signature.
+	 * @param triggerOffset offset where the signature help is triggered
+	 * @param proposal completion proposal
+	 * @param context signature help context
+	 */
+	private static int getActiveParameter(int triggerOffset, CompletionProposal proposal, SignatureHelpContext context) {
+		if (triggerOffset >= context.completionOffset()) {
+			boolean isVarargs = Flags.isVarargs(proposal.getFlags());
+			String[] parameterTypes = Signature.getParameterTypes(String.valueOf(proposal.getSignature()));
+			// when no argument is written yet but the method has at least one parameter,
+			// return 0 as the active parameter index.
+			if (parameterTypes.length > 0 && context.argumentRanges().size() == 0) {
+				return 0;
+			}
+			for (int i = 0; i < context.argumentRanges().size(); i++) {
+				int[] range = context.argumentRanges().get(i);
+				if (range[0] <= triggerOffset && range[1] >= triggerOffset) {
+					if (i >= parameterTypes.length && isVarargs) {
+						return parameterTypes.length - 1;
+					}
+					return i;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	/**
+	 * Return the simple type name of the given type signature, which the generic
+	 * type information will be removed if it has.
+	 * @param signature the signature string.
+	 */
+	public static String getSimpleTypeName(String signature) {
+		String res = Signature.getSimpleName(Signature.toString(signature));
+		return res.replaceAll("<.*>", "").replace(";", "");
+	}
+
+	// https://github.com/redhat-developer/vscode-java/issues/2097
+	public static void fix2097(SignatureHelp help, ASTNode node, SignatureHelpRequestor collector, int pos) throws JavaModelException {
+		IMethodBinding binding = ((ClassInstanceCreation) node).resolveConstructorBinding();
+		if (binding == null) {
+			return;
+		}
+
+		ITypeBinding typeBinding = binding.getDeclaringClass();
+		if (typeBinding.isAnonymous()) {
+			return;
+		}
+
+		if (binding.isDefaultConstructor()) {
+			InternalCompletionProposal proposal = new ConstructorProposal(CompletionProposal.METHOD_REF, pos);
+			proposal.setName(binding.getName().toCharArray());
+			String signature = "()V";
+			proposal.setSignature(signature.toCharArray());
+			proposal.setParameterNames(new char[0][]);
+			char[] result = Signature.createTypeSignature(typeBinding.getQualifiedName(), false).toCharArray();
+			proposal.setDeclarationSignature(result);
+			SignatureInformation info = collector.toSignatureInformation(proposal);
+			collector.getInfoProposals().put(info, proposal);
+			help.getSignatures().add(info);
+			return;
+		}
+
+		if (typeBinding.isRecord()) {
+			// todo: support record
+			return;
+		}
+		IType type = (IType) typeBinding.getJavaElement();
+		if (type == null) {
+			return;
+		}
+		
+		IMethod[] methods = type.getMethods();
+		List<SignatureInformation> infos = new ArrayList<>();
+		for (IMethod method : methods) {
+			try {
+				if (method.isConstructor()) {
+					InternalCompletionProposal proposal = new ConstructorProposal(CompletionProposal.METHOD_REF, pos);
+					proposal.setName(method.getElementName().toCharArray());
+					String signature = method.getSignature().replace("/", ".");
+					proposal.setSignature(signature.toCharArray());
+					char[][] parameterNames = new char[method.getParameterNames().length][];
+					for (int i = 0; i < method.getParameterNames().length; i++) {
+						parameterNames[i] = method.getParameterNames()[i].toCharArray();
+					}
+					proposal.setParameterNames(parameterNames);
+					char[] result = Signature.createTypeSignature(typeBinding.getQualifiedName(), false).toCharArray();
+					proposal.setDeclarationSignature(result);
+					SignatureInformation info = collector.toSignatureInformation(proposal);
+					infos.add(info);
+					collector.getInfoProposals().put(info, proposal);
+				}
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.logException(e.getMessage(), e);
+			}
+		}
+		infos.sort((SignatureInformation a, SignatureInformation b) -> a.getParameters().size() - b.getParameters().size());
+		help.getSignatures().addAll(infos);
+	}
+
+	static class ConstructorProposal extends InternalCompletionProposal {
+
+		public ConstructorProposal(int kind, int completionLocation) {
+			super(kind, completionLocation);
+			setIsContructor(true);
+		}
+	}
+}


### PR DESCRIPTION
fix #2025

The PR works in the following steps:
1. Check if we can find a method-like node with the trigger offset, which might be: `ClassInstanceCreation`, `ConstructorInvocation`, `SuperConstructorInvocation`, `MethodInvocation`, `SuperMethodInvocation` and `MethodRef`.
   - If no method-like node is found, fallback to the [previous implementation](https://github.com/eclipse/eclipse.jdt.ls/blob/4dd3f74d3883586bbf10d29b218633efe9bee7a2/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandler.java#L80).
   - If a method-like node, we leverage that node to provide more context, especially range information to provide signature help (newly added code in `SignatureHelpUtils.java`)

It fixes the following cases:

#### 1. Can trigger at the method name (as a feature to quickly peek all the overrides of a method)
![sig1](https://user-images.githubusercontent.com/6193897/160543842-a8d4bec0-e553-4d02-b57a-cfa274784561.gif)

#### 2. Strings containing `()` and `,`
![sig2](https://user-images.githubusercontent.com/6193897/160543988-3debd33e-a2dc-475f-b708-d8ba2c310ddc.gif)

#### 3. varargs method
![sig3](https://user-images.githubusercontent.com/6193897/160544024-650e1d87-4c35-4159-9d70-a0cdfcb8e8fb.gif)

#### 4. complex arguments
![sig4](https://user-images.githubusercontent.com/6193897/160544050-70f31a4a-1e6f-4b0b-9321-f0649a074ff1.gif)

#### 5. default constructor
![sig5](https://user-images.githubusercontent.com/6193897/160544106-3d7199fa-c640-403c-a66b-40d7b7f5f999.gif)

#### 6. consturutor invocation
![sig6](https://user-images.githubusercontent.com/6193897/160544090-c689b2f9-e8f1-4c4d-9d42-7c265e0a2516.gif)

#### 7. super constructor invocation
![sig7](https://user-images.githubusercontent.com/6193897/160544192-c4586798-6d01-4666-b53c-50c2975248f6.gif)

#### 8. super method invocation
![sig8](https://user-images.githubusercontent.com/6193897/160544224-64a45284-ad50-48b0-9b57-01c66919e99c.gif)

#### 9. diamond signs
![diamond-sign](https://user-images.githubusercontent.com/6193897/161920639-17ac7bc8-71f2-4269-9941-2ecd79df3531.gif)


Signed-off-by: sheche <sheche@microsoft.com>