### PR TITLE
Adjust the order of code actions

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -51,6 +51,7 @@ import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.text.correction.AssignToVariableAssistCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.NonProjectFixProcessor;
+import org.eclipse.jdt.ls.core.internal.text.correction.CodeActionComparator;
 import org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.RefactoringCorrectionCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
@@ -216,6 +217,7 @@ public class CodeActionHandler {
 			return Collections.emptyList();
 		}
 
+		codeActions.sort(new CodeActionComparator());
 		populateDataFields(codeActions);
 		return codeActions;
 	}
@@ -372,7 +374,7 @@ public class CodeActionHandler {
 
 		public CodeActionData(Object proposal) {
 			this.proposal = proposal;
-			this.priority = 0;
+			this.priority = CodeActionComparator.LOWEST_PRIORITY;
 		}
 
 		public CodeActionData(Object proposal, int priority) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CodeActionComparator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CodeActionComparator.java
@@ -14,37 +14,58 @@ package org.eclipse.jdt.ls.core.internal.text.correction;
 
 import java.util.Comparator;
 
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler.CodeActionData;
 import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-public class QuickAssistComparator implements Comparator<Either<Command, CodeAction>> {
+public class CodeActionComparator implements Comparator<Either<Command, CodeAction>> {
 
 	public static int ORGANIZE_IMPORTS_PRIORITY = 0;
-	public static int GENERATE_ACCESSORS_PRIORITY = 100;
-	public static int GENERATE_CONSTRUCTORS_PRIORITY = 200;
-	public static int GENERATE_HASHCODE_EQUALS_PRIORITY = 300;
-	public static int GENERATE_TOSTRING_PRIORITY = 400;
-	public static int GENERATE_OVERRIDE_IMPLEMENT_PRIORITY = 500;
-	public static int GENERATE_DELEGATE_METHOD_PRIORITY = 600;
-	public static int CHANGE_MODIFIER_TO_FINAL_PRIORITY = 700;
-	public static int MAX_PRIORITY = 1000;
+	public static int GENERATE_ACCESSORS_PRIORITY = 10;
+	public static int GENERATE_CONSTRUCTORS_PRIORITY = 20;
+	public static int GENERATE_HASHCODE_EQUALS_PRIORITY = 30;
+	public static int GENERATE_TOSTRING_PRIORITY = 40;
+	public static int GENERATE_OVERRIDE_IMPLEMENT_PRIORITY = 50;
+	public static int GENERATE_DELEGATE_METHOD_PRIORITY = 60;
+	public static int CHANGE_MODIFIER_TO_FINAL_PRIORITY = 70;
+	public static int LOWEST_PRIORITY = 100;
 
 	public int compare(Either<Command, CodeAction> e1, Either<Command, CodeAction> e2) {
 		if (e1.isRight() && e2.isRight()) {
-			Object data1 = e1.getRight().getData();
-			Object data2 = e2.getRight().getData();
+			CodeAction action1 = e1.getRight();
+			CodeAction action2 = e2.getRight();
+			int kindDiff = getCodeActionKindOrdinal(action1.getKind()) - getCodeActionKindOrdinal(action2.getKind());
+			if (kindDiff != 0) {
+				return kindDiff;
+			}
+			Object data1 = action1.getData();
+			Object data2 = action2.getData();
 			if (data1 instanceof CodeActionData && data2 instanceof CodeActionData) {
 				int priority1 = ((CodeActionData) data1).getPriority();
 				int priority2 = ((CodeActionData) data2).getPriority();
 				return priority1 - priority2;
 			} else if (data1 instanceof CodeActionData) {
-				return -100;
+				return 10;
 			} else if (data2 instanceof CodeActionData) {
-				return 100;
+				return -10;
 			}
 		}
 		return 0;
+	}
+
+	private int getCodeActionKindOrdinal(String kind) {
+		if (kind.equals(CodeActionKind.QuickFix)) {
+			return 0;
+		} else if (kind.startsWith(CodeActionKind.Refactor)) {
+			return 1000;
+		} else if (kind.equals(JavaCodeActionKind.QUICK_ASSIST)) {
+			return 2000;
+		} else if (kind.startsWith(CodeActionKind.Source)) {
+			return 3000;
+		}
+		return 4000;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistComparator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/QuickAssistComparator.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.text.correction;
+
+import java.util.Comparator;
+
+import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler.CodeActionData;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+public class QuickAssistComparator implements Comparator<Either<Command, CodeAction>> {
+
+	public static int ORGANIZE_IMPORTS_PRIORITY = 0;
+	public static int GENERATE_ACCESSORS_PRIORITY = 100;
+	public static int GENERATE_CONSTRUCTORS_PRIORITY = 200;
+	public static int GENERATE_HASHCODE_EQUALS_PRIORITY = 300;
+	public static int GENERATE_TOSTRING_PRIORITY = 400;
+	public static int GENERATE_OVERRIDE_IMPLEMENT_PRIORITY = 500;
+	public static int GENERATE_DELEGATE_METHOD_PRIORITY = 600;
+	public static int CHANGE_MODIFIER_TO_FINAL_PRIORITY = 700;
+	public static int MAX_PRIORITY = 1000;
+
+	public int compare(Either<Command, CodeAction> e1, Either<Command, CodeAction> e2) {
+		if (e1.isRight() && e2.isRight()) {
+			Object data1 = e1.getRight().getData();
+			Object data2 = e2.getRight().getData();
+			if (data1 instanceof CodeActionData && data2 instanceof CodeActionData) {
+				int priority1 = ((CodeActionData) data1).getPriority();
+				int priority2 = ((CodeActionData) data2).getPriority();
+				return priority1 - priority2;
+			} else if (data1 instanceof CodeActionData) {
+				return -100;
+			} else if (data2 instanceof CodeActionData) {
+				return 100;
+			}
+		}
+		return 0;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -146,12 +146,12 @@ public class SourceAssistProcessor {
 			// Generate QuickAssist
 			if (isInImportDeclaration) {
 				Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
-					JavaCodeActionKind.QUICK_ASSIST, organizeImportsProposal, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY);
+					JavaCodeActionKind.QUICK_ASSIST, organizeImportsProposal, CodeActionComparator.ORGANIZE_IMPORTS_PRIORITY);
 				addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 			}
 			// Generate Source Action
 			Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
-					CodeActionKind.SourceOrganizeImports, organizeImportsProposal, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY);
+					CodeActionKind.SourceOrganizeImports, organizeImportsProposal, CodeActionComparator.ORGANIZE_IMPORTS_PRIORITY);
 			addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 		}
 
@@ -213,12 +213,12 @@ public class SourceAssistProcessor {
 				// Generate QuickAssist
 				if (isInTypeDeclaration) {
 					Optional<Either<Command, CodeAction>> generateToStringQuickAssist = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateToStringAction_label,
-							JavaCodeActionKind.QUICK_ASSIST, generateToStringProposal, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY);
+							JavaCodeActionKind.QUICK_ASSIST, generateToStringProposal, CodeActionComparator.GENERATE_TOSTRING_PRIORITY);
 					addSourceActionCommand($, params.getContext(), generateToStringQuickAssist);
 				}
 				// Generate Source Action
 				Optional<Either<Command, CodeAction>> generateToStringCommand = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateToStringAction_label,
-						JavaCodeActionKind.SOURCE_GENERATE_TO_STRING, generateToStringProposal, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY);
+						JavaCodeActionKind.SOURCE_GENERATE_TO_STRING, generateToStringProposal, CodeActionComparator.GENERATE_TOSTRING_PRIORITY);
 				addSourceActionCommand($, params.getContext(), generateToStringCommand);
 			}
 		}
