### PR TITLE
Automatically include the required plug-ins in the launch files

### DIFF
--- a/launch/jdt.ls.remote.server.launch
+++ b/launch/jdt.ls.remote.server.launch
@@ -5,6 +5,7 @@
 <stringAttribute key="application" value="org.eclipse.jdt.ls.core.id1"/>
 <booleanAttribute key="askclear" value="true"/>
 <booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticIncludeRequirements" value="true"/>
 <booleanAttribute key="automaticValidate" value="false"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>

--- a/launch/jdt.ls.socket-stream.launch
+++ b/launch/jdt.ls.socket-stream.launch
@@ -5,6 +5,7 @@
 <stringAttribute key="application" value="org.eclipse.jdt.ls.core.id1"/>
 <booleanAttribute key="askclear" value="true"/>
 <booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticIncludeRequirements" value="true"/>
 <booleanAttribute key="automaticValidate" value="false"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>

--- a/launch/jdt.ls.socket-stream.syntaxserver.launch
+++ b/launch/jdt.ls.socket-stream.syntaxserver.launch
@@ -5,6 +5,7 @@
 <stringAttribute key="application" value="org.eclipse.jdt.ls.core.id1"/>
 <booleanAttribute key="askclear" value="true"/>
 <booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticIncludeRequirements" value="true"/>
 <booleanAttribute key="automaticValidate" value="false"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>


### PR DESCRIPTION
The existing *.launch files are often broken while updating the target platform. We can mitigate this by adopting a new option to automatically include the required plugins while launching. This new option was introduced from Eclispe 2022-06 
https://www.eclipse.org/eclipse/news/4.24/pde.php#auto-add-requirements-launches.