### PR TITLE
Provide reload project diagnostics on demand

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -176,4 +176,9 @@
          <run class="org.eclipse.jdt.ls.core.internal.filesystem.JLSFileSystem"/>
       </filesystem>
    </extension>
+   <extension
+      id="org.eclipse.jdt.ls.buildFileMarker"
+      point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"/>
+   </extension>
 </plugin>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -85,6 +85,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 	public static final String PROJECTS_IMPORTED = "__PROJECTS_IMPORTED__";
 	private static final String CORE_RESOURCES_MATCHER_ID = "org.eclipse.core.resources.regexFilterMatcher";
 	public static final String CREATED_BY_JAVA_LANGUAGE_SERVER = "__CREATED_BY_JAVA_LANGUAGE_SERVER__";
+	public static final String BUILD_FILE_MARKER_TYPE = "org.eclipse.jdt.ls.buildFileMarker";
 	private static final int JDTLS_FILTER_TYPE = IResourceFilterDescription.EXCLUDE_ALL | IResourceFilterDescription.INHERITABLE | IResourceFilterDescription.FILES | IResourceFilterDescription.FOLDERS;
 
 	private PreferenceManager preferenceManager;
@@ -421,6 +422,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 						registerWatchers(true);
 					}
 					updateEncoding(monitor);
+					project.deleteMarkers(BUILD_FILE_MARKER_TYPE, false, IResource.DEPTH_ONE);
 					long elapsed = System.currentTimeMillis() - start;
 					JavaLanguageServerPlugin.logInfo("Updated " + projectName + " in " + elapsed + " ms");
 				} catch (Exception e) {


### PR DESCRIPTION
requires https://github.com/redhat-developer/vscode-java/pull/2575 (with a gif)

- store the build file digest so that the update notification will only
  appear when necessary.
- if the build file needs a reload, append a problem marker to it.

Signed-off-by: Sheng Chen <sheche@microsoft.com>