@@ -231,7 +231,6 @@ public class SourceAssistProcessor {
 		Optional<Either<Command, CodeAction>> generateFinalModifiers = addFinalModifierWherePossibleAction(context);
 		addSourceActionCommand($, params.getContext(), generateFinalModifiers);
 
-		$.sort(new QuickAssistComparator());
 		return $;
 	}
 
@@ -349,7 +348,7 @@ public class SourceAssistProcessor {
 		CodeAction codeAction = new CodeAction(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description);
 		codeAction.setKind(kind);
 		codeAction.setCommand(command);
-		codeAction.setData(new CodeActionData(null, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY));
+		codeAction.setData(new CodeActionData(null, CodeActionComparator.ORGANIZE_IMPORTS_PRIORITY));
 		codeAction.setDiagnostics(Collections.emptyList());
 		return Optional.of(Either.forRight(codeAction));
 
@@ -365,7 +364,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.OverrideMethodsAction_label);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
-			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_OVERRIDE_IMPLEMENT_PRIORITY));
+			codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_OVERRIDE_IMPLEMENT_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -400,7 +399,7 @@ public class SourceAssistProcessor {
 					TextEdit edit = operation.createTextEdit(pm, accessors);
 					return convertToWorkspaceEdit(context.getCompilationUnit(), edit);
 				};
