### PR TITLE
Always interpret the full workspace symbol query as a package name.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -188,6 +188,17 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 	}
 
 	@Test
+	public void testSearchAllTypesOfPackage() {
+		List<SymbolInformation> results = WorkspaceSymbolHandler.search("java.io", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> "File".equals(s.getName()) && "java.io".equals(s.getContainerName())));
+
+		results = WorkspaceSymbolHandler.search("java.lang", monitor);
+		assertTrue(results.size() > 1);
+		assertTrue(results.stream().anyMatch(s -> "Exception".equals(s.getName()) && "java.lang".equals(s.getContainerName())));
+	}
+
+	@Test
 	public void testSearchSourceMethodDeclarations() {
 		preferences.setIncludeSourceMethodDeclarations(true);
 		List<SymbolInformation> results = WorkspaceSymbolHandler.search("deleteSomething", "hello", true, monitor);


### PR DESCRIPTION
- For a query of 'foo.bar.baz', in addition to searching for all types
  matching 'baz', whose package matches 'foo.bar', we should also search
  for all types whose package matches 'foo.bar.baz'
- Refactor custom TypeNameMatchRequestor & MethodNameMatchRequestor
- Add testcase

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This was discussed in https://github.com/redhat-developer/vscode-java/pull/2538#discussion_r915894958

CC : @gayanper 