### PR TITLE
Fix the inlay hint for varargs methods

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintVisitor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintVisitor.java
@@ -158,12 +158,13 @@ class InlayHintVisitor extends ASTVisitor {
 
 		// not showing the inlay hints when arguments are incomplete,
 		// this is to avoid hint flickering
-		if (arguments.size() < parameterNames.length) {
+		if (!methodBinding.isVarargs() && arguments.size() != parameterNames.length) {
 			return;
 		}
 
 		try {
-			for (int i = 0; i < parameterNames.length; i++) {
+			int paramNum = Math.min(parameterNames.length, arguments.size());
+			for (int i = 0; i < paramNum; i++) {
 				Expression arg = arguments.get(i);
 				if (!acceptArgument(arg, parameterNames[i])) {
 					continue;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintHandlerTest.java
@@ -281,6 +281,28 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testVarargs2() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(Integer i, String... args) {}\n" +
+			"	void bar() {\n" +
+			"		foo(1);\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertEquals(1, inlayHints.size());
+		assertEquals("i:", inlayHints.get(0).getLabel().getLeft());
+	}
+
+	@Test
 	public void testNoInlayHintsWhenNamesAreEqual() throws JavaModelException {
 		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
 		ICompilationUnit unit = getWorkingCopy(


### PR DESCRIPTION
- When a method is a varargs method like: 'foo(Integer i, String... s)',
  and be invoked by 'foo(1)'. We should show inlay hint for this case.

Signed-off-by: sheche <sheche@microsoft.com>