### PR TITLE
Fix type completion when type name conflicts

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -37,10 +37,13 @@ import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
+import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
 import org.eclipse.jdt.ls.core.internal.ChangeUtil;
@@ -1021,7 +1024,12 @@ public class CompletionProposalReplacementProvider {
 
 		/* Add imports if the preference is on. */
 		if (importRewrite != null) {
-			return importRewrite.addImport(qualifiedTypeName, null);
+			CompilationUnit cu = SharedASTProviderCore.getAST(compilationUnit, SharedASTProviderCore.WAIT_NO, new NullProgressMonitor());
+			ContextSensitiveImportRewriteContext rewriteContext = null;
+			if (cu != null) {
+				rewriteContext = new ContextSensitiveImportRewriteContext(cu, this.offset, this.importRewrite);
+			}
+			return importRewrite.addImport(qualifiedTypeName, rewriteContext);
 		}
 
 		// fall back for the case we don't have an import rewrite (see

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompilationUnitBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/AbstractCompilationUnitBasedTest.java
@@ -69,8 +69,17 @@ public abstract class AbstractCompilationUnitBasedTest extends AbstractProjectsM
 	}
 
 	protected int[] findCompletionLocation(ICompilationUnit unit, String completeBehind) throws JavaModelException {
+		return findCompletionLocation(unit, completeBehind, 0);
+	}
+
+	protected int[] findCompletionLocation(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
 		String str= unit.getSource();
-		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		int cursorLocation;
+		if (fromIndex > 0) {
+			cursorLocation = str.indexOf(completeBehind, fromIndex) + completeBehind.length();
+		} else {
+			cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		}
 		return JsonRpcHelpers.toLine(unit.getBuffer(), cursorLocation);
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3501,7 +3501,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_withConflictingTypeNames() throws Exception{
-		getWorkingCopy("src/java/List.java", 
+		getWorkingCopy("src/java/List.java",
 			"package util;\n" +
 			"public class List {\n" +
 			"}\n");
@@ -3514,19 +3514,26 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 						"		List \n"+
 						"	}\n"+
 				"}\n");
-		CompletionList list = requestCompletions(unit, "List");
+		CoreASTProvider.getInstance().setActiveJavaElement(unit);
+		CoreASTProvider.getInstance().getAST(unit, CoreASTProvider.WAIT_YES, monitor);
+
+		CompletionList list = requestCompletions(unit, "List", unit.getSource().indexOf("List()") + 6);
 		assertNotNull(list);
 		assertFalse("No proposals were found",list.getItems().isEmpty());
 
 		List<CompletionItem> items = list.getItems().stream().filter(p -> "java.util.List".equals(p.getDetail()))
 			.collect(Collectors.toList());
 		assertFalse("java.util.List not found",items.isEmpty());
-		assertEquals("java.util.List", items.get(0).getInsertText());
+		assertEquals("java.util.List", items.get(0).getTextEdit().getLeft().getNewText());
 	}
 
 
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
-		int[] loc = findCompletionLocation(unit, completeBehind);
+		return requestCompletions(unit, completeBehind, 0);
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
+		int[] loc = findCompletionLocation(unit, completeBehind, fromIndex);
 		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3499,6 +3499,32 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("java.util.ArrayList()", list.getItems().get(0).getFilterText());
 	}
 
+	@Test
+	public void testCompletion_withConflictingTypeNames() throws Exception{
+		getWorkingCopy("src/java/List.java", 
+			"package util;\n" +
+			"public class List {\n" +
+			"}\n");
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"package util;\n" +
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						" 		Object list = new List();\n" +
+						"		List \n"+
+						"	}\n"+
+				"}\n");
+		CompletionList list = requestCompletions(unit, "List");
+		assertNotNull(list);
+		assertFalse("No proposals were found",list.getItems().isEmpty());
+
+		List<CompletionItem> items = list.getItems().stream().filter(p -> "java.util.List".equals(p.getDetail()))
+			.collect(Collectors.toList());
+		assertFalse("java.util.List not found",items.isEmpty());
+		assertEquals("java.util.List", items.get(0).getInsertText());
+	}
+
+
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
 		int[] loc = findCompletionLocation(unit, completeBehind);
 		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();


### PR DESCRIPTION
When type completion are applied where the same simple name already imported in the scope, the second type completion is completed as a fully qualified completion.