### PR TITLE
Avoid unnecessary project updates when the default vm changes

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2020 Red Hat Inc. and others.
+ * Copyright (c) 2019-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -302,8 +302,7 @@ public class JVMConfigurator implements IVMInstallChangedListener {
 				configureJVMSettings(javaProject, current);
 			}
 			ProjectsManager projectsManager = JavaLanguageServerPlugin.getProjectsManager();
-			if (projectsManager != null) {
-				//TODO Only trigger update if the project uses the default JVM
+			if (projectsManager != null && projectsManager.useDefaultVM(project, current)) {
 				JavaLanguageServerPlugin.logInfo("defaultVMInstallChanged -> force update of " + project.getName());
 				projectsManager.updateProject(project, true);
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2020 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -42,6 +42,7 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
@@ -161,6 +162,11 @@ public class GradleBuildSupport implements IBuildSupport {
 			return false;
 		}
 		return IBuildSupport.super.fileChanged(resource, changeType, monitor) || isBuildFile(resource);
+	}
+
+	@Override
+	public boolean useDefaultVM(IProject project, IVMInstall defaultVM) {
+		return GradleProjectImporter.useDefaultVM();
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporter.java
@@ -467,6 +467,17 @@ public class GradleProjectImporter extends AbstractProjectImporter {
 		return build;
 	}
 
+	static boolean useDefaultVM() {
+		File javaHome = getGradleJavaHomeFile();
+		if (javaHome == null) {
+			IVMInstall javaDefaultRuntime = JavaRuntime.getDefaultVMInstall();
+			return javaDefaultRuntime != null
+				&& javaDefaultRuntime.getVMRunner(ILaunchManager.RUN_MODE) != null;
+		}
+
+		return false;
+	}
+
 	private static File getJavaHome(Preferences preferences) {
 		File javaHome = getGradleJavaHomeFile();
 		if (javaHome == null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2020 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -78,6 +79,13 @@ public interface IBuildSupport {
 	 */
 	default boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
 		refresh(resource, changeType, monitor);
+		return false;
+	}
+
+	/**
+	 * Check if the build support for the specified project depends on the default VM.
+	 */
+	default boolean useDefaultVM(IProject project, IVMInstall defaultVM) {
 		return false;
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -443,6 +443,22 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 		return buildSupports().filter(bs -> bs.applies(project)).findFirst();
 	}
 
+	/**
+	 * Check if the build support for the specified project depends on the default VM.
+	 */
+	public boolean useDefaultVM(IProject project, IVMInstall defaultVM) {
+		if (project == null) {
+			return false;
+		}
+
+		IBuildSupport buildSupport = getBuildSupport(project).orElse(null);
+		if (buildSupport != null) {
+			return buildSupport.useDefaultVM(project, defaultVM);
+		}
+
+		return false;
+	}
+
 	private Stream<IBuildSupport> buildSupports() {
 		return Stream.of(new EclipseBuildSupport());
 	}


### PR DESCRIPTION
Fixes part of the issue #1960, the reason is that JDT triggers unnecessary update with the default vm change. (See the analysis from the PR https://github.com/eclipse/eclipse.jdt.ls/pull/1961).

See the TODO in the following snippet, we should trigger project update only if the project importer uses the default vm.
https://github.com/eclipse/eclipse.jdt.ls/blob/f8452b422add64f9bbc80d0e22b48ed71797e563/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JVMConfigurator.java#L305-L309

Since the Eclipse and Maven project importer doesn't depend on the default vm, I changed it to only trigger update for gradle projects. Also, see the earliest PR https://github.com/eclipse/eclipse.jdt.ls/pull/1430 that introduced this snippet, where it exactly is used to solve gradle import issue.