### PR TITLE
Use ProcessHandle.of(long) to determine state of the parent process.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
@@ -65,6 +65,13 @@ public final class ParentProcessWatcher implements Runnable, Function<MessageCon
 		if (pid == 0 || lastActivityTime > (System.currentTimeMillis() - INACTIVITY_DELAY_SECS)) {
 			return true;
 		}
+
+		try {
+			return ProcessHandle.of(pid).isPresent();
+		} catch (UnsupportedOperationException | SecurityException e) {
+			// Unable to determine process state, fallback behaviour
+		}
+
 		String command;
 		if (Platform.OS_WIN32.equals(Platform.getOS())) {
 			command = "cmd /c \"tasklist /FI \"PID eq " + pid + "\" | findstr " + pid + "\"";


### PR DESCRIPTION
- Fixes https://github.com/redhat-developer/vscode-java/issues/2488
- Avoid usage of java.lang.Runtime#exec(..) along with the 'kill'
  command to determine the status of the parent process
- Fall back to previous behaviour in case of error

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>