### PR TITLE
Ask to run generate proto tasks after projects are imported

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -50,6 +50,7 @@ Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.
  org.eclipse.jdt.ls.core.internal.javadoc;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.lsp;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.managers;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
+ org.eclipse.jdt.ls.core.internal.framework.protobuf;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.preferences;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
  org.eclipse.jdt.ls.core.internal.semantictokens;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.syntaxserver;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver",

--- a/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
@@ -41,6 +41,8 @@ class ProtobufPatchPlugin implements Plugin<Project> {
 
     private static final String GRADLE_USED_BY_SCOPE = "gradle_used_by_scope"
 
+    private static final String PROTOBUF_GENERATED_SOURCE = "protobuf_generated_source"
+
     @Override
     void apply(Project project) {
         project.afterEvaluate {
@@ -80,6 +82,7 @@ class ProtobufPatchPlugin implements Plugin<Project> {
                                 }
 
                                 SourceFolder entry = new SourceFolder(relativePath, getOutputPath(cp, sourceSetName))
+                                entry.entryAttributes.put(PROTOBUF_GENERATED_SOURCE, "true")
                                 entry.entryAttributes.put(OPTIONAL, "true")
                                 entry.entryAttributes.put(IGNORE_OPTIONAL_PROBLEMS, "true")
 

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -106,6 +106,9 @@
             <command
             	  id="java.project.resolveWorkspaceSymbol">
     	    </command>
+            <command
+                  id="java.protobuf.generateSources">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2020 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,6 +23,7 @@ import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.OrganizeImportsCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions;
+import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.jdt.ls.core.internal.commands.TypeHierarchyCommand;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
@@ -127,6 +128,10 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 				case "java.project.resolveWorkspaceSymbol":
 					SymbolInformation si = JSONUtility.toModel(arguments.get(0), SymbolInformation.class);
 					return ProjectCommand.resolveWorkspaceSymbol(si);
+				case "java.protobuf.generateSources":
+					ArrayList<String> projectUris = (ArrayList<String>) arguments.get(0);
+					ProtobufSupport.generateProtobufSources(projectUris, monitor);
+					return null;
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/IFrameworkSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/IFrameworkSupport.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.framework;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+
+/**
+ * Interface class for framework support.
+ */
+public interface IFrameworkSupport {
+    /**
+	 * Tasks can be executed here after projects import finished.
+	 * @param monitor progress monitor
+	 */
+    void onDidProjectsImported(IProgressMonitor monitor);
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
@@ -160,19 +160,11 @@ public class ProtobufSupport implements IFrameworkSupport {
 		progressReport.setStatus("Generating Java sources from proto files...");
 		client.sendProgressReport(progressReport);
 		try {
-			boolean succeeded = false;
 			for (String projectUri : projectUris) {
 				if (!StringUtils.isEmpty(projectUri)) {
-					succeeded = runGenerateProtobufTasks(projectUri, monitor);
+					 runGenerateProtobufTasks(projectUri, monitor);
 				}
 				progressReport.setWorkDone(progressReport.getWorkDone() + 1);
-			}
-
-			if (!succeeded) {
-				ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Error)
-						.withMessage("Exception happens when generating source files, please open logs for details.")
-						.withCommands(Arrays.asList(new Command("Open", "java.open.serverLog")));
-				client.sendActionableNotification(notification);
 			}
 		} finally {
 			progressReport.setComplete(true);
@@ -185,7 +177,7 @@ public class ProtobufSupport implements IFrameworkSupport {
 	 * @param projectUri uri of the project.
 	 * @param monitor progress monitor.
 	 */
-	private static boolean runGenerateProtobufTasks(String projectUri, IProgressMonitor monitor) {
+	private static void runGenerateProtobufTasks(String projectUri, IProgressMonitor monitor) {
 		Path dir = Path.of(URI.create(projectUri));
 		BuildConfiguration configuration = GradleProjectImporter.getBuildConfiguration(dir);
 		GradleBuild build = GradleCore.getWorkspace().createBuild(configuration);
@@ -197,8 +189,6 @@ public class ProtobufSupport implements IFrameworkSupport {
 			}, monitor);
 		} catch (Exception e) {
 			JavaLanguageServerPlugin.logException(e);
-			return false;
 		}
-		return true;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -108,8 +109,8 @@ public class ProtobufSupport implements IFrameworkSupport {
 					continue;
 				}
 				for (IClasspathAttribute attribute : entry.getExtraAttributes()) {
-					if (attribute.getName().equals(PROTOBUF_GENERATED_SOURCE)
-							&& attribute.getValue().equals("true")) {
+					if (Objects.equals(attribute.getName(), PROTOBUF_GENERATED_SOURCE)
+							&& Objects.equals(attribute.getValue(), "true")) {
 						protobufOutputDirs.add(new File(project.getLocation().toFile(),
 								entry.getPath().removeFirstSegments(1).toString()));
 					}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupport.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.framework.protobuf;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.buildship.core.BuildConfiguration;
+import org.eclipse.buildship.core.GradleBuild;
+import org.eclipse.buildship.core.GradleCore;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.ActionableNotification;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProgressReport;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.framework.IFrameworkSupport;
+import org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.MessageType;
+
+public class ProtobufSupport implements IFrameworkSupport {
+
+	/**
+	 * The classpath entry attribute which will be added for the protobuf source output directories.
+	 */
+	public static final String PROTOBUF_GENERATED_SOURCE = "protobuf_generated_source";
+
+	@Override
+	public void onDidProjectsImported(IProgressMonitor monitor) {
+		PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
+		if (preferencesManager == null) {
+			return;
+		}
+
+		if (!preferencesManager.getPreferences().isProtobufSupportEnabled()) {
+			return;
+		}
+
+		List<IProject> projects = ProjectUtils.getGradleProjects();
+		if (projects.isEmpty()) {
+			return;
+		}
+
+		List<Object> projectUris = new ArrayList<>();
+		for (IProject project : projects) {
+			if (!ProjectUtils.isJavaProject(project)) {
+				continue;
+			}
+
+			Set<File> protobufOutputDirs = findProtobufOutputDirectories(project);
+			if (protobufOutputDirs.isEmpty()) {
+				continue;
+			}
+
+			boolean hasGenerated = containsJavaFiles(protobufOutputDirs);
+			if (!hasGenerated) {
+				projectUris.add(project.getLocationURI().toString());
+			}
+		}
+		if (!projectUris.isEmpty()) {
+			ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Info)
+					.withMessage("Would you like to generate Java source files out of your proto files?")
+					.withCommands(Arrays.asList(new Command("Yes", "java.protobuf.generateSources", Arrays.asList(projectUris))));
+			JavaLanguageServerPlugin.getProjectsManager().getConnection().sendActionableNotification(notification);
+		}
+	}
+	
+	/**
+	 * Find all the Protobuf source output directories of the given project.
+	 * @param project project.
+	 */
+	private Set<File> findProtobufOutputDirectories(IProject project) {
+		IJavaProject javaProject = JavaCore.create(project);
+		Set<File> protobufOutputDirs = new HashSet<>();
+		try {
+			for (IClasspathEntry entry : javaProject.getRawClasspath()) {
+				if (entry.getEntryKind() != IClasspathEntry.CPE_SOURCE) {
+					continue;
+				}
+				for (IClasspathAttribute attribute : entry.getExtraAttributes()) {
+					if (attribute.getName().equals(PROTOBUF_GENERATED_SOURCE)
+							&& attribute.getValue().equals("true")) {
+						protobufOutputDirs.add(new File(project.getLocation().toFile(),
+								entry.getPath().removeFirstSegments(1).toString()));
+					}
+				}
+			}
+		} catch (JavaModelException e) {
+			JavaLanguageServerPlugin.log(e);
+		}
+		return protobufOutputDirs;
+	}
+
+	/**
+	 * Check if any of the input directories contains Java source files.
+	 * @param generatedDirectories directories to check.
+	 */
+	private boolean containsJavaFiles(Set<File> generatedDirectories) {
+		for (File dir : generatedDirectories) {
+			if (!dir.exists()) {
+				return false;
+			}
+
+			try (Stream<Path> walkStream = Files.walk(dir.toPath())) {
+				boolean containsJavaFile = walkStream.filter(p -> p.toFile().isFile()).anyMatch(f -> {
+					return f.toString().endsWith(".java");
+				});
+
+				if (containsJavaFile) {
+					return true;
+				}
+			} catch (IOException e) {
+				JavaLanguageServerPlugin.logException(e);
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Run generate proto tasks.
+	 * @param projectUris the project uris where the tasks will be executed.
+	 * @param monitor progress monitor.
+	 */
+	public static void generateProtobufSources(List<String> projectUris, IProgressMonitor monitor) {
+		JavaLanguageClient client = JavaLanguageServerPlugin.getProjectsManager().getConnection();
+		ProgressReport progressReport = new ProgressReport(UUID.randomUUID().toString());
+		progressReport.setTask("Running Gradle tasks");
+		progressReport.setComplete(false);
+		progressReport.setTotalWork(projectUris.size());
+		progressReport.setStatus("Generating Java sources from proto files...");
+		client.sendProgressReport(progressReport);
+		try {
+			boolean succeeded = false;
+			for (String projectUri : projectUris) {
+				if (!StringUtils.isEmpty(projectUri)) {
+					succeeded = runGenerateProtobufTasks(projectUri, monitor);
+				}
+				progressReport.setWorkDone(progressReport.getWorkDone() + 1);
+			}
+
+			if (!succeeded) {
+				ActionableNotification notification = new ActionableNotification().withSeverity(MessageType.Error)
+						.withMessage("Exception happens when generating source files, please open logs for details.")
+						.withCommands(Arrays.asList(new Command("Open", "java.open.serverLog")));
+				client.sendActionableNotification(notification);
+			}
+		} finally {
+			progressReport.setComplete(true);
+			client.sendProgressReport(progressReport);
+		}
+	}
+
+	/**
+	 * Run the Gradle task 'generateProto' & 'generateTestProto' under the uri.
+	 * @param projectUri uri of the project.
+	 * @param monitor progress monitor.
+	 */
+	private static boolean runGenerateProtobufTasks(String projectUri, IProgressMonitor monitor) {
+		Path dir = Path.of(URI.create(projectUri));
+		BuildConfiguration configuration = GradleProjectImporter.getBuildConfiguration(dir);
+		GradleBuild build = GradleCore.getWorkspace().createBuild(configuration);
+
+		try {
+			build.withConnection(connection -> {
+				connection.newBuild().forTasks("generateProto", "generateTestProto").run();
+				return null; 
+			}, monitor);
+		} catch (Exception e) {
+			JavaLanguageServerPlugin.logException(e);
+			return false;
+		}
+		return true;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -286,6 +286,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 
 					client.sendStatus(ServiceStatus.ServiceReady, "ServiceReady");
 					status = ServiceStatus.ServiceReady;
+					pm.projectsImported(monitor);
 				} catch (OperationCanceledException | CoreException e) {
 					logException(e.getMessage(), e);
 					return Status.CANCEL_STATUS;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IProjectsManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2020 Microsoft Corporation and others.
+* Copyright (c) 2020-2022 Microsoft Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License 2.0
 * which accompanies this distribution, and is available at
@@ -91,4 +91,11 @@ public interface IProjectsManager {
 	default void unregisterListeners() {
 		// do nothing
 	};
+
+	/**
+	 * Executed after the projects are imported.
+	 */
+	default void projectsImported(IProgressMonitor monitor) {
+		// do nothing
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2019 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -78,6 +78,8 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.framework.IFrameworkSupport;
+import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
 import org.eclipse.jdt.ls.core.internal.preferences.IPreferencesChangeListener;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -628,5 +630,12 @@ public class StandardProjectsManager extends ProjectsManager {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}
 		});
+	}
+
+	@Override
+	public void projectsImported(IProgressMonitor monitor) {
+		// TODO: consider to register as a extension point once we have multiple frameworks to support.
+		IFrameworkSupport protobufSupport = new ProtobufSupport();
+		protobufSupport.onDidProjectsImported(monitor);
 	}
 }

--- a/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/build.gradle
@@ -19,3 +19,9 @@ sourceCompatibility = '11'
 repositories {
     mavenCentral()
 }
+
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.21.4'
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/src/main/proto/simple.proto
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/protobuf/src/main/proto/simple.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Message {
+  int32 id = 1;
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupportTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.ls.core.internal.framework.protobuf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,10 +62,6 @@ public class ProtobufSupportTest extends AbstractGradleBasedTest {
 
 		waitForBackgroundJobs();
 
-		// generating protobuf source files need java compiler, in the test env,
-		// the task execution will fail, so we test if the failure notification
-		// is sent to client.
-		List<Object> notifications = this.clientRequests.get("sendActionableNotification");
-		assertEquals(1, notifications.size());
+		assertTrue(project.getFile("build/extracted-protos").getLocation().toFile().exists());
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupportTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/framework/protobuf/ProtobufSupportTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.framework.protobuf;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractGradleBasedTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProtobufSupportTest extends AbstractGradleBasedTest {
+
+	@Before
+	public void setUp() {
+		JavaLanguageServerPlugin.getProjectsManager().setConnection(this.client);
+		this.preferences.setProtobufSupportEnabled(true);
+	}
+
+	@After
+	public void tearDown() {
+		JavaLanguageServerPlugin.getProjectsManager().setConnection(null);
+		this.preferences.setProtobufSupportEnabled(false);
+	}
+
+	@Test
+	public void testAfterImportsForProtobuf() throws Exception {
+		importGradleProject("protobuf");
+
+		ProtobufSupport protobufSupport = new ProtobufSupport();
+		protobufSupport.onDidProjectsImported(new NullProgressMonitor());
+		waitForBackgroundJobs();
+
+		List<Object> notifications = this.clientRequests.get("sendActionableNotification");
+		assertEquals(1, notifications.size());
+	}
+	
+	@Test
+	public void testGenerateProtobufSources() throws Exception {
+		IProject project = importGradleProject("protobuf");
+
+		String uriString = project.getLocationURI().toString();
+		ProtobufSupport.generateProtobufSources(Arrays.asList(uriString), new NullProgressMonitor());
+
+		waitForBackgroundJobs();
+
+		// generating protobuf source files need java compiler, in the test env,
+		// the task execution will fail, so we test if the failure notification
+		// is sent to client.
+		List<Object> notifications = this.clientRequests.get("sendActionableNotification");
+		assertEquals(1, notifications.size());
+	}
+}


### PR DESCRIPTION
After projects are imported, check if any of the projects contains the
classpath entry having 'protobuf_generated_source' attribute and is empty.

If we found such projects, ask users to run 'generateProto' and `generateTestProto`
Gradle tasks to generate those Java source files.

#### How to test this PR
1. Import https://github.com/square/retrofit
2. If the protobuf output sources haven't been generated, a notification will be popped up to ask user to generate.
3. If it has been generated, nothing happens.

Signed-off-by: Sheng Chen <sheche@microsoft.com>