### PR TITLE
Add quick-fix for permitting subtype of a sealed class.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -212,6 +212,12 @@ public class QuickFixProcessor {
 			case IProblem.SealedMissingInterfaceModifier:
 				ModifierCorrectionSubProcessor.addSealedMissingModifierProposal(context, problem, proposals);
 				break;
+			case IProblem.SealedNotDirectSuperInterface:
+			case IProblem.SealedNotDirectSuperClass:
+				LocalCorrectionsSubProcessor.addSealedAsDirectSuperTypeProposal(context, problem, proposals);
+			case IProblem.SealedSuperClassDoesNotPermit:
+			case IProblem.SealedSuperInterfaceDoesNotPermit:
+				LocalCorrectionsSubProcessor.addTypeAsPermittedSubTypeProposal(context, problem, proposals);
 			case IProblem.StaticMethodRequested:
 			case IProblem.NonStaticFieldFromStaticInvocation:
 			case IProblem.InstanceMethodDuringConstructorInvocation:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
@@ -95,6 +95,7 @@ public interface IProposalRelevance {
 	public static final int INSERT_INFERRED_TYPE_ARGUMENTS= 7;
 	public static final int RETURN_ALLOCATED_OBJECT_MATCH= 7;
 	public static final int CREATE_LOCAL= 7;
+	public static final int DECLARE_SEALED_AS_DIRECT_SUPER_TYPE = 7;
 
 	public static final int MOVE_REFACTORING = 6;
 	public static final int REMOVE_SEMICOLON= 6;

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -27,7 +27,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/I20221013-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/I20221017-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ModifierCorrectionsQuickFixTest.java
@@ -1255,4 +1255,68 @@ public class ModifierCorrectionsQuickFixTest extends AbstractQuickFixTest {
 		Expected e3 = new Expected("Change 'Square' to 'sealed'", buf.toString());
 		assertCodeActions(cu, e3);
 	}
+
+	@Test
+	public void testAddSealedAsDirectSuperClass() throws Exception {
+		Map<String, String> options19 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options19, JavaCore.VERSION_19);
+		options19.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		options19.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+		fJProject.setOptions(options19);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test", false, null);
+		assertNoErrors(fJProject.getResource());
+
+		StringBuilder buf = new StringBuilder();
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public sealed class Shape permits Square {}\n");
+		buf.append("\n");
+		buf.append("final class Square {}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("Shape.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public sealed class Shape permits Square {}\n");
+		buf.append("\n");
+		buf.append("final class Square extends Shape {}\n");
+		Expected e1 = new Expected("Declare 'Shape' as direct super class of 'Square'", buf.toString());
+		assertCodeActions(cu, e1);
+	}
+
+	@Test
+	public void testAddPermitsToDirectSuperClass() throws Exception {
+		Map<String, String> options19 = new HashMap<>();
+		JavaModelUtil.setComplianceOptions(options19, JavaCore.VERSION_19);
+		options19.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		options19.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+		fJProject.setOptions(options19);
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test", false, null);
+		assertNoErrors(fJProject.getResource());
+
+		StringBuilder buf = new StringBuilder();
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public sealed class Shape {}\n");
+		buf.append("\n");
+		pack1.createCompilationUnit("Shape.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("final class Square extends Shape {}\n");
+		buf.append("\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("Square.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public sealed class Shape permits Square {}\n");
+		buf.append("\n");
+		Expected e1 = new Expected("Declare 'Square' as permitted subtype of 'Shape'", buf.toString());
+		assertCodeActions(cu, e1);
+	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/MoveHandlerTest.java
@@ -226,12 +226,16 @@ public class MoveHandlerTest extends AbstractProjectsManagerBasedTest {
 				"public class B {\r\n" +
 				"}";
 		//@formatter:on
-		TextDocumentEdit textEdit = changes.get(0).getLeft();
+		TextDocumentEdit textEdit = changes.stream().filter(
+				chg -> chg.isLeft() && chg.getLeft().getTextDocument().getUri().endsWith("B.java"))
+				.findFirst().get().getLeft();
 		assertNotNull(textEdit);
 		List<TextEdit> edits = new ArrayList<>(textEdit.getEdits());
 		assertEquals(expected, TextEditUtil.apply(unitB.getSource(), edits));
 
-		RenameFile renameFileB = (RenameFile) changes.get(1).getRight();
+		RenameFile renameFileB = (RenameFile) changes.stream().filter(
+				chg -> chg.isRight() && ((RenameFile) chg.getRight()).getOldUri().endsWith("B.java"))
+				.findFirst().get().getRight();
 		assertNotNull(renameFileB);
 		assertEquals(JDTUtils.toURI(unitB), renameFileB.getOldUri());
 		assertEquals(ResourceUtils.fixURI(unitB.getResource().getRawLocationURI()).replace("test1", "test2"), renameFileB.getNewUri());
@@ -243,12 +247,16 @@ public class MoveHandlerTest extends AbstractProjectsManagerBasedTest {
 				"	private B b = new B();\r\n" +
 				"}";
 		//@formatter:on
-		textEdit = changes.get(2).getLeft();
+		textEdit = changes.stream().filter(
+				chg -> chg.isLeft() && chg.getLeft().getTextDocument().getUri().endsWith("A.java"))
+				.findFirst().get().getLeft();
 		assertNotNull(textEdit);
 		edits = new ArrayList<>(textEdit.getEdits());
 		assertEquals(expected, TextEditUtil.apply(unitA.getSource(), edits));
 
-		RenameFile renameFileA = (RenameFile) changes.get(3).getRight();
+		RenameFile renameFileA = (RenameFile) changes.stream().filter(
+				chg -> chg.isRight() && ((RenameFile) chg.getRight()).getOldUri().endsWith("A.java"))
+				.findFirst().get().getRight();
 		assertNotNull(renameFileA);
 		assertEquals(JDTUtils.toURI(unitA), renameFileA.getOldUri());
 		assertEquals(ResourceUtils.fixURI(unitA.getResource().getRawLocationURI()).replace("test1", "test2"), renameFileA.getNewUri());


### PR DESCRIPTION
This takes advantage of the refactorings done in https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/288 & https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/294.

![quick-fix-permit-subtype-for-sealed-class](https://user-images.githubusercontent.com/1417342/194645102-e2fb00c8-26a9-454d-8c13-9aff8af6580d.gif)

![declare-as-superclass-of-permitted](https://user-images.githubusercontent.com/1417342/196794440-122d4392-f791-4148-a53d-0bced59debe8.gif)

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

- [x] Need to wait for an I-build that contains the newly moved API, and update the target file with it. Build will fail otherwise, but can be tested by building org.eclipse.jdt.core.manipulation.locally
- [x] It would be nice to add some test case(s) for this. In https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/master/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest17.java , the `testAddSealedAsDirectSuperTypeProposal*` tests deal with this.