### PR TITLE
Allow to update multiple projects at the same time

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -56,7 +56,8 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.text.correction;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.internal.gradle.checksums;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.filesystem;x-friends:="org.eclipse.jdt.ls.tests",
- org.eclipse.lsp4j.proposed;x-friends:="org.eclipse.jdt.ls.tests"
+ org.eclipse.lsp4j.proposed;x-friends:="org.eclipse.jdt.ls.tests",
+ org.eclipse.lsp4j.extended;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-ClassPath: lib/jsoup-1.14.2.jar,
  lib/remark-1.2.0.jar,
  .

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -137,6 +137,7 @@ import org.eclipse.lsp4j.TypeDefinitionParams;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.extended.ProjectConfigurationsUpdateParam;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.services.JsonDelegate;
@@ -841,6 +842,16 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		logInfo(">> java/projectConfigurationUpdate");
 		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
 		handler.updateConfiguration(param);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.JavaProtocolExtensions#projectConfigurationsUpdate(org.eclipse.lsp4j.extended.ProjectConfigurationsUpdateParam)
+	 */
+	@Override
+	public void projectConfigurationsUpdate(ProjectConfigurationsUpdateParam param) {
+		logInfo(">> java/projectConfigurationsUpdate");
+		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
+		handler.updateConfigurations(param.getIdentifiers());
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandler.java
@@ -38,9 +38,15 @@ public class ProjectConfigurationUpdateHandler {
 		this.projectManager = projectManager;
 	}
 
-	public void updateConfigurations(List<TextDocumentIdentifier> param) {
+	/**
+	 * Update the projects' configurations (build files).
+	 *
+	 * @param identifiers the identifiers which may point to the projects' paths or
+	 * files that belong to some projects in the workspace.
+	 */
+	public void updateConfigurations(List<TextDocumentIdentifier> identifiers) {
 		Set<IProject> projects = new HashSet<>();
-		for (TextDocumentIdentifier identifier : param) {
+		for (TextDocumentIdentifier identifier : identifiers) {
 			IProject project = getProjectFromUri(identifier.getUri());
 			if (project != null) {
 				projects.add(project);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
@@ -62,6 +62,8 @@ public interface JavaProtocolExtensions {
 
 	/**
 	 * Request a project configuration update
+	 *
+	 * @deprecated Please use {@link #projectConfigurationsUpdate(TextDocumentIdentifier)}.
 	 * @param documentUri the document from which the project configuration will be updated
 	 */
 	@JsonNotification
@@ -72,7 +74,7 @@ public interface JavaProtocolExtensions {
 	 * @param documentUris the documents from which the project configuration will be updated
 	 */
 	@JsonNotification
-	void projectConfigurationsUpdate(ProjectConfigurationsUpdateParam documentUris);
+	void projectConfigurationsUpdate(ProjectConfigurationsUpdateParam params);
 
 	@JsonRequest
 	CompletableFuture<BuildWorkspaceStatus> buildWorkspace(Either<Boolean, boolean[]> forceReBuild);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
@@ -42,6 +42,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.extended.ProjectConfigurationsUpdateParam;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -65,6 +66,13 @@ public interface JavaProtocolExtensions {
 	 */
 	@JsonNotification
 	void projectConfigurationUpdate(TextDocumentIdentifier documentUri);
+
+	/**
+	 * Request multiple project configurations update
+	 * @param documentUris the documents from which the project configuration will be updated
+	 */
+	@JsonNotification
+	void projectConfigurationsUpdate(ProjectConfigurationsUpdateParam documentUris);
 
 	@JsonRequest
 	CompletableFuture<BuildWorkspaceStatus> buildWorkspace(Either<Boolean, boolean[]> forceReBuild);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/lsp4j/extended/ProjectConfigurationsUpdateParam.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/lsp4j/extended/ProjectConfigurationsUpdateParam.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.lsp4j.extended;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class ProjectConfigurationsUpdateParam {
+	/**
+	 * The text document's identifiers.
+	 */
+	@NonNull
+	private List<TextDocumentIdentifier> identifiers;
+
+	public ProjectConfigurationsUpdateParam() {
+	}
+
+	public ProjectConfigurationsUpdateParam(@NonNull final List<TextDocumentIdentifier> identifiers) {
+		this.identifiers = Preconditions.<List<TextDocumentIdentifier>>checkNotNull(identifiers, "identifiers");
+	}
+
+	@Pure
+	@NonNull
+	public List<TextDocumentIdentifier> getIdentifiers() {
+		return identifiers;
+	}
+
+	public void setIdentifiers(@NonNull final List<TextDocumentIdentifier> identifiers) {
+		this.identifiers = Preconditions.<List<TextDocumentIdentifier>>checkNotNull(identifiers, "identifiers");
+	}
+
+	@Override
+	@Pure
+	public String toString() {
+	  ToStringBuilder b = new ToStringBuilder(this);
+	  b.add("identifiers", this.identifiers);
+	  return b.toString();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((identifiers == null) ? 0 : identifiers.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ProjectConfigurationsUpdateParam other = (ProjectConfigurationsUpdateParam) obj;
+		if (identifiers == null) {
+			if (other.identifiers != null)
+				return false;
+		} else if (!identifiers.equals(other.identifiers))
+			return false;
+		return true;
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.extended.ProjectConfigurationsUpdateParam;
+import org.junit.Test;
+
+public class ProjectConfigurationUpdateHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	@Test
+	public void testUpdateConfiguration() throws Exception {
+		importProjects("maven/multimodule");
+		ProjectsManager pm = mock(ProjectsManager.class);
+		when(pm.updateProject(any(IProject.class), anyBoolean())).thenReturn(null);
+		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
+		IProject project = WorkspaceHelper.getProject("multimodule");
+		handler.updateConfiguration(new TextDocumentIdentifier(project.getLocationURI().toString()));
+		verify(pm, times(1)).updateProject(any(IProject.class), eq(true));
+	}
+
+	@Test
+	public void testUpdateConfigurations() throws Exception {
+		importProjects("maven/multimodule");
+		ProjectsManager pm = mock(ProjectsManager.class);
+		when(pm.updateProject(any(IProject.class), anyBoolean())).thenReturn(null);
+		ProjectConfigurationUpdateHandler handler = new ProjectConfigurationUpdateHandler(pm);
+		List<TextDocumentIdentifier> list = new ArrayList<>();
+		IProject project = WorkspaceHelper.getProject("module1");
+		list.add(new TextDocumentIdentifier(project.getLocationURI().toString()));
+		project = WorkspaceHelper.getProject("module2");
+		list.add(new TextDocumentIdentifier(project.getLocationURI().toString()));
+
+		ProjectConfigurationsUpdateParam param = new ProjectConfigurationsUpdateParam(list);
+
+		handler.updateConfigurations(param.getIdentifiers());
+		verify(pm, times(2)).updateProject(any(IProject.class), eq(true));
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProjectConfigurationUpdateHandlerTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
- Multiple project can be updated at the same time via 'java/projectConfigurationsUpdate'
  request.
- Argument of this request is 'ProjectConfigurationsUpdateParam', which
  contains a list of 'TextDocumentIdentifier'.

requires https://github.com/redhat-developer/vscode-java/pull/2513

Signed-off-by: sheche <sheche@microsoft.com>