### PR TITLE
Add a compatible constructor to CompletionProposalDescriptionProvider to avoid breaking Java Debugger

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -62,6 +62,11 @@ public class CompletionProposalDescriptionProvider {
 		fUnit = unit;
 	}
 
+	public CompletionProposalDescriptionProvider(CompletionContext context) {
+		super();
+		fContext = context;
+	}
+
 	/**
 	 * Creates and returns the method signature suitable for display.
 	 *


### PR DESCRIPTION
https://github.com/eclipse/eclipse.jdt.ls/pull/2152 added a new parameter to the original constructor, that would break the completion feature of DEBUG CONSOLE in Java Debugger extension. Add a compatible constructor to avoid breaking other extensions.