-				return getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), actionMessage, kind, getAccessorsProposal, QuickAssistComparator.GENERATE_ACCESSORS_PRIORITY);
+				return getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), actionMessage, kind, getAccessorsProposal, CodeActionComparator.GENERATE_ACCESSORS_PRIORITY);
 			} else {
 				String actionMessage;
 				switch (accessorKind) {
@@ -422,7 +421,7 @@ public class SourceAssistProcessor {
 					CodeAction codeAction = new CodeAction(actionMessage);
 					codeAction.setKind(kind);
 					codeAction.setCommand(command);
-					codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_ACCESSORS_PRIORITY));
+					codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_ACCESSORS_PRIORITY));
 					codeAction.setDiagnostics(Collections.emptyList());
 					return Optional.of(Either.forRight(codeAction));
 				} else {
@@ -462,7 +461,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateHashCodeEqualsAction_label);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
-			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_HASHCODE_EQUALS_PRIORITY));
+			codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_HASHCODE_EQUALS_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -491,7 +490,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateToStringAction_ellipsisLabel);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
-			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY));
+			codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_TOSTRING_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -518,7 +517,7 @@ public class SourceAssistProcessor {
 					TextEdit edit = GenerateConstructorsHandler.generateConstructors(type, status.constructors, status.fields, params.getRange(), pm);
 					return convertToWorkspaceEdit(type.getCompilationUnit(), edit);
 				};
-				return getCodeActionFromProposal(params.getContext(), type.getCompilationUnit(), ActionMessages.GenerateConstructorsAction_label, kind, generateConstructorsProposal, QuickAssistComparator.GENERATE_CONSTRUCTORS_PRIORITY);
+				return getCodeActionFromProposal(params.getContext(), type.getCompilationUnit(), ActionMessages.GenerateConstructorsAction_label, kind, generateConstructorsProposal, CodeActionComparator.GENERATE_CONSTRUCTORS_PRIORITY);
 			}
 
 			Command command = new Command(ActionMessages.GenerateConstructorsAction_ellipsisLabel, COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT, Collections.singletonList(params));
@@ -526,7 +525,7 @@ public class SourceAssistProcessor {
 				CodeAction codeAction = new CodeAction(ActionMessages.GenerateConstructorsAction_ellipsisLabel);
 				codeAction.setKind(kind);
 				codeAction.setCommand(command);
-				codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_CONSTRUCTORS_PRIORITY));
+				codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_CONSTRUCTORS_PRIORITY));
 				codeAction.setDiagnostics(Collections.emptyList());
 				return Optional.of(Either.forRight(codeAction));
 			} else {
@@ -551,7 +550,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateDelegateMethodsAction_label);
 			codeAction.setKind(JavaCodeActionKind.SOURCE_GENERATE_DELEGATE_METHODS);
 			codeAction.setCommand(command);
