### PR TITLE
Show toString()/hashCode() and equals() fields in definition order 

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
@@ -66,14 +66,14 @@ public class JdtDomModels {
 
 	public static IVariableBinding[] convertToVariableBindings(ITypeBinding typeBinding, LspVariableBinding[] fields) {
 		Set<String> bindingKeys = Stream.of(fields).map((field) -> field.bindingKey).collect(Collectors.toSet());
-		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new IVariableBindingComparator()).filter(f -> bindingKeys.contains(f.getKey())).toArray(IVariableBinding[]::new);
+		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new VariableBindingComparator()).filter(f -> bindingKeys.contains(f.getKey())).toArray(IVariableBinding[]::new);
 	}
 
 	public static LspVariableBinding[] getDeclaredFields(ITypeBinding typeBinding, boolean includeStatic) {
-		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new IVariableBindingComparator()).filter(f -> includeStatic || !Modifier.isStatic(f.getModifiers())).map(f -> new LspVariableBinding(f)).toArray(LspVariableBinding[]::new);
+		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new VariableBindingComparator()).filter(f -> includeStatic || !Modifier.isStatic(f.getModifiers())).map(f -> new LspVariableBinding(f)).toArray(LspVariableBinding[]::new);
 	}
 
-	public static class IVariableBindingComparator implements Comparator<IVariableBinding> {
+	public static class VariableBindingComparator implements Comparator<IVariableBinding> {
 		@Override
 		public int compare(IVariableBinding a, IVariableBinding b) {
 			try {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JdtDomModels.java
@@ -14,14 +14,17 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
 
 public class JdtDomModels {
 
@@ -63,10 +66,21 @@ public class JdtDomModels {
 
 	public static IVariableBinding[] convertToVariableBindings(ITypeBinding typeBinding, LspVariableBinding[] fields) {
 		Set<String> bindingKeys = Stream.of(fields).map((field) -> field.bindingKey).collect(Collectors.toSet());
-		return Arrays.stream(typeBinding.getDeclaredFields()).filter(f -> bindingKeys.contains(f.getKey())).toArray(IVariableBinding[]::new);
+		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new IVariableBindingComparator()).filter(f -> bindingKeys.contains(f.getKey())).toArray(IVariableBinding[]::new);
 	}
 
 	public static LspVariableBinding[] getDeclaredFields(ITypeBinding typeBinding, boolean includeStatic) {
-		return Arrays.stream(typeBinding.getDeclaredFields()).filter(f -> includeStatic || !Modifier.isStatic(f.getModifiers())).map(f -> new LspVariableBinding(f)).toArray(LspVariableBinding[]::new);
+		return Arrays.stream(typeBinding.getDeclaredFields()).sorted(new IVariableBindingComparator()).filter(f -> includeStatic || !Modifier.isStatic(f.getModifiers())).map(f -> new LspVariableBinding(f)).toArray(LspVariableBinding[]::new);
+	}
+
+	public static class IVariableBindingComparator implements Comparator<IVariableBinding> {
+		@Override
+		public int compare(IVariableBinding a, IVariableBinding b) {
+			try {
+				return JDTUtils.getNameRange(a.getJavaElement()).getOffset() - JDTUtils.getNameRange(b.getJavaElement()).getOffset();
+			} catch (JavaModelException e) {
+				return 0;
+			}
+		}
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandlerTest.java
@@ -125,7 +125,60 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 				"	String[] arrays;\r\n" +
 				"	@Override\r\n" +
 				"	public String toString() {\r\n" +
-				"		return \"B [aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \", id=\" + id + \", name=\" + name + \"]\";\r\n" +
+				"		return \"B [name=\" + name + \", id=\" + id + \", aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \"]\";\r\n" +
+				"	}\r\n" +
+				"}";
+		/* @formatter:on */
+
+		compareSource(expected, unit.getSource());
+	}
+
+	@Test
+	public void testGenerateToStringOrder() throws ValidateEditException, CoreException, IOException {
+		//@formatter:off
+		ICompilationUnit unit = fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
+				"\r\n" +
+				"public class B {\r\n" +
+				"	public String stringField;\r\n" +
+				"	public int intField;\r\n" +
+				"	public static int staticIntField;\r\n" +
+				"	public boolean booleanField;\r\n" +
+				"}"
+				, true, null);
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "String stringField");
+		CheckToStringResponse response = GenerateToStringHandler.checkToStringStatus(params);
+		assertEquals("B", response.type);
+		assertNotNull(response.fields);
+		assertEquals(3, response.fields.length);
+		assertFalse(response.exists);
+		assertEquals("stringField", response.fields[0].name);
+		assertEquals("intField", response.fields[1].name);
+		assertEquals("booleanField", response.fields[2].name);
+
+		ToStringGenerationSettingsCore settings = new ToStringGenerationSettingsCore();
+		settings.overrideAnnotation = true;
+		settings.createComments = false;
+		settings.useBlocks = false;
+		settings.stringFormatTemplate = GenerateToStringHandler.DEFAULT_TEMPLATE;
+		settings.toStringStyle = GenerateToStringOperation.STRING_CONCATENATION;
+		settings.skipNulls = false;
+		settings.customArrayToString = true;
+		settings.limitElements = false;
+		settings.customBuilderSettings = new CustomBuilderSettings();
+		generateToString(unit.findPrimaryType(), settings);
+
+		/* @formatter:off */
+		String expected = "package p;\r\n" +
+				"\r\n" +
+				"public class B {\r\n" +
+				"	public String stringField;\r\n" +
+				"	public int intField;\r\n" +
+				"	public static int staticIntField;\r\n" +
+				"	public boolean booleanField;\r\n" +
+				"	@Override\r\n" +
+				"	public String toString() {\r\n" +
+				"		return \"B [stringField=\" + stringField + \", intField=\" + intField + \", booleanField=\" + booleanField + \"]\";\r\n" +
 				"	}\r\n" +
 				"}";
 		/* @formatter:on */
@@ -184,15 +237,15 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 				"		final int maxLen = 10;\r\n" +
 				"		StringBuilder builder = new StringBuilder();\r\n" +
 				"		builder.append(\"B [\");\r\n" +
+				"		if (name != null) {\r\n" +
+				"			builder.append(\"name=\").append(name).append(\", \");\r\n" +
+				"		}\r\n" +
+				"		builder.append(\"id=\").append(id).append(\", \");\r\n" +
 				"		if (aList != null) {\r\n" +
 				"			builder.append(\"aList=\").append(aList.subList(0, Math.min(aList.size(), maxLen))).append(\", \");\r\n" +
 				"		}\r\n" +
 				"		if (arrays != null) {\r\n" +
-				"			builder.append(\"arrays=\").append(arrays).append(\", \");\r\n" +
-				"		}\r\n" +
-				"		builder.append(\"id=\").append(id).append(\", \");\r\n" +
-				"		if (name != null) {\r\n" +
-				"			builder.append(\"name=\").append(name);\r\n" +
+				"			builder.append(\"arrays=\").append(arrays);\r\n" +
 				"		}\r\n" +
 				"		builder.append(\"]\");\r\n" +
 				"		return builder.toString();\r\n" +
@@ -248,7 +301,7 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 					"	List<String> aList;/*|*/\r\n" +
 					"	@Override\r\n" +
 					"	public String toString() {\r\n" +
-					"		return \"B [aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \", id=\" + id + \", name=\" + name + \"]\";\r\n" +
+					"		return \"B [name=\" + name + \", id=\" + id + \", aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \"]\";\r\n" +
 					"	}\r\n" +
 					"	String[] arrays;\r\n" +
 					"}";
@@ -304,7 +357,7 @@ public class GenerateToStringHandlerTest extends AbstractSourceTestCase {
 					"	int id;\r\n" +
 					"	@Override\r\n" +
 					"	public String toString() {\r\n" +
-					"		return \"B [aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \", id=\" + id + \", name=\" + name + \"]\";\r\n" +
+					"		return \"B [name=\" + name + \", id=\" + id + \", aList=\" + aList + \", arrays=\" + (arrays != null ? Arrays.asList(arrays) : null) + \"]\";\r\n" +
 					"	}\r\n" +
 					"	List<String> aList;/*|*/\r\n" +
 					"	String[] arrays;\r\n" +

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandlerTest.java
@@ -122,13 +122,13 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	public int hashCode() {\r\n" +
 				"		final int prime = 31;\r\n" +
 				"		int result = 1;\r\n" +
-				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-				"		result = prime * result + id;\r\n" +
 				"		result = prime * result + ((name == null) ? 0 : name.hashCode());\r\n" +
+				"		result = prime * result + id;\r\n" +
 				"		long temp;\r\n" +
 				"		temp = Double.doubleToLongBits(rate);\r\n" +
 				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
+				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
+				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
@@ -140,21 +140,21 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		if (getClass() != obj.getClass())\r\n" +
 				"			return false;\r\n" +
 				"		B other = (B) obj;\r\n" +
-				"		if (aList == null) {\r\n" +
-				"			if (other.aList != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aList.equals(other.aList))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
-				"			return false;\r\n" +
-				"		if (id != other.id)\r\n" +
-				"			return false;\r\n" +
 				"		if (name == null) {\r\n" +
 				"			if (other.name != null)\r\n" +
 				"				return false;\r\n" +
 				"		} else if (!name.equals(other.name))\r\n" +
 				"			return false;\r\n" +
+				"		if (id != other.id)\r\n" +
+				"			return false;\r\n" +
 				"		if (Double.doubleToLongBits(rate) != Double.doubleToLongBits(other.rate))\r\n" +
+				"			return false;\r\n" +
+				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
+				"			return false;\r\n" +
+				"		if (aList == null) {\r\n" +
+				"			if (other.aList != null)\r\n" +
+				"				return false;\r\n" +
+				"		} else if (!aList.equals(other.aList))\r\n" +
 				"			return false;\r\n" +
 				"		return true;\r\n" +
 				"	}\r\n" +
@@ -202,7 +202,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		final int prime = 31;\r\n" +
 				"		int result = 1;\r\n" +
 				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-				"		result = prime * result + Objects.hash(aList, id, name, rate);\r\n" +
+				"		result = prime * result + Objects.hash(name, id, rate, aList);\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
@@ -214,8 +214,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		if (getClass() != obj.getClass())\r\n" +
 				"			return false;\r\n" +
 				"		B other = (B) obj;\r\n" +
-				"		return Objects.equals(aList, other.aList) && Arrays.deepEquals(anArray, other.anArray) && id == other.id "
-				+ "&& Objects.equals(name, other.name) && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate);\r\n" +
+				"		return Objects.equals(name, other.name) && id == other.id && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate) && Arrays.deepEquals(anArray, other.anArray) && Objects.equals(aList, other.aList);\r\n" +
 				"	}\r\n" +
 				"}";
 		/* @formatter:on */
@@ -259,13 +258,13 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	public int hashCode() {\r\n" +
 				"		final int prime = 31;\r\n" +
 				"		int result = 1;\r\n" +
-				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-				"		result = prime * result + id;\r\n" +
 				"		result = prime * result + ((name == null) ? 0 : name.hashCode());\r\n" +
+				"		result = prime * result + id;\r\n" +
 				"		long temp;\r\n" +
 				"		temp = Double.doubleToLongBits(rate);\r\n" +
 				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
+				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
+				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
@@ -275,21 +274,21 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		if (!(obj instanceof B))\r\n" +
 				"			return false;\r\n" +
 				"		B other = (B) obj;\r\n" +
-				"		if (aList == null) {\r\n" +
-				"			if (other.aList != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aList.equals(other.aList))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
-				"			return false;\r\n" +
-				"		if (id != other.id)\r\n" +
-				"			return false;\r\n" +
 				"		if (name == null) {\r\n" +
 				"			if (other.name != null)\r\n" +
 				"				return false;\r\n" +
 				"		} else if (!name.equals(other.name))\r\n" +
 				"			return false;\r\n" +
+				"		if (id != other.id)\r\n" +
+				"			return false;\r\n" +
 				"		if (Double.doubleToLongBits(rate) != Double.doubleToLongBits(other.rate))\r\n" +
+				"			return false;\r\n" +
+				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
+				"			return false;\r\n" +
+				"		if (aList == null) {\r\n" +
+				"			if (other.aList != null)\r\n" +
+				"				return false;\r\n" +
+				"		} else if (!aList.equals(other.aList))\r\n" +
 				"			return false;\r\n" +
 				"		return true;\r\n" +
 				"	}\r\n" +
@@ -335,13 +334,13 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	public int hashCode() {\r\n" +
 				"		final int prime = 31;\r\n" +
 				"		int result = 1;\r\n" +
-				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-				"		result = prime * result + id;\r\n" +
 				"		result = prime * result + ((name == null) ? 0 : name.hashCode());\r\n" +
+				"		result = prime * result + id;\r\n" +
 				"		long temp;\r\n" +
 				"		temp = Double.doubleToLongBits(rate);\r\n" +
 				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
+				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
+				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
@@ -356,19 +355,6 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"			return false;\r\n" +
 				"		}\r\n" +
 				"		B other = (B) obj;\r\n" +
-				"		if (aList == null) {\r\n" +
-				"			if (other.aList != null) {\r\n" +
-				"				return false;\r\n" +
-				"			}\r\n" +
-				"		} else if (!aList.equals(other.aList)) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		if (!Arrays.deepEquals(anArray, other.anArray)) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		if (id != other.id) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
 				"		if (name == null) {\r\n" +
 				"			if (other.name != null) {\r\n" +
 				"				return false;\r\n" +
@@ -376,7 +362,20 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		} else if (!name.equals(other.name)) {\r\n" +
 				"			return false;\r\n" +
 				"		}\r\n" +
+				"		if (id != other.id) {\r\n" +
+				"			return false;\r\n" +
+				"		}\r\n" +
 				"		if (Double.doubleToLongBits(rate) != Double.doubleToLongBits(other.rate)) {\r\n" +
+				"			return false;\r\n" +
+				"		}\r\n" +
+				"		if (!Arrays.deepEquals(anArray, other.anArray)) {\r\n" +
+				"			return false;\r\n" +
+				"		}\r\n" +
+				"		if (aList == null) {\r\n" +
+				"			if (other.aList != null) {\r\n" +
+				"				return false;\r\n" +
+				"			}\r\n" +
+				"		} else if (!aList.equals(other.aList)) {\r\n" +
 				"			return false;\r\n" +
 				"		}\r\n" +
 				"		return true;\r\n" +
@@ -427,13 +426,13 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"	public int hashCode() {\r\n" +
 				"		final int prime = 31;\r\n" +
 				"		int result = 1;\r\n" +
-				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-				"		result = prime * result + id;\r\n" +
 				"		result = prime * result + ((name == null) ? 0 : name.hashCode());\r\n" +
+				"		result = prime * result + id;\r\n" +
 				"		long temp;\r\n" +
 				"		temp = Double.doubleToLongBits(rate);\r\n" +
 				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
+				"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
+				"		result = prime * result + ((aList == null) ? 0 : aList.hashCode());\r\n" +
 				"		return result;\r\n" +
 				"	}\r\n" +
 				"	/* (non-Javadoc)\r\n" +
@@ -449,21 +448,21 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 				"		if (getClass() != obj.getClass())\r\n" +
 				"			return false;\r\n" +
 				"		B other = (B) obj;\r\n" +
-				"		if (aList == null) {\r\n" +
-				"			if (other.aList != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aList.equals(other.aList))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
-				"			return false;\r\n" +
-				"		if (id != other.id)\r\n" +
-				"			return false;\r\n" +
 				"		if (name == null) {\r\n" +
 				"			if (other.name != null)\r\n" +
 				"				return false;\r\n" +
 				"		} else if (!name.equals(other.name))\r\n" +
 				"			return false;\r\n" +
+				"		if (id != other.id)\r\n" +
+				"			return false;\r\n" +
 				"		if (Double.doubleToLongBits(rate) != Double.doubleToLongBits(other.rate))\r\n" +
+				"			return false;\r\n" +
+				"		if (!Arrays.deepEquals(anArray, other.anArray))\r\n" +
+				"			return false;\r\n" +
+				"		if (aList == null) {\r\n" +
+				"			if (other.aList != null)\r\n" +
+				"				return false;\r\n" +
+				"		} else if (!aList.equals(other.aList))\r\n" +
 				"			return false;\r\n" +
 				"		return true;\r\n" +
 				"	}\r\n" +
@@ -565,7 +564,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 					"		final int prime = 31;\r\n" +
 					"		int result = 1;\r\n" +
 					"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-					"		result = prime * result + Objects.hash(aList, id, name, rate);\r\n" +
+					"		result = prime * result + Objects.hash(name, id, rate, aList);\r\n" +
 					"		return result;\r\n" +
 					"	}\r\n" +
 					"	@Override\r\n" +
@@ -577,8 +576,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 					"		if (getClass() != obj.getClass())\r\n" +
 					"			return false;\r\n" +
 					"		B other = (B) obj;\r\n" +
-					"		return Objects.equals(aList, other.aList) && Arrays.deepEquals(anArray, other.anArray) && id == other.id "
-					+ "&& Objects.equals(name, other.name) && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate);\r\n" +
+					"		return Objects.equals(name, other.name) && id == other.id && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate) && Arrays.deepEquals(anArray, other.anArray) && Objects.equals(aList, other.aList);\r\n" +
 					"	}\r\n" +
 					"	int id;\r\n" +
 					"	double rate;\r\n" +
@@ -629,7 +627,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 					"		final int prime = 31;\r\n" +
 					"		int result = 1;\r\n" +
 					"		result = prime * result + Arrays.deepHashCode(anArray);\r\n" +
-					"		result = prime * result + Objects.hash(aList, id, name, rate);\r\n" +
+					"		result = prime * result + Objects.hash(name, id, rate, aList);\r\n" +
 					"		return result;\r\n" +
 					"	}\r\n" +
 					"	@Override\r\n" +
@@ -641,8 +639,7 @@ public class HashCodeEqualsHandlerTest extends AbstractSourceTestCase {
 					"		if (getClass() != obj.getClass())\r\n" +
 					"			return false;\r\n" +
 					"		B other = (B) obj;\r\n" +
-					"		return Objects.equals(aList, other.aList) && Arrays.deepEquals(anArray, other.anArray) && id == other.id "
-					+ "&& Objects.equals(name, other.name) && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate);\r\n" +
+					"		return Objects.equals(name, other.name) && id == other.id && Double.doubleToLongBits(rate) == Double.doubleToLongBits(other.rate) && Arrays.deepEquals(anArray, other.anArray) && Objects.equals(aList, other.aList);\r\n" +
 					"	}\r\n" +
 					"	String name;\r\n" +
 					"	int id;\r\n" +


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix https://github.com/redhat-developer/vscode-java/issues/2502

Sort IVariableBindings before return to the client/after receiving pick results from the client.