### PR TITLE
Add support for opening binary symbols with no source

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTUtils.java
@@ -704,6 +704,8 @@ public final class JDTUtils {
 				} else {
 					return toLocation(cf, nameRange.getOffset(), nameRange.getLength());
 				}
+			} else if (cf != null) {
+				return toLocation(cf);
 			}
 		}
 		return null;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -224,4 +224,16 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		assertTrue("Should be deprecated", deprecated.getDeprecated());
 	}
 
+	@Test
+	public void testWorkspaceSearchWithClassContentSupport() {
+		when(preferenceManager.isClientSupportsClassFileContent()).thenReturn(true);
+		//Classes will be found with jar container path.
+		List<SymbolInformation> results = WorkspaceSymbolHandler.search("Array", monitor);
+		assertNotNull(results);
+		assertNotEquals("Unexpected results", 0, results.size());
+		// sample just the first symbol
+		assertNotNull("Location is null", results.get(0).getLocation());
+		assertNotNull("Location URI is null", results.get(0).getLocation().getUri());
+		assertTrue("Wrong location URI", results.get(0).getLocation().getUri().contains("rtstubs.jar/"));
+	}
 }


### PR DESCRIPTION
As reported in #2087 when searching for workspace symbols
which doesn't have attached source, trying to open them result
in a NPE in logs. This is due to the location ending up null.

The fix fallback in this situation to find the location by using the
class file.

Signed-off-by: Gayan Perera <gayanper@gmail.com>