### PR TITLE
Symbol search should support qualified names.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandler.java
@@ -58,13 +58,31 @@ public class WorkspaceSymbolHandler {
 		try {
 			monitor.beginTask("Searching the types...", 100);
 			IJavaSearchScope searchScope = createSearchScope(projectName, sourceOnly);
-			int typeMatchRule = SearchPattern.R_CAMELCASE_MATCH;
-			if (query.contains("*") || query.contains("?")) {
-				typeMatchRule |= SearchPattern.R_PATTERN_MATCH;
+
+			String tQuery = query.trim();
+			String qualifierName = null;
+			String typeName = tQuery;
+			int qualifierMatchRule = SearchPattern.R_PATTERN_MATCH;
+
+			int qualIndex = tQuery.lastIndexOf('.');
+			if (qualIndex != -1) {
+				qualifierName = tQuery.substring(0, qualIndex);
+				typeName = tQuery.substring(qualIndex + 1);
+				qualifierMatchRule = SearchPattern.R_CAMELCASE_MATCH;
+				if (qualifierName.contains("*") || qualifierName.contains("?")) {
+					qualifierMatchRule = SearchPattern.R_PATTERN_MATCH;
+				}
 			}
+
+			int typeMatchRule = SearchPattern.R_CAMELCASE_MATCH;
+			if (typeName.contains("*") || typeName.contains("?")) {
+				typeMatchRule = SearchPattern.R_PATTERN_MATCH;
+			}
+
+
 			PreferenceManager preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
 
-			new SearchEngine().searchAllTypeNames(null, SearchPattern.R_PATTERN_MATCH, query.trim().toCharArray(), typeMatchRule, IJavaSearchConstants.TYPE, searchScope, new TypeNameMatchRequestor() {
+			new SearchEngine().searchAllTypeNames(qualifierName == null ? null : qualifierName.toCharArray(), qualifierMatchRule, typeName.toCharArray(), typeMatchRule, IJavaSearchConstants.TYPE, searchScope, new TypeNameMatchRequestor() {
 
 				@Override
 				public void acceptTypeNameMatch(TypeNameMatch match) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -166,6 +166,28 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
+	public void testSearchQualifiedTypeNoWildcards() {
+		List<SymbolInformation> results = WorkspaceSymbolHandler.search("java.io.file", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> s.getName().startsWith("File") && "java.io".equals(s.getContainerName())));
+
+		results = WorkspaceSymbolHandler.search("java.util.array", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> s.getName().startsWith("Array") && "java.util".equals(s.getContainerName())));
+	}
+
+	@Test
+	public void testSearchQualifiedTypeWithWildcards() {
+		List<SymbolInformation> results = WorkspaceSymbolHandler.search("java.util.*list*", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> "List".equals(s.getName()) && "java.util".equals(s.getContainerName())));
+
+		results = WorkspaceSymbolHandler.search("*.lang*.*exception", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().allMatch(s -> s.getName().endsWith("Exception") && s.getContainerName().contains(".lang")));
+	}
+
+	@Test
 	public void testSearchSourceMethodDeclarations() {
 		preferences.setIncludeSourceMethodDeclarations(true);
 		List<SymbolInformation> results = WorkspaceSymbolHandler.search("deleteSomething", "hello", true, monitor);


### PR DESCRIPTION
- Fixes #2084
- Intepret everything prior to the last '.' as a package qualifier and
  everything after as the type name

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>