### PR TITLE
Fix Gradle project synchorization error when init script path contains spaces

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -601,7 +601,12 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 	private static File getGradleInitScript(String scriptPath) {
 		try {
 			URL fileURL = FileLocator.toFileURL(JavaLanguageServerPlugin.class.getResource(scriptPath));
-			File initScript = new File(fileURL.getFile());
+			String fileString = fileURL.getFile();
+			// workaround for https://github.com/eclipse/buildship/issues/1207, buildship doesn't support spaces in passed Gradle arguments
+			if (fileString.contains(" ")) {
+				return getGradleInitScriptTempFile(scriptPath);
+			}
+			File initScript = new File(fileString);
 			if (!initScript.exists()) {
 				initScript.createNewFile();
 			}


### PR DESCRIPTION
more details can be found in https://github.com/redhat-developer/vscode-java/issues/2692#issuecomment-1259093782

Signed-off-by: Shi Chen chenshi@microsoft.com