### PR TITLE
Rename Gradle project name when conflict

### DIFF
--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -9,5 +9,6 @@ bin.includes = META-INF/,\
                plugin.properties,\
                gradle/checksums/checksums.json,\
                gradle/checksums/versions.json,\
-               gradle/protobuf/init.gradle
+               gradle/protobuf/init.gradle,\
+               gradle/init/init.gradle
 src.includes = src/

--- a/org.eclipse.jdt.ls.core/gradle/init/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/init/init.gradle
@@ -1,0 +1,8 @@
+allprojects {
+    project.plugins.withId("eclipse", {
+        // Add prefix when project name has conflicts with root project name
+        if (project != rootProject && rootProject.name.toLowerCase() == project.name.toLowerCase()) {
+            eclipse.project.name = (rootProject.name + project.path).replaceAll(':', '-')
+        }
+    })
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/nameConflict/nameconflict/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/nameConflict/nameconflict/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'application'
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/nameConflict/settings.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/nameConflict/settings.gradle
@@ -1,0 +1,1 @@
+include ':nameconflict'


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

related to https://github.com/microsoft/vscode-java-pack/issues/1040

When we open a Gradle project having the same name in the rootfolder and subfolder, the language server will report the following error:

![image](https://user-images.githubusercontent.com/45906942/185275462-d8f2aa93-3f56-4283-946c-3ecd95903ed4.png)

The root cause is that eclipse resource system doesn't allow the duplicate names, so the proposal here is that we can rename the project name with `${rootProject.name}-${project.path}` when conflicts are detected. The new project name looks like this:

![image](https://user-images.githubusercontent.com/45906942/185275973-2da73db6-6512-44f0-9523-352a081d593b.png)

TODOs:

- [x] Will add test cases later.
- [x] This PR uses a similar Gradle init mechanism with #2189 so will rebase after it gets merged.