### PR TITLE
Improve lambda completions

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -216,9 +216,18 @@ public class CompletionProposalReplacementProvider {
 	}
 
 	private void appendLambdaExpressionReplacement(StringBuilder completionBuffer, CompletionProposal proposal) {
-		completionBuffer.append(LPAREN);
-		appendGuessingCompletion(completionBuffer, proposal);
-		completionBuffer.append(RPAREN);
+		StringBuilder paramBuffer = new StringBuilder();
+		appendGuessingCompletion(paramBuffer, proposal);
+		boolean needParens = paramBuffer.indexOf(",") > -1 || paramBuffer.length() == 0;
+
+		if (needParens) {
+			completionBuffer.append(LPAREN);
+		}
+		completionBuffer.append(paramBuffer);
+		if (needParens) {
+			completionBuffer.append(RPAREN);
+		}
+
 		completionBuffer.append(" -> ");
 		if(client.isCompletionSnippetsSupported()){
 			completionBuffer.append(CURSOR_POSITION);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3364,7 +3364,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				.filter(item -> (item.getLabel().matches("\\(Object \\w+\\) -> : void") && item.getKind() == CompletionItemKind.Method))
 				.findFirst().orElse(null);
 		assertNotNull(lambda);
-		assertTrue(lambda.getTextEdit().getLeft().getNewText().matches("\\(\\$\\{1:\\w+\\}\\) -> \\$\\{0\\}"));
+		assertTrue(lambda.getTextEdit().getLeft().getNewText().matches("\\$\\{1:\\w+\\} -> \\$\\{0\\}"));
 	}
 
 	@Test
@@ -3527,6 +3527,45 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertEquals("java.util.List", items.get(0).getTextEdit().getLeft().getNewText());
 	}
 
+	@Test
+	public void testCompletion_lambdaWithNoParam() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						" 		Runnable r = \n" +
+						"	}\n"+
+				"}\n");
+
+		CompletionList list = requestCompletions(unit, "= ");
+		assertNotNull(list);
+		assertFalse("No proposals were found",list.getItems().isEmpty());
+
+		List<CompletionItem> items = list.getItems().stream().filter(p -> p.getLabel() != null && p.getLabel().contains("->"))
+			.collect(Collectors.toList());
+		assertFalse("Lambda not found",items.isEmpty());
+		assertTrue(items.get(0).getTextEdit().getLeft().getNewText().matches("\\(\\) -> \\$\\{0\\}"));
+	}
+
+	@Test
+	public void testCompletion_lambdaWithMultipleParams() throws Exception{
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"public class Foo {\n"+
+						"	void foo() {\n"+
+						" 		java.util.function.BiConsumer<Integer, Long> bc = \n" +
+						"	}\n"+
+				"}\n");
+
+		CompletionList list = requestCompletions(unit, "= ");
+		assertNotNull(list);
+		assertFalse("No proposals were found",list.getItems().isEmpty());
+
+		List<CompletionItem> items = list.getItems().stream().filter(p -> p.getLabel() != null && p.getLabel().contains("->"))
+			.collect(Collectors.toList());
+		assertFalse("Lambda not found",items.isEmpty());
+		assertTrue(items.get(0).getTextEdit().getLeft().getNewText().matches("\\(\\$\\{1:\\w+\\}\\, \\$\\{2:\\w+\\}\\) -> \\$\\{0\\}"));
+	}
 
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
 		return requestCompletions(unit, completeBehind, 0);


### PR DESCRIPTION
When completing lambda the parenthesis are only added if the lambda
- has multiple parameters
- no parameters

This will suggest 
Runnable r = () ->

Consumer<String>  c = s ->

BiConsumer <Long, Integer> bc = (i,l) ->

The variable names might differ based on the name guesser.