### PR TITLE
Search more folders to infer source roots for invisible projects

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporter.java
@@ -186,8 +186,7 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 	 * Based on the trigger file and its belonging source folder, search more places and collect
 	 * the valid source paths.
 	 * @param triggerFilePath the path of the import trigger file.
-	 * @param triggerFolder the folder which contains the trigger file. A search will be executed
-	 *                      based on the trigger folder.
+	 * @param triggerFolder the folder which is the source root of the trigger file.
 	 * @param linkedFolder the invisible project's linked folder.
 	 */
 	private static Collection<IPath> collectSourcePaths(IPath triggerFilePath, IFolder triggerFolder,
@@ -220,8 +219,7 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 	/**
 	 * Collect folders that may contain Java source files.
 	 * @param triggerFilePath the path of the import trigger file.
-	 * @param triggerFolder the folder which contains the trigger file. A search will be executed
-	 *                      based on the trigger folder.
+	 * @param triggerFolder the folder which is the source root of the trigger file.
 	 * @param linkedFolderPath the path of invisible project's linked folder.
 	 */
 	private static Collection<File> collectFoldersToSearch(IPath triggerFilePath, IFolder triggerFolder,
@@ -253,9 +251,9 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 				continue;
 			}
 
-			Path eclipsePath = new Path(dir.getAbsolutePath());
+			Path dirPath = new Path(dir.getAbsolutePath());
 			// skip ancestor folder of the trigger file.
-			if (eclipsePath.isPrefixOf(triggerFilePath)) {
+			if (dirPath.isPrefixOf(triggerFilePath)) {
 				continue;
 			}
 
@@ -266,7 +264,7 @@ public class InvisibleProjectImporter extends AbstractProjectImporter {
 
 	/**
 	 * Get the sibling folders of the trigger folder.
-	 * @param triggerFolder the trigger folder
+	 * @param triggerFolder the folder which is the source root of the trigger file.
 	 * @param linkedFolderPath the path of invisible project's linked folder.
 	 */
 	private static Collection<File> getSiblingFolders(IFolder triggerFolder, IPath linkedFolderPath) {

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/Main.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/Main.java
@@ -1,0 +1,1 @@
+public class Main {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/a/very/deep/path/Source.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/inferSourceRoot/a/very/deep/path/Source.java
@@ -1,0 +1,1 @@
+public class Source {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/Main.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/Main.java
@@ -1,0 +1,1 @@
+public class Main {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/eclipse/Eclipse.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/eclipse/Eclipse.java
@@ -1,0 +1,1 @@
+public class Eclipse {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/excluded/Excluded.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/excluded/Excluded.java
@@ -1,0 +1,1 @@
+public class Excluded {}

--- a/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/other-project/Other.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/invisibleFileDetector/other-project/Other.java
@@ -1,0 +1,1 @@
+public class Other {}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -97,9 +97,11 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         List<String> settingKeys = Arrays.asList(ProjectCommand.SOURCE_PATHS);
         Map<String, Object> options = ProjectCommand.getProjectSettings(linkedFolder, settingKeys);
         String[] actualSourcePaths = (String[]) options.get(ProjectCommand.SOURCE_PATHS);
-        String expectedSourcePath = project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("src").getLocation().toOSString();
-        assertTrue(actualSourcePaths.length == 1);
-        assertEquals(expectedSourcePath, actualSourcePaths[0]);
+        assertTrue(actualSourcePaths.length == 2);
+        assertTrue(Arrays.stream(actualSourcePaths).anyMatch(sourcePath -> {
+            return sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("src").getLocation().toOSString())
+                    || sourcePath.equals(project.getFolder(ProjectUtils.WORKSPACE_LINK).getFolder("test").getLocation().toOSString());
+        }));
     }
 
     @Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -408,23 +408,15 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 		long sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
 				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
 				.count();
-		assertEquals(1, sourceRootsCount);
-
-		IFile unDiscoveredFile = invisibleProject.getFile("_/lesson2/Lesson2.java");
-		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
-		waitForBackgroundJobs();
-		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
-				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
-				.count();
-		assertEquals(2, sourceRootsCount);
-
-		unDiscoveredFile = invisibleProject.getFile("_/lesson3/Lesson3.java");
-		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
-		waitForBackgroundJobs();
-		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
-				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
-				.count();
 		assertEquals(3, sourceRootsCount);
+
+		IFile unDiscoveredFile = invisibleProject.getFile("_/a/very/deep/path/Source.java");
+		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
+		waitForBackgroundJobs();
+		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
+				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
+				.count();
+		assertEquals(4, sourceRootsCount);
 
 		List<IMarker> markers = ResourceUtils.getErrorMarkers(invisibleProject);
 		assertTrue(markers.isEmpty());
@@ -432,7 +424,7 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 
 	@Test
 	public void testInferSourceRoot2() throws Exception {
-		IProject invisibleProject = copyAndImportFolder("singlefile/inferSourceRoot", "lesson3/Lesson3.java");
+		IProject invisibleProject = copyAndImportFolder("singlefile/inferSourceRoot", "Main.java");
 		waitForBackgroundJobs();
 
 		IFolder projectFolder = invisibleProject.getFolder(ProjectUtils.WORKSPACE_LINK);
@@ -443,23 +435,15 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 		long sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
 				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
 				.count();
-		assertEquals(1, sourceRootsCount);
-
-		IFile unDiscoveredFile = invisibleProject.getFile("_/lesson2/Lesson2.java");
-		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
-		waitForBackgroundJobs();
-		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
-				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
-				.count();
-		assertEquals(2, sourceRootsCount);
-
-		unDiscoveredFile = invisibleProject.getFile("_/lesson1/Lesson1.java");
-		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
-		waitForBackgroundJobs();
-		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
-				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
-				.count();
 		assertEquals(3, sourceRootsCount);
+
+		IFile unDiscoveredFile = invisibleProject.getFile("_/a/very/deep/path/Source.java");
+		InvisibleProjectImporter.inferSourceRoot(javaProject, unDiscoveredFile.getLocation());
+		waitForBackgroundJobs();
+		sourceRootsCount = Arrays.stream(javaProject.getRawClasspath())
+				.filter(cp -> cp.getEntryKind() == IClasspathEntry.CPE_SOURCE)
+				.count();
+		assertEquals(4, sourceRootsCount);
 
 		List<IMarker> markers = ResourceUtils.getErrorMarkers(invisibleProject);
 		assertTrue(markers.isEmpty());

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectPreferenceChangeListenerTest.java
@@ -154,6 +154,7 @@ public class InvisibleProjectPreferenceChangeListenerTest extends AbstractInvisi
 
 	@Test
 	public void testUpdateSourcePaths() throws Exception {
+		preferences.setInvisibleProjectSourcePaths(Arrays.asList("src"));
 		IProject project = copyAndImportFolder("singlefile/simple", "src/App.java");
 		IJavaProject javaProject = JavaCore.create(project);
 		IFolder linkFolder = project.getFolder(ProjectUtils.WORKSPACE_LINK);


### PR DESCRIPTION
Another enhancement for inferring the source roots of the invisible projects.

- based on the source root inferred from the trigger file, do more search for other potential source roots.
- if the source root is linked folder, search all direct child folders.
- otherwise, search all the sibling folders.

This pre-inference behavior plus the [lazy inference](https://github.com/eclipse/eclipse.jdt.ls/pull/2160), should improve the getting start experience for the unmanaged folders.

Signed-off-by: sheche <sheche@microsoft.com>