### PR TITLE
Improve project initialization

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -542,6 +542,29 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return changed;
 	}
 
+	public static Runnable interruptAutoBuild() throws CoreException {
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		if (workspace instanceof Workspace) {
+			((Workspace) workspace).getBuildManager().interrupt();
+			return () -> {
+			};
+		} else {
+			boolean changed = setAutoBuilding(false);
+			if (changed) {
+				return () -> {
+					try {
+						setAutoBuilding(true);
+					} catch (CoreException e) {
+						// ignore
+					}
+				};
+			} else {
+				return () -> {
+				};
+			}
+		}
+	}
+
 	public void configureFilters(IProgressMonitor monitor) throws CoreException {
 		List<String> resourceFilters = preferenceManager.getPreferences().getResourceFilters();
 		if (resourceFilters != null && !resourceFilters.isEmpty()) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -50,6 +50,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
@@ -216,7 +217,6 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 		IMarker m1 = createMavenMarker(IMarker.SEVERITY_ERROR, msg1, 2, 95, 100);
 
 		IDocument d = mock(IDocument.class);
-		when(d.getLineOffset(1)).thenReturn(90);
 
 		List<Diagnostic> diags = WorkspaceDiagnosticsHandler.toDiagnosticsArray(d, new IMarker[] { m1, null }, true);
 		assertEquals(1, diags.size());
@@ -386,6 +386,7 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 	public void testMissingNatures() throws Exception {
 		//import project
 		importProjects("eclipse/wtpproject");
+		JobHelpers.waitForInitializeJobs(5000);
 		ArgumentCaptor<PublishDiagnosticsParams> captor = ArgumentCaptor.forClass(PublishDiagnosticsParams.class);
 		verify(connection, atLeastOnce()).publishDiagnostics(captor.capture());
 		List<PublishDiagnosticsParams> allCalls = captor.getAllValues();


### PR DESCRIPTION
Today when importing projects we disable auto build and reset it back to previous value to avoid conflicts between project imports and build jobs. But resetting back auto build to true cause the whole workspace to build again which takes considerable time for large projects which blocks all other operations.

The improvement use workspace scheduling rule to make sure another job cannot be executed at the same time such as a auto build according to how eclipse workspace sensitive jobs are implemented internally.

Must further future improvement would be to apply this rule at each project import iteration if further optimization is needed.