### PR TITLE
Change the order for configuration updating options

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -242,8 +242,8 @@ public class StandardProjectsManager extends ProjectsManager {
 								String cmd = "java.projectConfiguration.status";
 								TextDocumentIdentifier uri = new TextDocumentIdentifier(uriString);
 								ActionableNotification updateProjectConfigurationNotification = new ActionableNotification().withSeverity(MessageType.Info)
-										.withMessage("A build file was modified. Do you want to synchronize the Java classpath/configuration?").withCommands(asList(new Command("Never", cmd, asList(uri, FeatureStatus.disabled)),
-												new Command("Now", cmd, asList(uri, FeatureStatus.interactive)), new Command("Always", cmd, asList(uri, FeatureStatus.automatic))));
+										.withMessage("A build file was modified. Do you want to synchronize the Java classpath/configuration?").withCommands(asList(new Command("Yes", cmd, asList(uri, FeatureStatus.interactive)),
+												new Command("Always", cmd, asList(uri, FeatureStatus.automatic)), new Command("Never", cmd, asList(uri, FeatureStatus.disabled))));
 								client.sendActionableNotification(updateProjectConfigurationNotification);
 							}
 					}


### PR DESCRIPTION
part of https://github.com/redhat-developer/vscode-java/issues/2473

Before, the highlighted option is `Never`. This PR changes the order of the options so that `Yes` will be highlighted.

##### Before
![WeChat Screenshot_20220616085436](https://user-images.githubusercontent.com/6193897/173970165-0f7736c9-a07b-4bb8-a32e-38c85edd5cca.png)

##### Now
![WeChat Screenshot_20220620145342](https://user-images.githubusercontent.com/6193897/174543863-ebe650e0-cf51-4ae1-9b01-a28b9bd42fbf.png)

Note: I changed the word `Now` to `Yes` to make it sounds more straight-forward. @rgrunber Is this word change makes sense to you? (Since you are native speaker 😄  )

Signed-off-by: Sheng Chen <sheche@microsoft.com>