-			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_DELEGATE_METHOD_PRIORITY));
+			codeAction.setData(new CodeActionData(null, CodeActionComparator.GENERATE_DELEGATE_METHOD_PRIORITY));
 			codeAction.setDiagnostics(Collections.EMPTY_LIST);
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -570,7 +569,7 @@ public class SourceAssistProcessor {
 		if (this.preferenceManager.getClientPreferences().isResolveCodeActionSupported()) {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateFinalModifiersAction_label);
 			codeAction.setKind(proposal.getKind());
-			codeAction.setData(new CodeActionData(proposal, QuickAssistComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
+			codeAction.setData(new CodeActionData(proposal, CodeActionComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
 			codeAction.setDiagnostics(Collections.EMPTY_LIST);
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -590,7 +589,7 @@ public class SourceAssistProcessor {
 				CodeAction codeAction = new CodeAction(ActionMessages.GenerateFinalModifiersAction_label);
 				codeAction.setKind(proposal.getKind());
 				codeAction.setCommand(command);
-				codeAction.setData(new CodeActionData(null, QuickAssistComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
+				codeAction.setData(new CodeActionData(null, CodeActionComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
 				codeAction.setDiagnostics(Collections.EMPTY_LIST);
 				return Optional.of(Either.forRight(codeAction));
 			} else {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -74,6 +74,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.LspVariableBinding;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler.CodeActionData;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateAccessorsHandler.AccessorCodeActionParams;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CodeAction;
@@ -145,12 +146,12 @@ public class SourceAssistProcessor {
 			// Generate QuickAssist
 			if (isInImportDeclaration) {
 				Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
-					JavaCodeActionKind.QUICK_ASSIST, organizeImportsProposal);
+					JavaCodeActionKind.QUICK_ASSIST, organizeImportsProposal, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY);
 				addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 			}
 			// Generate Source Action
 			Optional<Either<Command, CodeAction>> sourceOrganizeImports = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description,
-					CodeActionKind.SourceOrganizeImports, organizeImportsProposal);
+					CodeActionKind.SourceOrganizeImports, organizeImportsProposal, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY);
 			addSourceActionCommand($, params.getContext(), sourceOrganizeImports);
 		}
 
@@ -212,12 +213,12 @@ public class SourceAssistProcessor {
 				// Generate QuickAssist
 				if (isInTypeDeclaration) {
 					Optional<Either<Command, CodeAction>> generateToStringQuickAssist = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateToStringAction_label,
-							JavaCodeActionKind.QUICK_ASSIST, generateToStringProposal);
+							JavaCodeActionKind.QUICK_ASSIST, generateToStringProposal, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY);
 					addSourceActionCommand($, params.getContext(), generateToStringQuickAssist);
 				}
 				// Generate Source Action
 				Optional<Either<Command, CodeAction>> generateToStringCommand = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateToStringAction_label,
-						JavaCodeActionKind.SOURCE_GENERATE_TO_STRING, generateToStringProposal);
+						JavaCodeActionKind.SOURCE_GENERATE_TO_STRING, generateToStringProposal, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY);
 				addSourceActionCommand($, params.getContext(), generateToStringCommand);
 			}
 		}
@@ -230,6 +231,7 @@ public class SourceAssistProcessor {
 		Optional<Either<Command, CodeAction>> generateFinalModifiers = addFinalModifierWherePossibleAction(context);
 		addSourceActionCommand($, params.getContext(), generateFinalModifiers);
 
+		$.sort(new QuickAssistComparator());
 		return $;
 	}
 
@@ -347,6 +349,7 @@ public class SourceAssistProcessor {
 		CodeAction codeAction = new CodeAction(CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description);
 		codeAction.setKind(kind);
 		codeAction.setCommand(command);
+		codeAction.setData(new CodeActionData(null, QuickAssistComparator.ORGANIZE_IMPORTS_PRIORITY));
 		codeAction.setDiagnostics(Collections.emptyList());
 		return Optional.of(Either.forRight(codeAction));
 
@@ -362,6 +365,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.OverrideMethodsAction_label);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
+			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_OVERRIDE_IMPLEMENT_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -396,7 +400,7 @@ public class SourceAssistProcessor {
 					TextEdit edit = operation.createTextEdit(pm, accessors);
 					return convertToWorkspaceEdit(context.getCompilationUnit(), edit);
 				};
-				return getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), actionMessage, kind, getAccessorsProposal);
+				return getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), actionMessage, kind, getAccessorsProposal, QuickAssistComparator.GENERATE_ACCESSORS_PRIORITY);
 			} else {
 				String actionMessage;
 				switch (accessorKind) {
@@ -418,6 +422,7 @@ public class SourceAssistProcessor {
 					CodeAction codeAction = new CodeAction(actionMessage);
 					codeAction.setKind(kind);
 					codeAction.setCommand(command);
+					codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_ACCESSORS_PRIORITY));
 					codeAction.setDiagnostics(Collections.emptyList());
 					return Optional.of(Either.forRight(codeAction));
 				} else {
@@ -457,6 +462,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateHashCodeEqualsAction_label);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
+			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_HASHCODE_EQUALS_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -485,6 +491,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateToStringAction_ellipsisLabel);
 			codeAction.setKind(kind);
 			codeAction.setCommand(command);
+			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_TOSTRING_PRIORITY));
 			codeAction.setDiagnostics(Collections.emptyList());
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -511,7 +518,7 @@ public class SourceAssistProcessor {
 					TextEdit edit = GenerateConstructorsHandler.generateConstructors(type, status.constructors, status.fields, params.getRange(), pm);
 					return convertToWorkspaceEdit(type.getCompilationUnit(), edit);
 				};
