### PR TITLE
[WIP] Improve the inlay hints

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintHandlerTest.java
@@ -41,7 +41,7 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(int i) {}\n" +
+			"	void foo(int val1, int val2) {}\n" +
 			"	void bar() {\n" +
 			"		foo(123);\n" +
 			"	}\n"+
@@ -62,9 +62,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(int i) {}\n" +
+			"	void foo(int val1, int val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(123);\n" +
+			"		foo(1, 2);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -83,9 +83,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(bool b) {}\n" +
+			"	void foo(boolean val1, boolean val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(true);\n" +
+			"		foo(true, false);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -95,8 +95,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("b:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -105,9 +106,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(char c) {}\n" +
+			"	void foo(char val1, char val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo('c');\n" +
+			"		foo('c', 'c');\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -117,8 +118,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("c:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -127,9 +129,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(char c) {}\n" +
+			"	void foo(char val1, char val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(null);\n" +
+			"		foo(null, null);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -139,8 +141,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("c:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -149,9 +152,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(int i) {}\n" +
+			"	void foo(int val1, int val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(123);\n" +
+			"		foo(1, 2);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -161,8 +164,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("i:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -171,9 +175,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(String s) {}\n" +
+			"	void foo(String val1, String val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(\"s\");\n" +
+			"		foo(\"s1\", \"s2\");\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -183,8 +187,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("s:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -193,9 +198,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(Class<T> clazz) {}\n" +
+			"	void foo(Class<T> val1, Class<T> val2) {}\n" +
 			"	void bar() {\n" +
-			"		foo(Foo.class);\n" +
+			"		foo(Foo.class, Foo.class);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -205,8 +210,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("clazz:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -215,10 +221,10 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(Double d) {}\n" +
+			"	void foo(Double val1, Double val2) {}\n" +
 			"	void bar() {\n" +
 			"		Double d = 0.0;\n" +
-			"		foo(d);\n" +
+			"		foo(d, d);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -237,13 +243,12 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(Double doubleParam) {}\n" +
+			"	void foo(Double doubleParam, Integer intParam) {}\n" +
 			"	void foo(Integer intParam) {}\n" +
 			"	void bar() {\n" +
 			"		Double d = 0.0;\n" +
 			"		Integer i = 0;\n" +
-			"		foo(d);\n" +
-			"		foo(i);\n" +
+			"		foo(d, i);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -286,7 +291,7 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(Integer i, String... args) {}\n" +
+			"	void foo(Integer val, String... args) {}\n" +
 			"	void bar() {\n" +
 			"		foo(1);\n" +
 			"	}\n"+
@@ -298,8 +303,51 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("i:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(0, inlayHints.size());
+	}
+
+	@Test
+	public void testVarargs3() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(String... args) {}\n" +
+			"	void bar() {\n" +
+			"		foo(\"1\");\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertEquals(0, inlayHints.size());
+	}
+
+	@Test
+	public void testVarargs4() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(Integer val, String... args) {}\n" +
+			"	void bar() {\n" +
+			"		foo(1, \"a\");\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertEquals(2, inlayHints.size());
+		assertEquals("val:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("...args:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -308,10 +356,10 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(Double d) {}\n" +
+			"	void foo(Double val) {}\n" +
 			"	void bar() {\n" +
-			"		Double d = 0.0;\n" +
-			"		foo(d);\n" +
+			"		Double val = 0.0;\n" +
+			"		foo(val);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -352,9 +400,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	Foo(String foo) {}\n" +
+			"	Foo(String foo, String bar) {}\n" +
 			"	void bar() {\n" +
-			"		Foo foo = new Foo(\"foo\");\n" +
+			"		Foo foo = new Foo(\"foo\", \"bar\");\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -364,8 +412,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
+		assertEquals(2, inlayHints.size());
 		assertEquals("foo:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("bar:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -374,9 +423,9 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public enum Foo {\n" +
-			"	I(\"i\"), J(\"j\");\n" +
+			"	I(\"i\", \"j\");\n" +
 			"	String id;\n" +
-			"	Foo(String id) {\n" +
+			"	Foo(String id, String name) {\n" +
 			"		this.id = id;" +
 			"	}\n"+
 			"}\n"
@@ -389,7 +438,7 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
 		assertEquals(2, inlayHints.size());
 		assertEquals("id:", inlayHints.get(0).getLabel().getLeft());
-		assertEquals("id:", inlayHints.get(1).getLabel().getLeft());
+		assertEquals("name:", inlayHints.get(1).getLabel().getLeft());
 	}
 
 	@Test
@@ -411,19 +460,19 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testComplexExpressions() throws JavaModelException {
+	public void testComplexExpressions1() throws JavaModelException {
 		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	void foo(String s) {}\n" +
+			"	void foo(String type, Integer val) {}\n" +
 			"	void bar(int i) {\n" +
 			"		foo(switch (i) {\n" +
 			"			case 1:\n" +
 			"				yield \"foo\";\n" +
 			"			default:\n" +
 			"				yield \"unknown\"\n" +
-			"		});\n" +
+			"		}, 1);\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -433,10 +482,32 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(10, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("s:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("type:", inlayHints.get(0).getLabel().getLeft());
 		assertEquals(3, inlayHints.get(0).getPosition().getLine());
 		assertEquals(6, inlayHints.get(0).getPosition().getCharacter());
+		assertEquals("val:", inlayHints.get(1).getLabel().getLeft());
+	}
+
+	@Test
+	public void testComplexExpressions2() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.LITERALS);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(String path, String source) {}\n" +
+			"	void bar() {\n" +
+			"		foo(\"path\", \"a\" + \"b\");\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertEquals(1, inlayHints.size());
 	}
 
 	@Test
@@ -448,7 +519,7 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 			"	public Foo(Integer a) {\n" +
 			"		this(1, 2);\n" +
 			"	}\n" +
-			"	public Foo(Integer a, Integer b) {\n" +
+			"	public Foo(Integer val1, Integer val2) {\n" +
 			"	}\n"+
 			"}\n"
 		);
