### PR TITLE
Update launch script, Java 17 is required now

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -34,8 +34,8 @@ def get_java_executable(validate_java_version):
 	for match in matches:
 		java_major_version = int(match.group("major"))
 
-		if java_major_version < 11:
-			raise Exception("jdtls requires at least Java 11")
+		if java_major_version < 17:
+			raise Exception("jdtls requires at least Java 17")
 
 		return java_executable
 


### PR DESCRIPTION
Related to https://github.com/eclipse/eclipse.jdt.ls/pull/2118

Signed-off-by: Wang Lun <me@wanglun.org>