### PR TITLE
Fix NPE in isCompletionInsertReplaceSupport check

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -387,6 +387,7 @@ public class ClientPreferences {
 		return v3supported
 			&& capabilities.getTextDocument().getCompletion() != null
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem() != null
+			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getInsertReplaceSupport() != null
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getInsertReplaceSupport().booleanValue();
 	}
 


### PR DESCRIPTION
If the capability is missing there was a NullPointerException

    java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.eclipse.lsp4j.CompletionItemCapabilities.getInsertReplaceSupport()" is null
    	at org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences.isCompletionInsertReplaceSupport(ClientPreferences.java:390)
    	at org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalReplacementProvider.updateReplacement(CompletionProposalReplacementProvider.java:198)
    	at org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalReplacementProvider.updateReplacement(CompletionProposalReplacementProvider.java:120)
