### PR TITLE
Automatically add Protobuf output source directories to classpath

### DIFF
--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -8,5 +8,6 @@ bin.includes = META-INF/,\
                lifecycle-mapping-metadata.xml,\
                plugin.properties,\
                gradle/checksums/checksums.json,\
-               gradle/checksums/versions.json
+               gradle/checksums/versions.json,\
+               gradle/protobuf/init.gradle
 src.includes = src/

--- a/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
@@ -1,0 +1,188 @@
+import org.gradle.plugins.ide.eclipse.model.Classpath
+import org.gradle.plugins.ide.eclipse.model.ClasspathEntry
+import org.gradle.plugins.ide.eclipse.model.EclipseModel
+import org.gradle.plugins.ide.eclipse.model.SourceFolder
+
+import java.lang.reflect.InvocationTargetException
+
+class ProtobufPatchPlugin implements Plugin<Project> {
+
+    /**
+     * The protobuf task names that will compile proto file to java source code.
+     */
+    private static final List<String> TASK_NAMES = Arrays.asList("generateProto", "generateTestProto")
+
+    /**
+     * The Gradle Eclipse plugin id.
+     */
+    private static final String ECLIPSE_PLUGIN = "eclipse"
+
+    /**
+     * The Gradle Protobuf plugin id.
+     */
+    private static final String PROTOBUF_PLUGIN = "com.google.protobuf"
+
+    /**
+     * Constant for the name of the ignore optional compile problems attribute.
+     */
+    private static final String IGNORE_OPTIONAL_PROBLEMS = "ignore_optional_problems"
+
+    /**
+     * Constant for the name of the module attribute.
+     */
+    private static final String OPTIONAL = "optional"
+
+    /**
+     * Constant for the name of the test attribute.
+     */
+    private static final String TEST = "test"
+
+    private static final String GRADLE_SCOPE = "gradle_scope"
+
+    private static final String GRADLE_USED_BY_SCOPE = "gradle_used_by_scope"
+
+    @Override
+    void apply(Project project) {
+        project.afterEvaluate {
+            project.plugins.withId(ECLIPSE_PLUGIN) {
+                project.plugins.withId(PROTOBUF_PLUGIN) {
+                    EclipseModel model = project.getExtensions().findByType(EclipseModel)
+                    model.classpath.file.whenMerged { Classpath cp ->
+                        File projectDir = project.getProjectDir()
+                        for (final String taskName : TASK_NAMES) {
+                            Task task = getTaskByName(project, taskName)
+                            if (task == null) {
+                                continue
+                            }
+
+                            Object sourceSetObj = getSourceSet(task);
+                            if (!(sourceSetObj instanceof SourceSet)) {
+                                continue
+                            }
+                            String sourceSetName = ((SourceSet) sourceSetObj).name
+
+                            Object outputSourceDirectorySet = getOutputSourceDirectorySet(task)
+                            if (!(outputSourceDirectorySet instanceof SourceDirectorySet)) {
+                                continue;
+                            }
+                            SourceDirectorySet sourceDirectorySet = (SourceDirectorySet) outputSourceDirectorySet
+                            Set<File> srcDirs = sourceDirectorySet.getSrcDirs()
+                            for (File srcDir : srcDirs) {
+                                // buildship requires the folder exists on disk, otherwise
+                                // it will be ignored when updating classpath file, see:
+                                // https://github.com/eclipse/buildship/issues/1196
+                                srcDir.mkdirs();
+
+                                String relativePath = projectDir.toURI().relativize(srcDir.toURI()).getPath()
+                                // remove trailing slash
+                                if (relativePath.endsWith("/")) {
+                                    relativePath = relativePath.substring(0, relativePath.length() - 1)
+                                }
+
+                                SourceFolder entry = new SourceFolder(relativePath, getOutputPath(cp, sourceSetName))
+                                entry.entryAttributes.put(OPTIONAL, "true")
+                                entry.entryAttributes.put(IGNORE_OPTIONAL_PROBLEMS, "true")
+
+                                boolean isTest = isTest(task)
+                                entry.entryAttributes.put(GRADLE_SCOPE, isTest ? "test" : "main")
+                                entry.entryAttributes.put(GRADLE_USED_BY_SCOPE, isTest ? "test" : "main,test")
+                                // check if output is not null here because test source folder
+                                // must have a separate output folder in Eclipse
+                                if (entry.output != null && isTest) {
+                                    entry.entryAttributes.put(TEST, "true")
+                                }
+                                cp.entries.add(entry)
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+
+    Task getTaskByName(Project project, String name) {
+        try {
+            return project.getTasks().getByName(name)
+        } catch (UnknownTaskException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get the output source directory set of the proto generation task. The source directories
+     * will be added to the Eclipse classpath entries.
+     */
+    Object getOutputSourceDirectorySet(Task task) {
+        try {
+            return task.getClass().getMethod("getOutputSourceDirectorySet").invoke(task)
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            return null
+        }
+    }
+
+    /**
+     * Get the source set of the proto generation task. The source set name will be used
+     * to determine the output path.
+     */
+    Object getSourceSet(Task task) {
+        try {
+            return task.getClass().getMethod("getSourceSet").invoke(task)
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            return null
+        }
+    }
+
+    /**
+     * Get if it's generate test proto task or not.
+     */
+    boolean isTest(Task task) {
+        try {
+            return (boolean) task.getClass().getMethod("getIsTest").invoke(task)
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            return false
+        }
+    }
+
+    /**
+     * Get the output path according to the source set name, if no valid path can be
+     * found, <code>null</code> will return.
+     */
+    String getOutputPath(Classpath classpath, String sourceSetName) {
+        String path = "bin/" + sourceSetName
+        if (isValidOutput(classpath, path)) {
+            return path
+        }
+        // fallback to default output
+        return null
+    }
+
+    /**
+     * Check if the output path is valid or not.
+     * See: org.eclipse.jdt.internal.core.ClasspathEntry#validateClasspath()
+     */
+    boolean isValidOutput(Classpath classpath, String path) {
+        Set<String> outputs = new HashSet<>()
+        for (ClasspathEntry cpe : classpath.getEntries()) {
+            if (cpe instanceof SourceFolder) {
+                outputs.add(((SourceFolder) cpe).getOutput())
+            }
+        }
+        for (String output : outputs) {
+            if (Objects.equals(output, path)) {
+                continue
+            }
+            // Eclipse does not allow nested output path
+            if (output.startsWith(path) || path.startsWith(output)) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+allprojects {
+    afterEvaluate {
+        it.getPlugins().apply(ProtobufPatchPlugin)
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradlePreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradlePreferenceChangeListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat Inc. and others.
+ * Copyright (c) 2020-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -45,6 +45,13 @@ public class GradlePreferenceChangeListener implements IPreferencesChangeListene
 					if (newPreferences.isGradleWrapperEnabled() || gradleJavaHomeChanged) {
 						updateProject(projectsManager, project, gradleJavaHomeChanged);
 					}
+				}
+			}
+
+			boolean protobufSupportChanged = !Objects.equals(oldPreferences.isProtobufSupportEnabled(), newPreferences.isProtobufSupportEnabled());
+			if (protobufSupportChanged) {
+				for (IProject project : ProjectUtils.getGradleProjects()) {
+					projectsManager.updateProject(project, true);
 				}
 			}
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -440,6 +440,8 @@ public class Preferences {
 
 	public static final String JAVA_CODEACTION_SORTMEMBER_AVOIDVOLATILECHANGES = "java.codeAction.sortMembers.avoidVolatileChanges";
 
+	public static final String JAVA_JDT_LS_PROTOBUF_SUPPORT_ENABLED = "java.jdt.ls.protobufSupport.enabled";
+
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting";
@@ -570,6 +572,7 @@ public class Preferences {
 	private List<String> inlayHintsExclusionList;
 	private ProjectEncodingMode projectEncoding;
 	private boolean avoidVolatileChanges;
+	private boolean protobufSupportEnabled;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -1078,6 +1081,8 @@ public class Preferences {
 		prefs.setProjectEncoding(ProjectEncodingMode.fromString(projectEncoding, ProjectEncodingMode.IGNORE));
 		boolean avoidVolatileChanges = getBoolean(configuration, JAVA_CODEACTION_SORTMEMBER_AVOIDVOLATILECHANGES, true);
 		prefs.setAvoidVolatileChanges(avoidVolatileChanges);
+		boolean protobufSupported = getBoolean(configuration, JAVA_JDT_LS_PROTOBUF_SUPPORT_ENABLED, false);
+		prefs.setProtobufSupportEnabled(protobufSupported);
 		return prefs;
 	}
 
@@ -1907,4 +1912,12 @@ public class Preferences {
 	public boolean getAvoidVolatileChanges() {
 		return this.avoidVolatileChanges;
 	}
+	public boolean isProtobufSupportEnabled() {
+		return protobufSupportEnabled;
+	}
+
+	public void setProtobufSupportEnabled(boolean protobufSupportEnabled) {
+		this.protobufSupportEnabled = protobufSupportEnabled;
+	}
+
 }

--- a/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.19'
+
+    }
+}
+
+apply plugin: 'java'
+apply plugin: "com.google.protobuf"
+apply plugin: 'eclipse'
+
+group 'com.jdtls.protobuf.test'
+version '1.0-SNAPSHOT'
+sourceCompatibility = '11'
+
+repositories {
+    mavenCentral()
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/settings.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'protobuf'

--- a/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/src/main/java/Library.java
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/src/main/java/Library.java
@@ -1,0 +1,5 @@
+public class Library {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}


### PR DESCRIPTION
A Gradle init script is added as a patch to automatically add Protobuf
output source directories to clsspath. The script works for Gradle
'com.google.protobuf' plugin 0.8.4 or higher.

The init script will be extracted as a sibling file of the bundle jars.

As a side effect, the Protobuf output source directories will be created
beforehand, due to an issue of Buildship.
See: https://github.com/eclipse/buildship/issues/1196.


#### Related issues
This should mitigate some complains about protobuf support:
- https://github.com/eclipse/eclipse.jdt.ls/issues/1667
- https://github.com/redhat-developer/vscode-java/issues/1482
- https://github.com/redhat-developer/vscode-java/issues/177#issuecomment-530638362

I also raised a PR at the protobuf plugin repo to support Eclipse classpath: https://github.com/google/protobuf-gradle-plugin/pull/596.

#### How to test this PR
1. Import https://github.com/square/retrofit
2. the protobuf output directories are automatically added into the sub module: `retrofit-converters/protobuf`'s .classpath file.
3. Run `./gradlew generateTestProto`, those type not found errors disappear.

requires: https://github.com/redhat-developer/vscode-java/pull/2629

Signed-off-by: sheche <sheche@microsoft.com>