### PR TITLE
Set default severity of "Circular classpath" to `warning`

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -143,6 +143,7 @@ public class PreferenceManager {
 		javaCoreOptions.put(JavaCore.COMPILER_PB_REDUNDANT_SUPERINTERFACE, JavaCore.WARNING);
 		javaCoreOptions.put(JavaCore.CODEASSIST_SUBWORD_MATCH, JavaCore.DISABLED);
 		javaCoreOptions.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JavaCore.IGNORE);
+		// workaround for https://github.com/redhat-developer/vscode-java/issues/718
 		javaCoreOptions.put(JavaCore.CORE_CIRCULAR_CLASSPATH, JavaCore.WARNING);
 		JavaCore.setOptions(javaCoreOptions);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -143,6 +143,7 @@ public class PreferenceManager {
 		javaCoreOptions.put(JavaCore.COMPILER_PB_REDUNDANT_SUPERINTERFACE, JavaCore.WARNING);
 		javaCoreOptions.put(JavaCore.CODEASSIST_SUBWORD_MATCH, JavaCore.DISABLED);
 		javaCoreOptions.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JavaCore.IGNORE);
+		javaCoreOptions.put(JavaCore.CORE_CIRCULAR_CLASSPATH, JavaCore.WARNING);
 		JavaCore.setOptions(javaCoreOptions);
 	}
 


### PR DESCRIPTION
Signed-off-by: Shi Chen chenshi@microsoft.com

This is a workaround about https://github.com/redhat-developer/vscode-java/issues/718, https://github.com/eclipse/buildship/issues/460

We observed a lot of projects (especially Gradle projects) have this error. Actually, we have a workaround to set the severity to `warning` manually: https://github.com/eclipse/buildship/issues/460#issuecomment-297953710

But for VS Code users, there is no existing wizard to config this setting and it's also hard and not recommended to change .prefs file in `.settings` folder. In this way, we can make the default value of config to `warning` to make the users not be blocked by this error at least. 

For example, given a sample project https://github.com/opensearch-project/OpenSearch.git, the redhat.java extension reports circular dependency found in the project and the project can't be built. If we set this severity to `warning`, we can only find some errors in RestTestFromSnippetsTaskTests.java (due to Java/Groovy polyglot project, which is not supported yet) and the project can be built.