### PR TITLE
show generate toString()/hashCode() and equals() quick fixes on demand

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringHandler.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.jdt.ls.core.internal.handlers;
 
-import java.util.stream.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -38,6 +36,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
 import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.LspVariableBinding;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.eclipse.jdt.ls.core.internal.text.correction.CodeActionUtility;
 import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Range;
@@ -45,7 +44,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.text.edits.TextEdit;
 
 public class GenerateToStringHandler {
-	private static final String METHODNAME_TOSTRING = "toString";
+	public static final String METHODNAME_TOSTRING = "toString";
 	public static final String DEFAULT_TEMPLATE = "${object.className} [${member.name()}=${member.value}, ${otherMembers}]";
 
 	// For test purpose
@@ -79,7 +78,7 @@ public class GenerateToStringHandler {
 			if (typeBinding != null) {
 				response.type = type.getTypeQualifiedName();
 				response.fields = JdtDomModels.getDeclaredFields(typeBinding, false);
-				response.exists = Stream.of(typeBinding.getDeclaredMethods()).anyMatch(method -> method.getName().equals(METHODNAME_TOSTRING) && method.getParameterTypes().length == 0);
+				response.exists = CodeActionUtility.hasMethod(type, METHODNAME_TOSTRING);
 			}
 		} catch (JavaModelException e) {
 			JavaLanguageServerPlugin.logException("Failed to check toString status", e);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsHandler.java
@@ -43,8 +43,8 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.text.edits.TextEdit;
 
 public class HashCodeEqualsHandler {
-	private static final String METHODNAME_HASH_CODE = "hashCode";
-	private static final String METHODNAME_EQUALS = "equals";
+	public static final String METHODNAME_HASH_CODE = "hashCode";
+	public static final String METHODNAME_EQUALS = "equals";
 
 	// For test purpose
 	public static CheckHashCodeEqualsResponse checkHashCodeEqualsStatus(CodeActionParams params) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CodeActionUtility.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/CodeActionUtility.java
@@ -17,7 +17,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
@@ -127,5 +130,33 @@ public class CodeActionUtility {
 			return name.getIdentifier();
 		}
 		return null;
+	}
+
+	public static boolean hasMethod(IType type, String methodName, Class... parameterTypes) {
+		if (type == null) {
+			return false;
+		}
+		try {
+			return Stream.of(type.getMethods()).anyMatch(method -> {
+				if (!method.getElementName().equals(methodName)) {
+					return false;
+				}
+				if (method.getParameterTypes().length != parameterTypes.length) {
+					return false;
+				}
+				String[] parameterTypeNames = method.getParameterTypes();
+				if (parameterTypes.length != parameterTypeNames.length) {
+					return false;
+				}
+				for (int i = 0; i < parameterTypeNames.length; i++) {
+					if (parameterTypes[i].getName().equals(parameterTypeNames[i])) {
+						return false;
+					}
+				}
+				return true;
+			});
+		} catch (JavaModelException e) {
+			return false;
+		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/text/correction/SourceAssistProcessor.java
@@ -78,6 +78,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.GenerateConstructorsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateConstructorsHandler.CheckConstructorsResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateDelegateMethodsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.GenerateToStringHandler;
+import org.eclipse.jdt.ls.core.internal.handlers.HashCodeEqualsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JdtDomModels.LspVariableBinding;
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.CodeActionHandler.CodeActionData;
@@ -180,10 +181,11 @@ public class SourceAssistProcessor {
 			JavaLanguageServerPlugin.logException("Failed to generate Getter and Setter source action", e);
 		}
 
+		boolean hashCodeAndEqualsExists = CodeActionUtility.hasMethod(type, HashCodeEqualsHandler.METHODNAME_HASH_CODE) && CodeActionUtility.hasMethod(type, HashCodeEqualsHandler.METHODNAME_EQUALS, Object.class);
 		// Generate hashCode() and equals()
 		if (supportsHashCodeEquals(context, type, monitor)) {
 			// Generate QuickAssist
-			if (isInTypeDeclaration) {
+			if (isInTypeDeclaration && !hashCodeAndEqualsExists) {
 				Optional<Either<Command, CodeAction>> quickAssistHashCodeEquals = getHashCodeEqualsAction(params, JavaCodeActionKind.QUICK_ASSIST);
 				addSourceActionCommand($, params.getContext(), quickAssistHashCodeEquals);
 			}
@@ -194,6 +196,7 @@ public class SourceAssistProcessor {
 
 		}
 
+		boolean toStringExists = CodeActionUtility.hasMethod(type, GenerateToStringHandler.METHODNAME_TOSTRING);
 		// Generate toString()
 		if (supportsGenerateToString(type)) {
 			boolean nonStaticFields = true;
@@ -204,7 +207,7 @@ public class SourceAssistProcessor {
 			}
 			if (nonStaticFields) {
 				// Generate QuickAssist
-				if (isInTypeDeclaration) {
+				if (isInTypeDeclaration && !toStringExists) {
 					Optional<Either<Command, CodeAction>> generateToStringQuickAssist = getGenerateToStringAction(params, JavaCodeActionKind.QUICK_ASSIST);
 					addSourceActionCommand($, params.getContext(), generateToStringQuickAssist);
 				}
@@ -218,7 +221,7 @@ public class SourceAssistProcessor {
 					return convertToWorkspaceEdit(cu, edit);
 				};
 				// Generate QuickAssist
-				if (isInTypeDeclaration) {
+				if (isInTypeDeclaration && !toStringExists) {
 					Optional<Either<Command, CodeAction>> generateToStringQuickAssist = getCodeActionFromProposal(params.getContext(), context.getCompilationUnit(), ActionMessages.GenerateToStringAction_label,
 							JavaCodeActionKind.QUICK_ASSIST, generateToStringProposal, CodeActionComparator.GENERATE_TOSTRING_PRIORITY);
 					addSourceActionCommand($, params.getContext(), generateToStringQuickAssist);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
@@ -177,4 +177,23 @@ public class GenerateToStringActionTest extends AbstractCompilationUnitBasedTest
 		quickAssistActions = CodeActionHandlerTest.findActions(codeActions, JavaCodeActionKind.QUICK_ASSIST);
 		Assert.assertFalse(CodeActionHandlerTest.commandExists(quickAssistActions, CodeActionHandler.COMMAND_ID_APPLY_EDIT, ActionMessages.GenerateToStringAction_label));
 	}
+
+	@Test
+	public void testGenerateToStringQuickAssistExists() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	String name;\r\n" +
+				"   public String toString() {\r\n" +
+				"		return this.name;\r\n" +
+				"	}\r\n" +
+				"}"
+				, true, null);
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "A");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		Assert.assertNull(CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.QUICK_ASSIST, "Generate toString()..."));
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/GenerateToStringActionTest.java
@@ -179,7 +179,7 @@ public class GenerateToStringActionTest extends AbstractCompilationUnitBasedTest
 	}
 
 	@Test
-	public void testGenerateToStringQuickAssistExists() throws JavaModelException {
+	public void testNoGenerateToStringQuickAssist() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
 				"\r\n" +

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsActionTest.java
@@ -149,7 +149,7 @@ public class HashCodeEqualsActionTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testHashCodeEqualsQuickAssistExists() throws JavaModelException {
+	public void testNoHashCodeEqualsQuickAssist() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
 				"\r\n" +

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsActionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/HashCodeEqualsActionTest.java
@@ -147,4 +147,25 @@ public class HashCodeEqualsActionTest extends AbstractCompilationUnitBasedTest {
 		Assert.assertFalse(quickAssistActions.isEmpty());
 		Assert.assertFalse(CodeActionHandlerTest.commandExists(quickAssistActions, SourceAssistProcessor.COMMAND_ID_ACTION_HASHCODEEQUALSPROMPT));
 	}
+
+	@Test
+	public void testHashCodeEqualsQuickAssistExists() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	String name;\r\n" +
+				"   public int hashCode() {\r\n" +
+				"	}\r\n" +
+				"	public boolean equals(Object a) {\r\n" +
+				"		return true;\r\n" +
+				"	}\r\n" +
+				"}"
+				, true, null);
+		//@formatter:on
+		CodeActionParams params = CodeActionUtil.constructCodeActionParams(unit, "A");
+		List<Either<Command, CodeAction>> codeActions = server.codeAction(params).join();
+		Assert.assertNotNull(codeActions);
+		Assert.assertNull(CodeActionHandlerTest.findAction(codeActions, JavaCodeActionKind.QUICK_ASSIST, "Generate hashCode() and equals()..."));
+	}
 }


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

This PR will detect the methods of the current type, and choose which quick fix to show.If the current type has corresponding:

-  toString() method without arguments, we do not show generate toString() in quick fixes
- hashCode() method without arguments **and** equals() method with an object argument, we do not show generate hashCode() and equals() in quick fixes

Please note that this change will not affect "Source Action" in the right click menu, the "Source Action" part will always show them in case of the user wants to override the methods anyway.