-				return getCodeActionFromProposal(params.getContext(), type.getCompilationUnit(), ActionMessages.GenerateConstructorsAction_label, kind, generateConstructorsProposal);
+				return getCodeActionFromProposal(params.getContext(), type.getCompilationUnit(), ActionMessages.GenerateConstructorsAction_label, kind, generateConstructorsProposal, QuickAssistComparator.GENERATE_CONSTRUCTORS_PRIORITY);
 			}
 
 			Command command = new Command(ActionMessages.GenerateConstructorsAction_ellipsisLabel, COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT, Collections.singletonList(params));
@@ -519,6 +526,7 @@ public class SourceAssistProcessor {
 				CodeAction codeAction = new CodeAction(ActionMessages.GenerateConstructorsAction_ellipsisLabel);
 				codeAction.setKind(kind);
 				codeAction.setCommand(command);
+				codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_CONSTRUCTORS_PRIORITY));
 				codeAction.setDiagnostics(Collections.emptyList());
 				return Optional.of(Either.forRight(codeAction));
 			} else {
@@ -543,6 +551,7 @@ public class SourceAssistProcessor {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateDelegateMethodsAction_label);
 			codeAction.setKind(JavaCodeActionKind.SOURCE_GENERATE_DELEGATE_METHODS);
 			codeAction.setCommand(command);
+			codeAction.setData(new CodeActionData(null, QuickAssistComparator.GENERATE_DELEGATE_METHOD_PRIORITY));
 			codeAction.setDiagnostics(Collections.EMPTY_LIST);
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -561,7 +570,7 @@ public class SourceAssistProcessor {
 		if (this.preferenceManager.getClientPreferences().isResolveCodeActionSupported()) {
 			CodeAction codeAction = new CodeAction(ActionMessages.GenerateFinalModifiersAction_label);
 			codeAction.setKind(proposal.getKind());
-			codeAction.setData(proposal);
+			codeAction.setData(new CodeActionData(proposal, QuickAssistComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
 			codeAction.setDiagnostics(Collections.EMPTY_LIST);
 			return Optional.of(Either.forRight(codeAction));
 		} else {
@@ -581,6 +590,7 @@ public class SourceAssistProcessor {
 				CodeAction codeAction = new CodeAction(ActionMessages.GenerateFinalModifiersAction_label);
 				codeAction.setKind(proposal.getKind());
 				codeAction.setCommand(command);
+				codeAction.setData(new CodeActionData(null, QuickAssistComparator.CHANGE_MODIFIER_TO_FINAL_PRIORITY));
 				codeAction.setDiagnostics(Collections.EMPTY_LIST);
 				return Optional.of(Either.forRight(codeAction));
 			} else {
@@ -589,11 +599,11 @@ public class SourceAssistProcessor {
 		}
 	}
 
-	private Optional<Either<Command, CodeAction>> getCodeActionFromProposal(CodeActionContext context, ICompilationUnit cu, String name, String kind, CodeActionProposal proposal) {
+	private Optional<Either<Command, CodeAction>> getCodeActionFromProposal(CodeActionContext context, ICompilationUnit cu, String name, String kind, CodeActionProposal proposal, int priority) {
 		if (preferenceManager.getClientPreferences().isResolveCodeActionSupported()) {
 			CodeAction codeAction = new CodeAction(name);
 			codeAction.setKind(kind);
-			codeAction.setData(proposal);
+			codeAction.setData(new CodeActionData(proposal, priority));
 			codeAction.setDiagnostics(Collections.EMPTY_LIST);
 			return Optional.of(Either.forRight(codeAction));
 		}
@@ -609,6 +619,7 @@ public class SourceAssistProcessor {
 				CodeAction codeAction = new CodeAction(name);
 				codeAction.setKind(kind);
 				codeAction.setCommand(command);
+				codeAction.setData(new CodeActionData(null, priority));
 				codeAction.setDiagnostics(context.getDiagnostics());
 				return Optional.of(Either.forRight(codeAction));
 			} else {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambaTest.java
@@ -71,7 +71,7 @@ public class ConvertMethodReferenceToLambaTest extends AbstractQuickFixTest {
 		Range range = new Range(new Position(4, 34), new Position(4, 34));
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
 		assertEquals(2, codeActions.size());
-		Either<Command, CodeAction> codeAction = codeActions.get(1);
+		Either<Command, CodeAction> codeAction = codeActions.get(0);
 		CodeAction action = codeAction.getRight();
 		assertEquals(CodeActionKind.QuickFix, action.getKind());
 		assertEquals("Convert to lambda expression", action.getTitle());
@@ -98,7 +98,7 @@ public class ConvertMethodReferenceToLambaTest extends AbstractQuickFixTest {
 		Range range = new Range(new Position(4, 39), new Position(4, 39));
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
 		assertEquals(2, codeActions.size());
-		Either<Command, CodeAction> codeAction = codeActions.get(1);
+		Either<Command, CodeAction> codeAction = codeActions.get(0);
 		CodeAction action = codeAction.getRight();
 		assertEquals(CodeActionKind.QuickFix, action.getKind());
 		assertEquals("Convert to method reference", action.getTitle());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -603,7 +603,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 
 		Assert.assertNotNull(codeActions);
-		CodeAction action = codeActions.get(2).getRight();
+		CodeAction action = codeActions.get(1).getRight();
 		Assert.assertEquals("Add missing method 'action' to class 'Foo'", action.getTitle());
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -607,6 +607,68 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertEquals("Add missing method 'action' to class 'Foo'", action.getTitle());
 	}
 
+	@Test
+	public void testQuickAssistForImportDeclarationOrder() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"import java.util.List;\n"+
+				"public class Foo {\n"+
+				"	void foo() {\n"+
+				"		String bar = \"astring\";"+
+				"	}\n"+
+				"}\n");
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "util");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(0)).getTitle(), "Organize imports");
+	}
+
+	@Test
+	public void testQuickAssistForFieldDeclarationOrder() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	public String name = \"name\";\r\n" +
+				"	public String pet = \"pet\";\r\n" +
+				"}");
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "String name");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(0)).getTitle(), "Generate Getter and Setter for 'name'");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(1)).getTitle(), "Generate Getter for 'name'");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(2)).getTitle(), "Generate Setter for 'name'");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(3)).getTitle(), "Generate Constructors...");
+	}
+
+	@Test
+	public void testQuickAssistForTypeDeclarationOrder() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	public String name = \"name\";\r\n" +
+				"	public String pet = \"pet\";\r\n" +
+				"}");
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "A");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(0)).getTitle(), "Generate Getters and Setters...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(1)).getTitle(), "Generate Getters...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(2)).getTitle(), "Generate Setters...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(3)).getTitle(), "Generate Constructors...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(4)).getTitle(), "Generate hashCode() and equals()...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(5)).getTitle(), "Generate toString()...");
+		Assert.assertEquals(CodeActionHandlerTest.getCommand(quickAssistActions.get(6)).getTitle(), "Override/Implement Methods...");
+	}
+
 	private List<Either<Command, CodeAction>> getCodeActions(CodeActionParams params) {
 		return server.codeAction(params).join();
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
@@ -100,7 +100,7 @@ public class GenerateConstructorsActionTest extends AbstractCompilationUnitBased
 		params = CodeActionUtil.constructCodeActionParams(unit, "A");
 		codeActions = server.codeAction(params).join();
 		Assert.assertNotNull(codeActions);
-		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
 		Assert.assertTrue(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT));
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateConstructorsActionTest.java
@@ -91,11 +91,9 @@ public class GenerateConstructorsActionTest extends AbstractCompilationUnitBased
 		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "String name");
 		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
 		Assert.assertNotNull(codeActions);
-		Either<Command, CodeAction> constructorAction = CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.QUICK_ASSIST, "Generate Constructors...");
-		Assert.assertNotNull(constructorAction);
-		Command constructorCommand = CodeActionHandlerTest.getCommand(constructorAction);
-		Assert.assertNotNull(constructorCommand);
-		Assert.assertEquals(SourceAssistProcessor.COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT, constructorCommand.getCommand());
+		List<Either<Command, CodeAction>> quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
+		Assert.assertNotNull(quickAssistActions);
+		Assert.assertTrue(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_GENERATECONSTRUCTORSPROMPT));
 		// test for type declaration
 		params = CodeActionUtil.constructCodeActionParams(unit, "A");
 		codeActions = server.codeAction(params).join();


### PR DESCRIPTION
This PR introduces the sort mechanism in quick assists for different contexts, we can define different priorities for different contexts in `QuickAssistComparator`. e.g., in field declaration, generate accessor > generate constructor


https://user-images.githubusercontent.com/45906942/171313406-3bc7f738-370e-444e-8931-ff73a27a28da.mp4



Signed-off-by: Shi Chen <chenshi@microsoft.com>