### PR TITLE
Ignore unnamed module for split packages

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -146,6 +146,7 @@ public class PreferenceManager {
 		javaCoreOptions.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JavaCore.IGNORE);
 		// workaround for https://github.com/redhat-developer/vscode-java/issues/718
 		javaCoreOptions.put(JavaCore.CORE_CIRCULAR_CLASSPATH, JavaCore.WARNING);
+		javaCoreOptions.put(JavaCore.COMPILER_IGNORE_UNNAMED_MODULE_FOR_SPLIT_PACKAGE, JavaCore.ENABLED);
 		JavaCore.setOptions(javaCoreOptions);
 	}
 

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -38,11 +38,6 @@
            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.12.0/"/>
            <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
         </location>
-        <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/eclipse/updates/4.25-P-builds/P20220912-0140/"/>
-	        <unit id="org.eclipse.jdt.java19patch.feature.group" version="0.0.0"/>
-	        <unit id="org.eclipse.jdt.java19patch.source.feature.group" version="0.0.0"/>
-        </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -27,7 +27,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.25/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.26-I-builds/I20221013-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -85,11 +85,6 @@
 										<version>0.0.0</version>
 										<type>eclipse-feature</type>
 									</dependency>
-									<dependency>
-										<artifactId>org.eclipse.jdt.java19patch</artifactId>
-										<version>0.0.0</version>
-										<type>eclipse-feature</type>
-									</dependency>
 								</dependencies>
 							</configuration>
 						</plugin>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IFolder;
@@ -943,10 +944,12 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		List<PublishDiagnosticsParams> diags = getClientRequests("publishDiagnostics");
 		assertEquals(expectedReports.length, diags.size());
 
-		for (int i = 0; i < expectedReports.length; i++) {
-			PublishDiagnosticsParams diag = diags.get(i);
-			ExpectedProblemReport expected = expectedReports[i];
-			assertEquals(JDTUtils.toURI(expected.cu), diag.getUri());
+		for (ExpectedProblemReport expected : expectedReports) {
+			String uri = JDTUtils.toURI(expected.cu);
+			List<PublishDiagnosticsParams> filteredList =
+					diags.stream().filter(d -> d.getUri().equals(uri)).collect(Collectors.toList());
+			assertTrue(filteredList.size() == 1);
+			PublishDiagnosticsParams diag = filteredList.get(0);
 			if (expected.problemCount != diag.getDiagnostics().size()) {
 				String message = "";
 				for (Diagnostic d : diag.getDiagnostics()) {
@@ -954,7 +957,6 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 				}
 				assertEquals(message, expected.problemCount, diag.getDiagnostics().size());
 			}
-
 		}
 		diags.clear();
 	}


### PR DESCRIPTION
Adopt the new preference to solve the problem 'The package xxx is accessible from more than one module'.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/pull/424

fix https://github.com/redhat-developer/vscode-java/issues/2061
fix https://github.com/redhat-developer/vscode-java/issues/1732
fix https://github.com/redhat-developer/vscode-java/issues/862
fix https://github.com/redhat-developer/vscode-java/issues/1619

Signed-off-by: Sheng Chen <sheche@microsoft.com>