### PR TITLE
fix: Do not use URI for getting project folder to avoid unsupported spaces

### DIFF
--- a/org.eclipse.jdt.ls.core/gradle/android/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/android/init.gradle
@@ -230,7 +230,7 @@ class JavaLanguageServerAndroidPlugin implements Plugin<Project> {
         if (!folder.isDirectory()) {
             return
         }
-        SourceFolder sourceFolder = new SourceFolder(project.getProjectDir().toURI().relativize(folder.toURI()).toString(), outputPath)
+        SourceFolder sourceFolder = new SourceFolder(project.getProjectDir().toPath().relativize(folder.toPath()).toString(), outputPath)
         // For Gradle version < 5.4, we add this attribute so that the folders can be recognized once the files are generated
         // For Gradle version >= 5.4, we add the compile task to synchronization tasks so that this attribute is not necessary
         if (GradleVersion.version(project.getGradle().getGradleVersion()) < GradleVersion.version("5.4")) {

--- a/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
+++ b/org.eclipse.jdt.ls.core/gradle/protobuf/init.gradle
@@ -71,7 +71,7 @@ class ProtobufPatchPlugin implements Plugin<Project> {
                                 // https://github.com/eclipse/buildship/issues/1196
                                 srcDir.mkdirs();
 
-                                String relativePath = projectDir.toURI().relativize(srcDir.toURI()).getPath()
+                                String relativePath = projectDir.toPath().relativize(srcDir.toPath()).toString()
                                 // remove trailing slash
                                 if (relativePath.endsWith("/")) {
                                     relativePath = relativePath.substring(0, relativePath.length() - 1)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -601,7 +601,7 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	private static File getGradleInitScript(String scriptPath) {
 		try {
 			URL fileURL = FileLocator.toFileURL(JavaLanguageServerPlugin.class.getResource(scriptPath));
-			File initScript = new File(fileURL.toURI());
+			File initScript = new File(fileURL.getFile());
 			if (!initScript.exists()) {
 				initScript.createNewFile();
 			}


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix #2222, currently we have lots of error logs in JDTLS server log for vscode-insider users since the workspace folder contains a space, which is not supported by URI, so we won't use it for recently changed Gradle supports.

cc: @rgrunber 
cc: @jdneo for protobuf support script.