### PR TITLE
Provide file & type comments for newly created compilation units

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/NewCUProposal.java
@@ -358,12 +358,11 @@ public class NewCUProposal extends ChangeCorrectionProposal {
 		return cuChange;
 	}
 
-	// fileComment/typeComment not enabled.
 	private String constructCUContent(ICompilationUnit cu, String typeContent, String lineDelimiter) throws CoreException {
-		//		String fileComment = getFileComment(cu, lineDelimiter);
-		//		String typeComment = getTypeComment(cu, lineDelimiter);
+		String fileComment = CodeGeneration.getFileComment(cu, lineDelimiter);
+		String typeComment = CodeGeneration.getTypeComment(cu, cu.getElementName(), lineDelimiter);
 		IPackageFragment pack = (IPackageFragment) cu.getParent();
-		String content = CodeGeneration.getCompilationUnitContent(cu, null/*fileComment*/, null/*typeComment*/, typeContent, lineDelimiter);
+		String content = CodeGeneration.getCompilationUnitContent(cu, fileComment, typeComment, typeContent, lineDelimiter);
 		if (content != null) {
 
 			ASTParser parser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
@@ -379,9 +378,6 @@ public class NewCUProposal extends ChangeCorrectionProposal {
 			buf.append("package ").append(pack.getElementName()).append(';'); //$NON-NLS-1$
 		}
 		buf.append(lineDelimiter).append(lineDelimiter);
-		//		if (typeComment != null) {
-		//			buf.append(typeComment).append(lineDelimiter);
-		//		}
 		buf.append(typeContent);
 		return buf.toString();
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeGenerationTemplate.java
@@ -20,6 +20,12 @@ import org.eclipse.jface.text.templates.Template;
 
 public enum CodeGenerationTemplate {
 	/**
+	 * New type template
+	 */
+	NEWTYPE(CodeTemplatePreferences.CODETEMPLATE_NEWTYPE,
+			CodeTemplateContextType.NEWTYPE_CONTEXTTYPE,
+			CodeTemplatePreferences.CODETEMPLATE_NEWTYPE_DEFAULT),
+	/**
 	 * File comment template
 	 */
 	FILECOMMENT(CodeTemplatePreferences.CODETEMPLATE_FILECOMMENT, CodeTemplateContextType.FILECOMMENT_CONTEXTTYPE, ""),

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/CodeTemplatePreferences.java
@@ -26,6 +26,10 @@ public class CodeTemplatePreferences {
 	private static final String BLOCK_SUFFIX = "block"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that defines the template for new types
+	 */
+	public static final String CODETEMPLATE_NEWTYPE = CODETEMPLATES_PREFIX + "newtype";
+	/**
 	 * A named preference that defines the template for file comments
 	 */
 	public static final String CODETEMPLATE_FILECOMMENT = CODETEMPLATES_PREFIX + "file" + COMMENT_SUFFIX;
@@ -106,6 +110,10 @@ public class CodeTemplatePreferences {
 
 	public static final String RECORDSNIPPET_CONTEXTTYPE = "recordsnippet_context"; //$NON-NLS-1$
 
+	/**
+	 * Default value for new type
+	 */
+	public static final String CODETEMPLATE_NEWTYPE_DEFAULT = "${filecomment}\n${package_declaration}\n\n${typecomment}\n${type_declaration}";
 	/**
 	 * Default value for field comments
 	 */

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -129,6 +129,7 @@ public class PreferenceManager {
 		templates.put(CodeTemplatePreferences.CODETEMPLATE_SETTERBODY, CodeGenerationTemplate.SETTERBOY.createTemplate());
 		templates.put(CodeTemplatePreferences.CODETEMPLATE_CATCHBODY, CodeGenerationTemplate.CATCHBODY.createTemplate());
 		templates.put(CodeTemplatePreferences.CODETEMPLATE_METHODBODY, CodeGenerationTemplate.METHODBODY.createTemplate());
+		templates.put(CodeTemplatePreferences.CODETEMPLATE_NEWTYPE, CodeGenerationTemplate.NEWTYPE.createTemplate());
 		reloadTemplateStore();
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
@@ -484,6 +484,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test2;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public class Test {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -492,6 +496,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test2;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public interface Test {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -499,6 +507,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 
 		buf = new StringBuilder();
 		buf.append("package test2;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
 		buf.append("\n");
 		buf.append("public enum Test {\n");
 		buf.append("\n");
@@ -598,6 +610,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public class XXX {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -620,6 +636,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
 		buf.append("\n");
 		buf.append("public class XXX {\n");
 		buf.append("\n");
@@ -649,6 +669,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public interface XXX {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -670,6 +694,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public @interface Xyz {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -690,6 +718,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 
 		buf = new StringBuilder();
 		buf.append("package scratch;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
 		buf.append("\n");
 		buf.append("public @interface Unimportant {\n");
 		buf.append("\n");
@@ -908,6 +940,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
+		buf.append("\n");
 		buf.append("public class XXY<T> {\n");
 		buf.append("\n");
 		buf.append("}\n");
@@ -915,6 +951,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
 		buf.append("\n");
 		buf.append("public interface XXY<T> {\n");
 		buf.append("\n");
@@ -1463,6 +1503,10 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 
 		buf = new StringBuilder();
 		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("/**\n");
+		buf.append(" * \n");
+		buf.append(" */\n");
 		buf.append("\n");
 		buf.append("public final class F implements E {\n");
 		buf.append("\n");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManagerTest.java
@@ -165,6 +165,15 @@ public class PreferenceManagerTest {
 	}
 
 	@Test
+	public void testUpdateNewTypeTemplate() {
+		preferenceManager.initialize();
+
+		Template template = JavaManipulation.getCodeTemplateStore().findTemplateById(CodeTemplateContextType.NEWTYPE_ID);
+		assertNotNull(template);
+		assertEquals(CodeTemplatePreferences.CODETEMPLATE_NEWTYPE_DEFAULT, template.getPattern());
+	}
+
+	@Test
 	public void testInsertSpacesTabSize() {
 		preferenceManager.initialize();
 		Preferences preferences = new Preferences();


### PR DESCRIPTION
This works from the client side when creating a new file, but it never did when creating a compilation unit from a code action.

- Use the file & type comments (java.templates.typeComment &
  java.templates.fileHeader) settings from the client to construct new
  compilation units
- Initialize the "newtype" template which will use the file & type
  comment template values

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

![file_and_type_comments](https://user-images.githubusercontent.com/1417342/162090855-4297d799-f5b1-46b5-9c46-25d06fe1ca66.gif)
