### PR TITLE
Support creating module-info.java

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -104,10 +104,13 @@
                   id="java.project.upgradeGradle">
             </command>
             <command
-            	  id="java.project.resolveWorkspaceSymbol">
-    	    </command>
+                  id="java.project.resolveWorkspaceSymbol">
+            </command>
             <command
                   id="java.protobuf.generateSources">
+            </command>
+            <command
+                  id="java.project.createModuleInfo">
             </command>
       </delegateCommandHandler>
    </extension>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions
 import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.jdt.ls.core.internal.commands.TypeHierarchyCommand;
+import org.eclipse.jdt.ls.core.internal.handlers.CreateModuleInfoHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.ResolveSourceMappingHandler;
 import org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter;
@@ -131,6 +132,8 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 				case "java.protobuf.generateSources":
 					ProtobufSupport.generateProtobufSources((ArrayList<String>) arguments.get(0), monitor);
 					return null;
+				case "java.project.createModuleInfo":
+					return CreateModuleInfoHandler.createModuleInfo((String) arguments.get(0), monitor);
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProjectUtils.java
@@ -634,7 +634,11 @@ public final class ProjectUtils {
 		return projects;
 	}
 
-	private static IProject getProjectFromUri(String uri) {
+	/**
+	 * Get <code>IProject</code> from a uri string. Or <code>null</code> if cannot find any project from the given uri.
+	 * @param uri uri string
+	 */
+	public static IProject getProjectFromUri(String uri) {
 		IPath uriPath = ResourceUtils.canonicalFilePathFromURI(uri);
 		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
 		for (IProject project : projects) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandler.java
@@ -1,0 +1,234 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.lsp4j.MessageType;
+
+/**
+ * The handler to create module-info.java
+ * Also see: org.eclipse.jdt.internal.ui.actions.CreateModuleInfoAction
+ *           org.eclipse.jdt.internal.ui.wizards.NewModuleInfoWizard
+ */
+public class CreateModuleInfoHandler {
+
+	/**
+	 * Create the module-info.java for given project.
+	 * @param projectUri uri of the project.
+	 * @param monitor progress monitor.
+	 * @return the created module-info.java file uri.
+	 */
+	public static String createModuleInfo(String projectUri, IProgressMonitor monitor) {
+		IProject project = ProjectUtils.getProjectFromUri(projectUri);
+		if (!ProjectUtils.isJavaProject(project)) {
+			JavaLanguageServerPlugin.getInstance().getClientConnection().showNotificationMessage(MessageType.Error, "The selected project is not a valid Java project.");
+			return null;
+		}
+
+		IJavaProject javaProject = JavaCore.create(project);
+		if (!JavaModelUtil.is9OrHigher(javaProject)) {
+			JavaLanguageServerPlugin.getInstance().getClientConnection().showNotificationMessage(MessageType.Error, "The project source compliance must be 9 or higher to create module-info.java.");
+			return null;
+		}
+
+		try {
+			IPackageFragmentRoot[] packageFragmentRoots = javaProject.getPackageFragmentRoots();
+			List<IPackageFragmentRoot> packageFragmentRootsAsList = new ArrayList<>(Arrays.asList(packageFragmentRoots));
+			for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+				IResource res = packageFragmentRoot.getCorrespondingResource();
+				if (res == null || res.getType() != IResource.FOLDER || packageFragmentRoot.getKind() != IPackageFragmentRoot.K_SOURCE) {
+					packageFragmentRootsAsList.remove(packageFragmentRoot);
+				}
+			}
+
+			packageFragmentRoots = packageFragmentRootsAsList.toArray(new IPackageFragmentRoot[packageFragmentRootsAsList.size()]);
+			if (packageFragmentRoots.length == 0) {
+				JavaLanguageServerPlugin.getInstance().getClientConnection().showNotificationMessage(MessageType.Error, "No source folder exists in the project.");
+				return null;
+			}
+
+			IPackageFragmentRoot targetPkgFragmentRoot = null;
+			for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+				if (packageFragmentRoot.getPackageFragment("").getCompilationUnit(JavaModelUtil.MODULE_INFO_JAVA).exists()) {
+					JavaLanguageServerPlugin.getInstance().getClientConnection().showNotificationMessage(MessageType.Error, 
+						"The module-info.java file already exists in the source folder \"" + packageFragmentRoot.getElementName() + "\"");
+					return null;
+				}
+				if (targetPkgFragmentRoot == null) {
+					targetPkgFragmentRoot = packageFragmentRoot;
+				}
+			}
+
+			if (targetPkgFragmentRoot == null) {
+				return null;
+			}
+
+			String moduleInfoUri = createModuleInfoJava(javaProject, targetPkgFragmentRoot, packageFragmentRoots, monitor);
+			if (moduleInfoUri != null) {
+				new Job("Update project: " + javaProject.getElementName()) {
+					@Override
+					protected IStatus run(IProgressMonitor monitor) {
+						try {
+							convertClasspathToModulePath(javaProject, monitor);
+						} catch (CoreException e) {
+							return e.getStatus();
+						}
+						return Status.OK_STATUS;
+					}
+				}.schedule();
+			}
+			return moduleInfoUri;
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e);
+		}
+
+		return null;
+	}
+
+	private static String createModuleInfoJava(IJavaProject javaProject, IPackageFragmentRoot targetPkgFragmentRoot,
+			IPackageFragmentRoot[] packageFragmentRoots, IProgressMonitor monitor) throws CoreException {
+		String fileContent = getModuleInfoFileContent(javaProject, packageFragmentRoots);
+		IPackageFragment defaultPkg = targetPkgFragmentRoot.getPackageFragment("");
+		ICompilationUnit moduleInfo = defaultPkg.createCompilationUnit(JavaModelUtil.MODULE_INFO_JAVA, fileContent, true, monitor);
+		return moduleInfo.getResource().getLocationURI().toString();
+	}
+
+	private static String getModuleInfoFileContent(IJavaProject javaProject, IPackageFragmentRoot[] packageFragmentRoots) throws CoreException {
+		HashSet<String> exportedPackages = new HashSet<>();
+		for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+			for (IJavaElement child : packageFragmentRoot.getChildren()) {
+				if (child instanceof IPackageFragment) {
+					IPackageFragment pkgFragment = (IPackageFragment) child;
+					if (!pkgFragment.isDefaultPackage() && pkgFragment.getCompilationUnits().length != 0) {
+						exportedPackages.add(pkgFragment.getElementName());
+					}
+				}
+			}
+		}
+
+		String[] requiredModules= JavaCore.getReferencedModules(javaProject);
+		String moduleName = javaProject.getElementName();
+		String lineDelimiter = StubUtility.getLineDelimiterUsed(javaProject);
+		StringBuilder fileContentBuilder = new StringBuilder();
+		fileContentBuilder.append("module ");
+		fileContentBuilder.append(moduleName);
+		fileContentBuilder.append(" {");
+		fileContentBuilder.append(lineDelimiter);
+
+		for (String exportedPkg : exportedPackages) {
+			fileContentBuilder.append("\t");
+			fileContentBuilder.append("exports ");
+			fileContentBuilder.append(exportedPkg);
+			fileContentBuilder.append(";");
+			fileContentBuilder.append(lineDelimiter);
+		}
+
+		for (String requiredModule : requiredModules) {
+			fileContentBuilder.append("\t");
+			fileContentBuilder.append("requires ");
+			fileContentBuilder.append(requiredModule);
+			fileContentBuilder.append(";");
+			fileContentBuilder.append(lineDelimiter);
+		}
+
+		fileContentBuilder.append("}");
+		fileContentBuilder.append(lineDelimiter);
+		String fileContent = fileContentBuilder.toString();
+
+		Map<String, String> options = javaProject.getOptions(true);
+		String formattedContent = CodeFormatterUtil.format(CodeFormatter.K_MODULE_INFO, fileContent, 0, lineDelimiter, options);
+
+		return formattedContent;
+	}
+
+	private static void convertClasspathToModulePath(IJavaProject javaProject, IProgressMonitor monitor) throws JavaModelException {
+		boolean changed = false;
+		IClasspathEntry[] rawClasspath = javaProject.getRawClasspath();
+		for (int i = 0; i < rawClasspath.length; i++) {
+			IClasspathEntry entry = rawClasspath[i];
+			switch (entry.getEntryKind()) {
+				case IClasspathEntry.CPE_CONTAINER:
+				case IClasspathEntry.CPE_LIBRARY:
+				case IClasspathEntry.CPE_PROJECT:
+					IClasspathAttribute[] newAttributes = addModuleAttributeIfNeeded(entry.getExtraAttributes());
+					if (newAttributes != null) {
+						rawClasspath[i] = addAttributes(entry, newAttributes);
+						changed= true;
+					}
+					break;
+				default:
+					// other kinds are not handled
+			}
+		}
+		if (changed) {
+			javaProject.setRawClasspath(rawClasspath, monitor);
+		}
+	}
+
+	private static IClasspathAttribute[] addModuleAttributeIfNeeded(IClasspathAttribute[] extraAttributes) {
+		for (int j= 0; j < extraAttributes.length; j++) {
+			IClasspathAttribute classpathAttribute = extraAttributes[j];
+			if (IClasspathAttribute.MODULE.equals(classpathAttribute.getName())) {
+				if ("true".equals(classpathAttribute.getValue())) {
+					return null; // no change required
+				}
+				extraAttributes[j] = JavaCore.newClasspathAttribute(IClasspathAttribute.MODULE, "true");
+				return extraAttributes;
+			}
+		}
+		extraAttributes= Arrays.copyOf(extraAttributes, extraAttributes.length+1);
+		extraAttributes[extraAttributes.length-1] = JavaCore.newClasspathAttribute(IClasspathAttribute.MODULE, "true");
+		return extraAttributes;
+	}
+
+	private static IClasspathEntry addAttributes(IClasspathEntry entry, IClasspathAttribute[] extraAttributes) {
+		switch (entry.getEntryKind()) {
+			case IClasspathEntry.CPE_CONTAINER:
+				return JavaCore.newContainerEntry(entry.getPath(), entry.getAccessRules(), extraAttributes, entry.isExported());
+			case IClasspathEntry.CPE_LIBRARY:
+				return JavaCore.newLibraryEntry(entry.getPath(), entry.getSourceAttachmentPath(),
+						entry.getSourceAttachmentRootPath(), entry.getAccessRules(), extraAttributes, entry.isExported());
+			case IClasspathEntry.CPE_PROJECT:
+				return JavaCore.newProjectEntry(entry.getPath(), entry.getAccessRules(), entry.combineAccessRules(),
+						extraAttributes, entry.isExported());
+			default:
+				return entry; // other kinds are not handled
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/modular-project2/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/modular-project2/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>modular-project2</artifactId>
+    <version>1.0.0</version>
+
+    <name>modular-project2</name>
+    <description></description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/modular-project2/src/main/java/com/example/A.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/modular-project2/src/main/java/com/example/A.java
@@ -1,0 +1,7 @@
+package com.example;
+import org.xml.sax.SAXException;
+public class A {
+	public static void main(String[] args) {
+		SAXException a = null;
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandlerTest.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -40,4 +41,10 @@ public class CreateModuleInfoHandlerTest extends AbstractProjectsManagerBasedTes
 		assertTrue(content.contains("exports com.example;"));
 		assertTrue(content.contains("requires xml.apis;"));
 	}
+
+	@Test
+	public void testConvertToModuleName() {
+		assertEquals("a.b", CreateModuleInfoHandler.convertToModuleName("..a-b.."));
+	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CreateModuleInfoHandlerTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+
+public class CreateModuleInfoHandlerTest extends AbstractProjectsManagerBasedTest {
+
+	@Test
+	public void testCreateModuleInfo() throws Exception {
+		importProjects("maven/modular-project2");
+		IProject project = WorkspaceHelper.getProject("modular-project2");
+
+		String moduleInfoUri = CreateModuleInfoHandler.createModuleInfo(project.getLocationURI().toString(), new NullProgressMonitor());
+
+		File file = ResourceUtils.toFile(new URI(moduleInfoUri));
+		String content = Files.toString(file, Charsets.UTF_8);
+		assertTrue(content.contains("exports com.example;"));
+		assertTrue(content.contains("requires xml.apis;"));
+	}
+}


### PR DESCRIPTION
requires https://github.com/redhat-developer/vscode-java/pull/2680

Create module-info.java if the Java project's compliance is 9 or higher and does not exist module descriptor file yet.

This could somehow mitigate the error: `The package XXX is accessible from more than one module: ...`

Another idea to resolve this issue is to let JDT Core allow disable the module system on demand, see: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/415

sample project that can be used to verify: [helloworld.zip](https://github.com/eclipse/eclipse.jdt.ls/files/9643870/helloworld.zip)


Signed-off-by: Sheng Chen <sheche@microsoft.com>