### PR TITLE
Show error status when the project is not created

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.eclipse.buildship.core.internal.configuration.GradleProjectNature;
 import org.eclipse.core.resources.ICommand;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -546,28 +545,13 @@ public final class ProjectUtils {
 			if (ProjectsManager.DEFAULT_PROJECT_NAME.equals(project.getName())) {
 				continue;
 			}
-			
+
 			try {
 				maxSeverity = Math.max(maxSeverity, project.findMaxProblemSeverity(null, true, IResource.DEPTH_ZERO));
-				if (ProjectUtils.isMavenProject(project)) {
-					IFile configFile = project.getFile(MavenProjectImporter.POM_FILE);
-					if (configFile.exists()) {
-						maxSeverity = Math.max(maxSeverity, configFile.findMaxProblemSeverity(null, true, IResource.DEPTH_ZERO));
-					}
-				} else if (ProjectUtils.isGradleProject(project)) {
-					List<String> gradleConfigs = Arrays.asList(
-						GradleProjectImporter.BUILD_GRADLE_DESCRIPTOR,
-						GradleProjectImporter.BUILD_GRADLE_KTS_DESCRIPTOR,
-						GradleProjectImporter.SETTINGS_GRADLE_DESCRIPTOR,
-						GradleProjectImporter.SETTINGS_GRADLE_KTS_DESCRIPTOR
-					);
-
-					for (String fileName : gradleConfigs) {
-						IFile configFile = project.getFile(fileName);
-						if (configFile.exists()) {
-							maxSeverity = Math.max(maxSeverity, configFile.findMaxProblemSeverity(null, true, IResource.DEPTH_ZERO));
-						}
-					}
+				List<IMarker> markers = ResourceUtils.findMarkers(project, IMarker.SEVERITY_ERROR, IMarker.SEVERITY_WARNING);
+				List<IMarker> buildFileMarkers = markers.stream().filter(marker -> isBuildFileMarker(marker, project)).collect(Collectors.toList());
+				for (IMarker marker : buildFileMarkers) {
+					maxSeverity = Math.max(maxSeverity, marker.getAttribute(IMarker.SEVERITY, 0));
 				}
 			} catch (CoreException e) {
 				// ignore
@@ -579,6 +563,23 @@ public final class ProjectUtils {
 		}
 
 		return maxSeverity;
+	}
+
+	private static boolean isBuildFileMarker(IMarker marker, IProject project) {
+		IResource resource = marker.getResource();
+		if (!resource.exists()) {
+			return false;
+		}
+		String lastSegment = resource.getFullPath().lastSegment();
+		if (ProjectUtils.isMavenProject(project)) {
+			return lastSegment.equals(MavenProjectImporter.POM_FILE);
+		} else if (ProjectUtils.isGradleProject(project)) {
+			return lastSegment.equals(GradleProjectImporter.BUILD_GRADLE_DESCRIPTOR) ||
+				lastSegment.equals(GradleProjectImporter.BUILD_GRADLE_KTS_DESCRIPTOR) ||
+				lastSegment.equals(GradleProjectImporter.SETTINGS_GRADLE_DESCRIPTOR) ||
+				lastSegment.equals(GradleProjectImporter.SETTINGS_GRADLE_KTS_DESCRIPTOR);
+		}
+		return false;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -552,6 +552,9 @@ public final class ProjectUtils {
 				List<IMarker> buildFileMarkers = markers.stream().filter(marker -> isBuildFileMarker(marker, project)).collect(Collectors.toList());
 				for (IMarker marker : buildFileMarkers) {
 					maxSeverity = Math.max(maxSeverity, marker.getAttribute(IMarker.SEVERITY, 0));
+					if (maxSeverity == IMarker.SEVERITY_ERROR) {
+						break;
+					}
 				}
 			} catch (CoreException e) {
 				// ignore

--- a/org.eclipse.jdt.ls.tests/projects/gradle/invalid-subproject/invalid/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/invalid-subproject/invalid/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+	// id 'java'
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	testImplementation(platform('org.junit:junit-bom:5.7.1'))
+	testImplementation('org.junit.jupiter:junit-jupiter')
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/invalid-subproject/settings.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/invalid-subproject/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'invalid-subproject'
+include 'invalid'

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ProjectUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ProjectUtilsTest.java
@@ -61,4 +61,10 @@ public class ProjectUtilsTest extends AbstractProjectsManagerBasedTest {
 		ProjectUtils.getMaxProjectProblemSeverity();
 	}
 
+	@Test
+	public void testGetMaxProjectProblemSeverityForSubProject() throws Exception {
+		importProjects("gradle/invalid-subproject");
+		assertEquals(IMarker.SEVERITY_ERROR, ProjectUtils.getMaxProjectProblemSeverity());
+	}
+
 }


### PR DESCRIPTION
fix #2058 

In some cases when importing is failed, the buildship will not create the corresponding IProject so that `ProjectUtils.getAllProjects()` will not list all the projects in the workspace, even though some build file in those projects has markers created.

Signed-off-by: Shi Chen <chenshi@microsoft.com>