### PR TITLE
Infer the source root only when necessary

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -306,6 +306,30 @@ public final class ProjectUtils {
 		return ResourceUtils.isContainedIn(project.getLocation(), rootPaths);
 	}
 
+	/**
+	 * Check if the input project is an unmanaged folder. (aka invisible project)
+	 * @param project
+	 */
+	public static boolean isUnmanagedFolder(IProject project) {
+		if (Objects.equals(project.getName(), ProjectsManager.DEFAULT_PROJECT_NAME)) {
+			return false;
+		}
+		
+		if (isVisibleProject(project)) {
+			return false;
+		}
+
+		try {
+			String[] natureIds = project.getDescription().getNatureIds();
+			// TODO: we should consider assign a dedicate nature id for unmanaged folders.
+			// see: https://github.com/redhat-developer/vscode-java/issues/2552
+			return natureIds.length == 1 && Objects.equals(natureIds[0], JavaCore.NATURE_ID);
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e);
+		}
+		return false;
+	}
+
 	public static List<IProject> getVisibleProjects(IPath workspaceRoot) {
 		List<IProject> projects = new ArrayList<>();
 		for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -575,11 +575,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 		}
 		
 		IProject project = javaProject.getProject();
-		if (project.getName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
-			return;
-		}
-
-		if (!ProjectUtils.isVisibleProject(project)) {
+		if (ProjectUtils.isUnmanagedFolder(project)) {
 			PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
 			List<String> sourcePaths = preferencesManager.getPreferences().getInvisibleProjectSourcePaths();
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ProjectUtilsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/ProjectUtilsTest.java
@@ -67,4 +67,18 @@ public class ProjectUtilsTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(IMarker.SEVERITY_ERROR, ProjectUtils.getMaxProjectProblemSeverity());
 	}
 
+
+	@Test
+	public void testIsUnmanagedFolder1() throws Exception {
+		importProjects("maven/salut");
+		IProject project = WorkspaceHelper.getProject("salut");
+		assertEquals(false, ProjectUtils.isUnmanagedFolder(project));
+	}
+
+	@Test
+	public void testIsUnmanagedFolder2() throws Exception {
+		IProject unmanagedFolder = copyAndImportFolder("singlefile/lesson1", "src/org/samples/HelloWorld.java");
+		assertEquals(true, ProjectUtils.isUnmanagedFolder(unmanagedFolder));
+	}
+
 }


### PR DESCRIPTION
- only infer the source root when the opened Java source file belongs
  to an unmanaged folder.

Signed-off-by: Sheng Chen <sheche@microsoft.com>