### PR TITLE
Refresh the invisible project's classpath on demand

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -596,6 +596,14 @@ public abstract class BaseDocumentLifeCycleHandler {
 	 */
 	private boolean needInferSourceRoot(IJavaProject javaProject, ICompilationUnit unit) {
 		if (javaProject.isOnClasspath(unit)) {
+			CompilationUnit astRoot = CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, new NullProgressMonitor());
+			IProblem[] problems = astRoot.getProblems();
+			boolean isPackageNotMatch = Arrays.stream(problems)
+					.anyMatch(p -> p.getID() == IProblem.PackageIsNotExpectedPackage);
+			if (!isPackageNotMatch) {
+				return false;
+			}
+
 			IJavaElement parent = unit.getParent();
 			if (parent == null || !(parent instanceof IPackageFragment)) {
 				return false;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -570,7 +570,15 @@ public abstract class BaseDocumentLifeCycleHandler {
 	 */
 	private void inferInvisibleProjectSourceRoot(ICompilationUnit unit) {
 		IJavaProject javaProject = unit.getJavaProject();
+		if (javaProject == null) {
+			return;
+		}
+		
 		IProject project = javaProject.getProject();
+		if (project.getName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
+			return;
+		}
+
 		if (!ProjectUtils.isVisibleProject(project)) {
 			PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
 			List<String> sourcePaths = preferencesManager.getPreferences().getInvisibleProjectSourcePaths();

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson1/Lesson1.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson1/Lesson1.java
@@ -1,0 +1,1 @@
+public class Lesson1 {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson2/Lesson2.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson2/Lesson2.java
@@ -1,0 +1,1 @@
+public class Lesson2 {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson3/Lesson3.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/lesson3/Lesson3.java
@@ -1,0 +1,2 @@
+package lesson3;
+public class Lesson3 {}


### PR DESCRIPTION
fix https://github.com/redhat-developer/vscode-java/issues/1282

When user opens a source file, we try to infer the source root on demand if:
- it's not the on the classpath
- it has package not matching errors

Signed-off-by: Sheng Chen <sheche@microsoft.com>