@@ -459,11 +530,11 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setRange(new Range(new Position(0, 0), new Position(6, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
 		assertEquals(2, inlayHints.size());
-		assertEquals("a:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
 		assertEquals(2, inlayHints.get(0).getPosition().getLine());
 		assertEquals(7, inlayHints.get(0).getPosition().getCharacter());
 
-		assertEquals("b:", inlayHints.get(1).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 		assertEquals(2, inlayHints.get(1).getPosition().getLine());
 		assertEquals(10, inlayHints.get(1).getPosition().getCharacter());
 	}
@@ -474,7 +545,7 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	public Foo(Integer a, Integer b) {}\n" +
+			"	public Foo(Integer val1, Integer val2) {}\n" +
 			"}\n" +
 			"class Bar extends Foo {\n" +
 			"	public Bar() {\n" +
@@ -489,11 +560,11 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setRange(new Range(new Position(0, 0), new Position(7, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
 		assertEquals(2, inlayHints.size());
-		assertEquals("a:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals("val1:", inlayHints.get(0).getLabel().getLeft());
 		assertEquals(5, inlayHints.get(0).getPosition().getLine());
 		assertEquals(8, inlayHints.get(0).getPosition().getCharacter());
 
-		assertEquals("b:", inlayHints.get(1).getLabel().getLeft());
+		assertEquals("val2:", inlayHints.get(1).getLabel().getLeft());
 		assertEquals(5, inlayHints.get(1).getPosition().getLine());
 		assertEquals(11, inlayHints.get(1).getPosition().getCharacter());
 	}
@@ -504,11 +575,11 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy(
 			"src/java/Foo.java",
 			"public class Foo {\n" +
-			"	public void foo(Object obj){}\n" +
+			"	public void foo(Object obj1, Object obj2){}\n" +
 			"}\n" +
 			"class Bar extends Foo {\n" +
 			"	public void bar() {\n" +
-			"		Bar.super.foo(1);\n" +
+			"		Bar.super.foo(1, 2);\n" +
 			"	}\n" +
 			"}\n"
 		);
@@ -518,9 +589,52 @@ public class InlayHintHandlerTest extends AbstractCompilationUnitBasedTest {
 		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
 		params.setRange(new Range(new Position(0, 0), new Position(7, 0)));
 		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
-		assertEquals(1, inlayHints.size());
-		assertEquals("obj:", inlayHints.get(0).getLabel().getLeft());
+		assertEquals(2, inlayHints.size());
+		assertEquals("obj1:", inlayHints.get(0).getLabel().getLeft());
 		assertEquals(5, inlayHints.get(0).getPosition().getLine());
 		assertEquals(16, inlayHints.get(0).getPosition().getCharacter());
+		assertEquals("obj2:", inlayHints.get(1).getLabel().getLeft());
+	}
+
+	@Test
+	public void testMeaninglessName() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(int x, int y) {}\n" +
+			"	void bar() {\n" +
+			"		foo(1, 2);\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertTrue(inlayHints.isEmpty());
+	}
+
+	@Test
+	public void testMethodWithOneParam() throws JavaModelException {
+		preferences.setInlayHintsParameterMode(InlayHintsParameterMode.ALL);
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n" +
+			"	void foo(int val) {}\n" +
+			"	void bar() {\n" +
+			"		foo(1);\n" +
+			"	}\n"+
+			"}\n"
+		);
+		unit.getResource().getLocationURI().toString();
+		InlayHintsHandler handler = new InlayHintsHandler(preferenceManager);
+		InlayHintParams params = new InlayHintParams();
+		params.setTextDocument(new TextDocumentIdentifier(unit.getResource().getLocationURI().toString()));
+		params.setRange(new Range(new Position(0, 0), new Position(5, 0)));
+		List<InlayHint> inlayHints = handler.inlayHint(params, new NullProgressMonitor());
+		assertTrue(inlayHints.isEmpty());
 	}
 }


### PR DESCRIPTION
- skip when parameter name's length is lower than 2.
- skip when the method only has 1 parameter.

fix https://github.com/redhat-developer/vscode-java/issues/2412

Signed-off-by: sheche <sheche@microsoft.com>