### PR TITLE
Remove -noverify option from JDT-LS startup script.

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -86,7 +86,6 @@ def main(args):
 		"-Dosgi.sharedConfiguration.area=" + str(shared_config_path),
 		"-Dosgi.sharedConfiguration.area.readOnly=true",
 		"-Dosgi.configuration.cascaded=true",
-		"-noverify",
 		"-Xms1G",
 		"--add-modules=ALL-SYSTEM",
 		"--add-opens", "java.base/java.util=ALL-UNNAMED",


### PR DESCRIPTION
- Option was deprecated in JDK 13
- Fixes #2221 

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>