### PR TITLE
Resolve the constructor parameter names conditionally

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -317,6 +317,14 @@ public class Preferences {
 	public static final int JAVA_COMPLETION_MAX_RESULTS_DEFAULT = 50;
 
 	/**
+	 * Preference key for the threshold to control whether the parameter names will be resolved
+	 * in the completion list. If the number of the constructors in the completion list is larger
+	 * than the threshold, parameter names will not be resolved.
+	 */
+	public static final String JAVA_COMPLETION_CONSTRUCTORS_RESOLVE_PARAMETER_NAMES_THRESHOLD = "java.completion.constructors.resolveParameterNamesThreshold";
+	public static final int JAVA_COMPLETION_CONSTRUCTORS_RESOLVE_PARAMETER_NAMES_THRESHOLD_DEFAULT = 30;
+
+	/**
 	 * A named preference that controls if the Java code assist only inserts
 	 * completions. When set to true, code completion overwrites the current text.
 	 * When set to false, code is simply added instead.
@@ -550,6 +558,7 @@ public class Preferences {
 	private Collection<IPath> projectConfigurations;
 	private int parallelBuildsCount;
 	private int maxCompletionResults;
+	private int resolveParameterNamesThreshold;
 	private int importOnDemandThreshold;
 	private int staticImportOnDemandThreshold;
 	private Set<RuntimeEnvironment> runtimes = new HashSet<>();
@@ -985,6 +994,9 @@ public class Preferences {
 
 		int maxCompletions = getInt(configuration, JAVA_COMPLETION_MAX_RESULTS_KEY, JAVA_COMPLETION_MAX_RESULTS_DEFAULT);
 		prefs.setMaxCompletionResults(maxCompletions);
+
+		int resolveThreshold = getInt(configuration, JAVA_COMPLETION_CONSTRUCTORS_RESOLVE_PARAMETER_NAMES_THRESHOLD, JAVA_COMPLETION_CONSTRUCTORS_RESOLVE_PARAMETER_NAMES_THRESHOLD_DEFAULT);
+		prefs.setParameterNamesResolvingThreshold(resolveThreshold);
 
 		int onDemandThreshold = getInt(configuration, IMPORTS_ONDEMANDTHRESHOLD, IMPORTS_ONDEMANDTHRESHOLD_DEFAULT);
 		prefs.setImportOnDemandThreshold(onDemandThreshold);
@@ -1689,6 +1701,14 @@ public class Preferences {
 			this.maxCompletionResults = maxCompletions;
 		}
 		return this;
+	}
+
+	public int getParameterNamesResolvingThreshold() {
+		return resolveParameterNamesThreshold;
+	}
+
+	public void setParameterNamesResolvingThreshold(int threshold) {
+		this.resolveParameterNamesThreshold = threshold;
 	}
 
 	public ReferencedLibraries getReferencedLibraries() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2020 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -119,6 +119,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//		sharedASTProvider.clearASTCreationCount();
 		javaClient = new JavaClientConnection(client);
 		lifeCycleHandler = new DocumentLifeCycleHandler(javaClient, preferenceManager, projectsManager, true);
+		preferences.setParameterNamesResolvingThreshold(0);
 	}
 
 	@After
@@ -3463,6 +3464,28 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		} finally {
 			unit.discardWorkingCopy();
 		}
+	}
+
+	@Test
+	public void testCompletion_resolveParameterNamesThreshold() throws JavaModelException{
+		preferences.setParameterNamesResolvingThreshold(1);
+
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+				"	void foo() {\n"+
+				"		String s = new String;\n" +
+				"	}\n"+
+				"}\n");
+		//@formatter:on
+
+		CompletionList list = requestCompletions(unit, "new String");
+		assertNotNull(list);
+		CompletionItem ci = list.getItems().stream()
+				.filter( item-> "String(int[], int, int)".equals(item.getLabel()))
+				.findFirst().orElse(null);
+		assertNotNull(ci);
 	}
 
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {


### PR DESCRIPTION
requires, https://github.com/redhat-developer/vscode-java/pull/2482. Part of https://github.com/eclipse/eclipse.jdt.ls/issues/2011.

- Introduced 'java.completion.constructors.resolveParameterNamesThreshold'
  to control whether the parameter names should be resolved. If the
  completion proposal number is larger than the threshold, parameter
  names will not be resolved. This is for the performance consideration.

Signed-off-by: sheche <sheche@microsoft.com>

