### PR TITLE
Fix gradle project classpath calculation

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaLaunchConfigurationInfo.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaLaunchConfigurationInfo.java
@@ -33,7 +33,7 @@ import org.xml.sax.helpers.DefaultHandler;
 public class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
 
 	private static final String JAVA_APPLICATION_LAUNCH = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-		+ "<launchConfiguration type=\"%s\">\n"
+		+ "<launchConfiguration type=\"org.eclipse.jdt.launching.localJavaApplication\">\n"
 		+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_PATHS\">\n"
 		+ "</listAttribute>\n"
 		+ "<listAttribute key=\"org.eclipse.debug.core.MAPPED_RESOURCE_TYPES\">\n"
@@ -43,21 +43,10 @@ public class JavaLaunchConfigurationInfo extends LaunchConfigurationInfo {
 	public JavaLaunchConfigurationInfo(String scope) {
 		super();
 
-		// Since MavenRuntimeClasspathProvider will only encluding test entries when:
-		// 1. Launch configuration is JUnit/TestNG type
-		// 2. Mapped resource is in test path.
-		// That's why we use JUnit launch configuration here to make sure the result is right when excludeTestCode is false.
-		// See: {@link org.eclipse.m2e.jdt.internal.launch.MavenRuntimeClasspathProvider#getArtifactScope(ILaunchConfiguration)}
-		String launchXml = null;
-		if ("test".equals(scope)) {
-			launchXml = String.format(JAVA_APPLICATION_LAUNCH, "org.eclipse.jdt.junit.launchconfig");
-		} else {
-			launchXml = String.format(JAVA_APPLICATION_LAUNCH, "org.eclipse.jdt.launching.localJavaApplication");
-		}
 		try {
 			DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			parser.setErrorHandler(new DefaultHandler());
-			StringReader reader = new StringReader(launchXml);
+			StringReader reader = new StringReader(JAVA_APPLICATION_LAUNCH);
 			InputSource source = new InputSource(reader);
 			Element root = parser.parse(source).getDocumentElement();
 			initializeFromXML(root);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/commands/ProjectCommandTest.java
@@ -210,10 +210,14 @@ public class ProjectCommandTest extends AbstractInvisibleProjectBasedTest {
         IProject project = WorkspaceHelper.getProject("simple-gradle");
         String uriString = project.getFile("src/main/java/Library.java").getLocationURI().toString();
         ClasspathOptions options = new ClasspathOptions();
-        // Gradle project will always return classpath containing test dependencies.
-        // So we only test `scope = "test"` scenario.
-        options.scope = "test";
+        options.scope = "runtime";
         ClasspathResult result = ProjectCommand.getClasspaths(uriString, options);
+        assertEquals(3, result.classpaths.length);
+        assertEquals(0, result.modulepaths.length);
+        assertTrue(result.classpaths[0].indexOf("junit") == -1);
+
+        options.scope = "test";
+        result = ProjectCommand.getClasspaths(uriString, options);
         assertEquals(5, result.classpaths.length);
         assertEquals(0, result.modulepaths.length);
         boolean containsJunit = Arrays.stream(result.classpaths).anyMatch(element -> {


### PR DESCRIPTION
use 'org.eclipse.jdt.launching.localJavaApplication' configuration type and use 'excludeTest' attribute to specify whether test classpath should be included.

Since we updated M2E, and the [restriction that previous versions have](https://github.com/eclipse/eclipse.jdt.ls/blob/3d1a42c80abb12357a1152a097ec63b14ea5068c/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/JavaLaunchConfigurationInfo.java#L46-L50) is now removed. So we can just simply use the `localJavaApplication` type configuration to resolve the classpaths.

fix https://github.com/redhat-developer/vscode-java/issues/2628

Signed-off-by: Sheng Chen <sheche@microsoft.com>