### PR TITLE
Synchronize the bundles on demand

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -112,6 +112,9 @@
             <command
                   id="java.project.createModuleInfo">
             </command>
+            <command
+                  id="java.reloadBundles">
+            </command>
       </delegateCommandHandler>
    </extension>
    <extension

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
 import org.eclipse.jdt.ls.core.internal.commands.DiagnosticsCommand;
@@ -26,6 +27,7 @@ import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathOptions
 import org.eclipse.jdt.ls.core.internal.framework.protobuf.ProtobufSupport;
 import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
 import org.eclipse.jdt.ls.core.internal.commands.TypeHierarchyCommand;
+import org.eclipse.jdt.ls.core.internal.handlers.BundleUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.CreateModuleInfoHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.ResolveSourceMappingHandler;
@@ -134,6 +136,14 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					return null;
 				case "java.project.createModuleInfo":
 					return CreateModuleInfoHandler.createModuleInfo((String) arguments.get(0), monitor);
+				case "java.reloadBundles":
+					try {
+						BundleUtils.loadBundles((ArrayList<String>) arguments.get(0));
+						return true;
+					} catch (CoreException e) {
+						JavaLanguageServerPlugin.log(e);
+						return false;
+					}
 				default:
 					break;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BundleUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BundleUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Microsoft Corporation and others.
+ * Copyright (c) 2017-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -132,7 +132,7 @@ public final class BundleUtils {
 						}
 
 						// Uninstall the singleton bundle if the location or version is not equal
-						uninstallBundle(context, bundlesToStart, toRefresh, bundles[0]);
+						uninstallBundle(bundlesToStart, toRefresh, bundles[0]);
 					} else {
 						boolean shouldSkip = false;
 						for (Bundle bundle : bundles) {
@@ -141,7 +141,7 @@ public final class BundleUtils {
 									shouldSkip = true;
 								} else {
 									// Uninstall non-singleton bundle if it's the same version but different location
-									uninstallBundle(context, bundlesToStart, toRefresh, bundle);
+									uninstallBundle(bundlesToStart, toRefresh, bundle);
 								}
 								break;
 							}
@@ -191,8 +191,6 @@ public final class BundleUtils {
 	 * Uninstall the specified bundle and update the set for bundle refreshing and
 	 * starting.
 	 *
-	 * @param context
-	 *            Bundle context
 	 * @param bundlesToStart
 	 *            The set containing bundles which need to start
 	 * @param toRefresh
@@ -203,7 +201,7 @@ public final class BundleUtils {
 	 *
 	 * @throws BundleException
 	 */
-	private static void uninstallBundle(BundleContext context, Set<Bundle> bundlesToStart, Set<Bundle> toRefresh, Bundle bundle) throws BundleException {
+	private static void uninstallBundle(Set<Bundle> bundlesToStart, Set<Bundle> toRefresh, Bundle bundle) throws BundleException {
 		bundle.uninstall();
 		JavaLanguageServerPlugin.logInfo("Uninstalled " + bundle.getLocation());
 		toRefresh.add(bundle);


### PR DESCRIPTION
- Add a command to enable client refresh bundles on demand.
- Before JDT.LS send ready notification to client, ask client to synchronize bundles if necessary.

requires https://github.com/redhat-developer/vscode-java/pull/2729

Signed-off-by: sheche <sheche@microsoft.com>