### PR TITLE
Listening to changes of Android preferences

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradlePreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradlePreferenceChangeListener.java
@@ -54,6 +54,13 @@ public class GradlePreferenceChangeListener implements IPreferencesChangeListene
 					projectsManager.updateProject(project, true);
 				}
 			}
+
+			boolean androidSupportChanged = !Objects.equals(oldPreferences.isAndroidSupportEnabled(), newPreferences.isAndroidSupportEnabled());
+			if (androidSupportChanged) {
+				for (IProject project : ProjectUtils.getGradleProjects()) {
+					projectsManager.updateProject(project, true);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

When the android support enable preferences changed, we should force update all Gradle project to apply these changes.
