### PR TITLE
Always send `begin` work done progress before sending `end`

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -157,21 +157,6 @@ public class JavaClientConnection {
 	}
 
 	/**
-	 * Sends a progress report to the client to be presented to users
-	 *
-	 * @param progressReport
-	 *            The progress report to send back to the client
-	 */
-	public void sendProgressReport(ProgressReport progressReport) {
-		var preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
-		if (preferenceManager.getClientPreferences().isProgressReportSupported()) {
-			client.sendProgressReport(progressReport);
-		} else {
-			client.notifyProgress(progressReport.toProgressParams());
-		}
-	}
-
-	/**
 	 * Sends a message to the client to be presented to users, with possible
 	 * commands to execute
 	 */

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProgressReport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ProgressReport.java
@@ -14,12 +14,6 @@ package org.eclipse.jdt.ls.core.internal;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import org.eclipse.lsp4j.ProgressParams;
-import org.eclipse.lsp4j.WorkDoneProgressBegin;
-import org.eclipse.lsp4j.WorkDoneProgressEnd;
-import org.eclipse.lsp4j.WorkDoneProgressNotification;
-import org.eclipse.lsp4j.WorkDoneProgressReport;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Progress Report sent to clients.
@@ -155,34 +149,5 @@ public class ProgressReport {
 	 */
 	public void setSubTask(String subTask) {
 		this.subTask = subTask;
-	}
-
-	public ProgressParams toProgressParams() {
-		WorkDoneProgressNotification notification;
-		if (complete) {
-			var endNotification = new WorkDoneProgressEnd();
-			endNotification.setMessage(task);
-
-			notification = endNotification;
-		}
-		else if(workDone > 0 && workDone < totalWork) {
-			var reportNotification = new WorkDoneProgressReport();
-			reportNotification.setMessage(task);
-			reportNotification.setPercentage((int)(((double) workDone) / totalWork * 100.0));
-
-			notification = reportNotification;
-		}
-		else {
-			var beginNotification = new WorkDoneProgressBegin();
-			beginNotification.setMessage(task);
-			beginNotification.setTitle(subTask != null ? subTask : task);
-
-			notification = beginNotification;
-		}
-
-		return new ProgressParams(
-			Either.forLeft(id),
-			Either.forLeft(notification)
-		);
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
@@ -28,7 +28,13 @@ import org.eclipse.jdt.ls.core.internal.ServiceStatus;
 import org.eclipse.jdt.ls.core.internal.StatusReport;
 import org.eclipse.jdt.ls.core.internal.managers.MavenProjectImporter;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.WorkDoneProgressBegin;
+import org.eclipse.lsp4j.WorkDoneProgressEnd;
+import org.eclipse.lsp4j.WorkDoneProgressNotification;
+import org.eclipse.lsp4j.WorkDoneProgressReport;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * Manager for creating {@link IProgressMonitor}s reporting progress to clients
@@ -161,6 +167,7 @@ public class ProgressReporterManager extends ProgressProvider {
 		protected int progress;
 		protected long lastReport = 0;
 		protected String progressId;
+		private boolean sentBegin = false;
 
 		public ProgressReporter() {
 			super(null);
@@ -233,23 +240,43 @@ public class ProgressReporterManager extends ProgressProvider {
 			if (client == null || preferenceManager == null || preferenceManager.getClientPreferences() == null) {
 				return;
 			}
-			ProgressReport progressReport = new ProgressReport(progressId);
 			String task = StringUtils.defaultIfBlank(taskName, (job == null || StringUtils.isBlank(job.getName())) ? "Background task" : job.getName());
-			progressReport.setTask(task);
-			progressReport.setSubTask(subTaskName);
-			progressReport.setTotalWork(totalWork);
-			progressReport.setWorkDone(progress);
-			progressReport.setComplete(isDone());
-			if (task != null && subTaskName != null && !subTaskName.isEmpty() && task.equals(MavenProjectImporter.IMPORTING_MAVEN_PROJECTS)) {
-				progressReport.setStatus(task + SEPARATOR + subTaskName);
-			} else {
-				progressReport.setStatus(formatMessage(task));
-			}
-
 			if (preferenceManager.getClientPreferences().isProgressReportSupported()) {
+				ProgressReport progressReport = new ProgressReport(progressId);
+				progressReport.setTask(task);
+				progressReport.setSubTask(subTaskName);
+				progressReport.setTotalWork(totalWork);
+				progressReport.setWorkDone(progress);
+				progressReport.setComplete(isDone());
+				if (task != null && subTaskName != null && !subTaskName.isEmpty() && task.equals(MavenProjectImporter.IMPORTING_MAVEN_PROJECTS)) {
+					progressReport.setStatus(task + SEPARATOR + subTaskName);
+				} else {
+					progressReport.setStatus(formatMessage(task));
+				}
+
 				client.sendProgressReport(progressReport);
 			} else {
-				client.notifyProgress(progressReport.toProgressParams());
+				Either<String, Integer> id = Either.forLeft(progressId);
+				if (!sentBegin) {
+					var workDoneProgressBegin = new WorkDoneProgressBegin();
+					workDoneProgressBegin.setMessage(task);
+					workDoneProgressBegin.setTitle(subTaskName == null ? task : subTaskName);
+					client.notifyProgress(new ProgressParams(id, Either.forLeft(workDoneProgressBegin)));
+					sentBegin = true;
+				}
+				WorkDoneProgressNotification notification;
+				if (isDone()) {
+					var endNotification = new WorkDoneProgressEnd();
+					endNotification.setMessage(task);
+					notification = endNotification;
+					sentBegin = false;
+				} else {
+					var reportNotification = new WorkDoneProgressReport();
+					reportNotification.setMessage(task);
+					reportNotification.setPercentage((int)(((double) progress) / totalWork * 100.0));
+					notification = reportNotification;
+				}
+				client.notifyProgress(new ProgressParams(id, Either.forLeft(notification)));
 			}
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManager.java
@@ -181,6 +181,7 @@ public class ProgressReporterManager extends ProgressProvider {
 
 		public ProgressReporter(CancelChecker checker) {
 			super(checker);
+			progressId = UUID.randomUUID().toString();
 		}
 
 		@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ProgressReporterManagerTest.java
@@ -121,7 +121,7 @@ public class ProgressReporterManagerTest {
 		monitor.done();
 
 		ArgumentCaptor<ProgressParams> captor = ArgumentCaptor.forClass(ProgressParams.class);
-		verify(client, times(1)).notifyProgress(captor.capture());
+		verify(client, times(2)).notifyProgress(captor.capture());
 	}
 
 	@Test


### PR DESCRIPTION
Clients like neovim show an error message if `end` is received for a
token without having received a corresponding `begin`.

The specification also requires it:

> To start progress reporting a $/progress notification with the following payload must be sent

This ensures `begin` is always sent first and also avoids creating
intermediate `ProgressReport` instances.

`isDone` can be immediately true. In that case the server send immediately a `end` notification without having sent a `begin`.