### PR TITLE
correct typo in gradle checksum mismatch error

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -117,7 +117,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 			+ "If you trust it, please add \n"
 			+ "`{\"sha256\": \"@checksum@\","
 			+ "\n\"allowed\": true}`"
-			+ "\n to the `java.import.gradle.wrapper.checksums` preference."
+			+ "\n to the `java.imports.gradle.wrapper.checksums` preference."
 			+ ""
 			.replaceAll("\n", System.lineSeparator());
 	//@formatter:on


### PR DESCRIPTION
Currently, jdtls uses `java.imports.gradle.wrapper.checksums` to configure
allowed/disallowed gradle-wrappers. But the error is misleading as it
says `java.import.gradle.wrapper.checksums`.

It took me an evening to figure out, we need to use `imports` and not  `import` for this config.

refer: https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java#L300

It's quite confusing. The [docs](https://github.com/eclipse/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line) are also misleading, as it has quite old info on the config which can be used.