### PR TITLE
Add tests for signature help on record class

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -156,7 +156,6 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 		}
 
 		char[] signature = SignatureUtil.fix83600(methodProposal.getSignature());
-		// todo: cannot get parameter names for record class
 		char[][] parameterNames = methodProposal.findParameterNames(null);
 		char[][] parameterTypes = Signature.getParameterTypes(signature);
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpUtils.java
@@ -231,10 +231,6 @@ public class SignatureHelpUtils {
 			return;
 		}
 
-		if (typeBinding.isRecord()) {
-			// todo: support record
-			return;
-		}
 		IType type = (IType) typeBinding.getJavaElement();
 		if (type == null) {
 			return;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.when;
 
 import java.net.URI;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -645,6 +647,18 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 
 		help = getSignatureHelp(cu, 3, 10);
 		assertEquals(1, help.getActiveParameter().intValue());
+	}
+
+	@Test
+	public void testSignatureHelp_record() throws Exception {
+		importProjects("eclipse/java16");
+		IProject proj = WorkspaceHelper.getProject("java16");
+		IJavaProject javaProject = JavaCore.create(proj);
+		ICompilationUnit unit = (ICompilationUnit) javaProject.findElement(new Path("foo/bar/Bar.java"));
+		SignatureHelp help = getSignatureHelp(unit, 9, 10);
+		assertNotNull(help);
+		SignatureInformation signature = help.getSignatures().get(help.getActiveSignature());
+		assertTrue(signature.getLabel().equals("Edge(int fromNodeId, int toNodeId, Object fromPoint, Object toPoint, double length, Object profile)"));
 	}
 
 	@Test


### PR DESCRIPTION
Today I just found out that the signature help works for record class now.

It was not working several months ago. Maybe this is thanks to @rgrunber's work in the upstream :)

So, I removed those todos and add a test for that.

Signed-off-by: Sheng Chen <sheche@microsoft.com>