### PR TITLE
Support postfix completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2019 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -57,10 +57,9 @@ import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.MembersOrderPreferenceCacheCommon;
 import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettingsConstants;
-import org.eclipse.jdt.internal.corext.template.java.VarResolver;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.contentassist.TypeFilter;
-import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaContextType;
+import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaContextTypeRegistry;
 import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaLanguageServerTemplateStore;
 import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
@@ -73,7 +72,6 @@ import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.StandardPreferenceManager;
 import org.eclipse.jdt.ls.core.internal.syntaxserver.SyntaxLanguageServer;
 import org.eclipse.jdt.ls.core.internal.syntaxserver.SyntaxProjectsManager;
-import org.eclipse.jface.text.templates.TemplateVariableResolver;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.text.templates.ContextTypeRegistry;
@@ -571,21 +569,7 @@ public class JavaLanguageServerPlugin extends Plugin {
 	 */
 	public synchronized ContextTypeRegistry getTemplateContextRegistry() {
 		if (fContextTypeRegistry == null) {
-			ContextTypeRegistry registry = new ContextTypeRegistry();
-
-			JavaContextType statementContextType = new JavaContextType();
-			statementContextType.setId(JavaContextType.ID_STATEMENTS);
-			statementContextType.setName(JavaContextType.ID_STATEMENTS);
-			statementContextType.initializeContextTypeResolvers();
-			// Todo: Some of the resolvers is defined in the XML of the jdt.ui, now we have to add them manually.
-			// See: https://github.com/eclipse/eclipse.jdt.ui/blob/cf6c42522ee5a5ea21a34fcfdecf3504d4750a04/org.eclipse.jdt.ui/plugin.xml#L5619-L5625
-			TemplateVariableResolver resolver = new VarResolver();
-			resolver.setType("var");
-			statementContextType.addResolver(resolver);
-
-			registry.addContextType(statementContextType);
-
-			fContextTypeRegistry = registry;
+			fContextTypeRegistry = new JavaContextTypeRegistry();
 		}
 		return fContextTypeRegistry;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/ActualTypeResolver.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/ActualTypeResolver.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Nicolaj Hoess.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nicolaj Hoess - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.List;
+
+import org.eclipse.jface.text.templates.TemplateContext;
+import org.eclipse.jface.text.templates.TemplateVariable;
+import org.eclipse.jdt.internal.corext.template.java.JavaVariable;
+import org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariable;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.ActualTypeResolver
+ */
+public class ActualTypeResolver extends TypeResolver  {
+	private static final String EMPTY= ""; //$NON-NLS-1$
+
+	private static final String ARRAY_BRACKETS= "[]"; //$NON-NLS-1$
+
+	private static final String GENERIC_CLASS_SERPATOR= ","; //$NON-NLS-1$
+
+	private static final String GENERIC_CLASS_OPEN_DIAMOND= "<"; //$NON-NLS-1$
+
+	private static final String GENERIC_CLASS_CLOSE_DIAMOND= ">"; //$NON-NLS-1$
+
+	@Override
+	public void resolve(TemplateVariable variable, TemplateContext context) {
+		List<String> params= variable.getVariableType().getParams();
+		if (params.size() > 0 && context instanceof JavaPostfixContext) {
+			String param= params.get(0);
+			JavaPostfixContext jc= (JavaPostfixContext) context;
+			TemplateVariable ref= jc.getTemplateVariable(param);
+			MultiVariable mv= (MultiVariable) variable;
+
+			if (ref instanceof JavaVariable) {
+				// Reference is another variable
+				JavaVariable refVar= (JavaVariable) ref;
+				jc.addDependency(refVar, mv);
+
+				param= refVar.getParamType();
+				if (param != null && EMPTY.equals(param) == false) {
+					param= param.replace("? extends ", EMPTY); //$NON-NLS-1$
+					if (param.endsWith(ARRAY_BRACKETS)) { // In case of List<Integer[]> we must not remove []
+						// Variable is an array, i.e. String[] or List<String>[]
+						// Actual type is supposed to be:
+						// String[]							=> String
+						// List<String>[]					=> List<String>
+						// String[][]						=> String[]
+						param= param.substring(0, param.length() - 2);
+					} else if (param.endsWith(">")) { // Generic //$NON-NLS-1$
+						// Actual type of a generic is supposed to be:
+						// List<Integer>					=> Integer
+						// List<List<Integer>>				=> List<Integer>
+						// List<Map<Integer,String>>		=> Map<Integer,String>
+						// Map<Integer,String>>				=> Integer
+						// Something<Integer,Float,String>	=> Integer
+						param= param.substring(param.indexOf(GENERIC_CLASS_OPEN_DIAMOND) + 1,
+								param.lastIndexOf(GENERIC_CLASS_CLOSE_DIAMOND));
+						if (!param.contains(GENERIC_CLASS_OPEN_DIAMOND) && param.contains(GENERIC_CLASS_SERPATOR)) {
+							param= param.substring(0, param.indexOf(GENERIC_CLASS_SERPATOR));
+						}
+					} else {
+						// The given parameter is already an actual type
+					}
+
+					String reference= jc.addImportGenericClass(param);
+					mv.setValue(reference);
+					mv.setUnambiguous(true);
+
+					mv.setResolved(true);
+					return;
+				}
+			}
+		}
+		super.resolve(variable, context);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/InnerExpressionResolver.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/InnerExpressionResolver.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Nicolaj Hoess.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nicolaj Hoess - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.List;
+
+import org.eclipse.jdt.internal.corext.template.java.JavaVariable;
+import org.eclipse.jface.text.templates.SimpleTemplateVariableResolver;
+import org.eclipse.jface.text.templates.TemplateContext;
+import org.eclipse.jface.text.templates.TemplateVariable;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.InnerExpressionResolver
+ */
+public class InnerExpressionResolver extends SimpleTemplateVariableResolver {
+	public static final String INNER_EXPRESSION_VAR= "inner_expression"; //$NON-NLS-1$
+
+	public static final String HIDE_FLAG= "novalue"; //$NON-NLS-1$
+
+	public static final String[] FLAGS= { HIDE_FLAG };
+
+	public InnerExpressionResolver() {
+		super(INNER_EXPRESSION_VAR, ""); // TODO Add description //$NON-NLS-1$
+	}
+
+	@Override
+	protected String resolve(TemplateContext context) {
+		if (!(context instanceof JavaPostfixContext))
+			return ""; //$NON-NLS-1$
+
+		return ((JavaPostfixContext) context).getAffectedStatement();
+	}
+
+	@Override
+	public void resolve(TemplateVariable variable, TemplateContext context) {
+		if (context instanceof JavaPostfixContext && variable instanceof JavaVariable) {
+			JavaPostfixContext c= (JavaPostfixContext) context;
+			JavaVariable jv= (JavaVariable) variable;
+			List<String> params= variable.getVariableType().getParams();
+
+			if (!params.contains(HIDE_FLAG)) {
+				jv.setValue(resolve(context));
+			} else {
+				// TODO This is a hacky solution to hide the output of the variable for specific templates (e.g. .field).
+				jv.setValues(new String[] { "", resolve(context) }); // We hide the value from the output //$NON-NLS-1$
+			}
+
+			jv.setParamType(c.getInnerExpressionTypeSignature());
+			jv.setResolved(true);
+			jv.setUnambiguous(true);
+			return;
+		}
+		super.resolve(variable, context);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContext.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2019 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Lars Vogel  <lars.vogel@gmail.com> - [templates][content assist] Ctrl+Space without any starting letter shows to no templates - https://bugs.eclipse.org/406463
+ *     Lukas Hanke <hanke@yatta.de> - [templates][content assist] Content assist for 'for' loop should suggest member variables - https://bugs.eclipse.org/117215
+ *     Nicolaj Hoess <nicohoess@gmail.com> - Make some internal methods accessible to help Postfix Code Completion plug-in - https://bugs.eclipse.org/433500
+ *     Microsoft Corporation - moved template related code to jdt.core.manipulation - https://bugs.eclipse.org/549989
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.internal.corext.template.java.JavaContextCore;
+import org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariable;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.templates.TemplateContextType;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.JavaContext
+ * UI related code is removed.
+ */
+public class JavaContext extends JavaContextCore {
+	/** A global state for proposals that change if a master proposal changes. */
+	protected MultiVariableGuess fMultiVariableGuess;
+
+	/**
+	 * Creates a java template context.
+	 *
+	 * @param type   the context type.
+	 * @param document the document.
+	 * @param completionOffset the completion offset within the document.
+	 * @param completionLength the completion length.
+	 * @param compilationUnit the compilation unit (may be <code>null</code>).
+	 */
+	public JavaContext(TemplateContextType type, IDocument document, int completionOffset, int completionLength, ICompilationUnit compilationUnit) {
+		super(type, document, completionOffset, completionLength, compilationUnit);
+	}
+
+	/**
+	 * Creates a java template context.
+	 *
+	 * @param type   the context type.
+	 * @param document the document.
+	 * @param completionPosition the position defining the completion offset and length
+	 * @param compilationUnit the compilation unit (may be <code>null</code>).
+	 * @since 3.2
+	 */
+	public JavaContext(TemplateContextType type, IDocument document, Position completionPosition, ICompilationUnit compilationUnit) {
+		super(type, document, completionPosition, compilationUnit);
+	}
+
+	/**
+	 * Adds a multi-variable guess dependency.
+	 *
+	 * @param master the master variable - <code>slave</code> needs to be updated when
+	 *        <code>master</code> changes
+	 * @param slave the dependent variable
+	 * @since 3.3
+	 */
+	@Override
+	public void addDependency(MultiVariable master, MultiVariable slave) {
+		if (this.fMultiVariableGuess == null) {
+			this.fMultiVariableGuess = new MultiVariableGuess();
+		}
+
+		this.fMultiVariableGuess.addDependency(master, slave);
+	}
+
+	public MultiVariableGuess getMultiVariableGuess() {
+		return this.fMultiVariableGuess;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContextType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContextType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Corporation and others.
+ * Copyright (c) 2019-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -15,6 +15,8 @@ package org.eclipse.jdt.ls.core.internal.corext.template.java;
 
 import org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextTypeCore;
 import org.eclipse.jdt.internal.corext.template.java.IJavaContext;
+import org.eclipse.jdt.internal.corext.template.java.VarResolver;
+import org.eclipse.jface.text.templates.TemplateVariableResolver;
 
 /**
  * The context type for templates inside Java code. The same class is used for
@@ -48,6 +50,11 @@ public class JavaContextType extends AbstractJavaContextTypeCore {
 	 */
 	public static final String ID_MODULE = "module"; //$NON-NLS-1$
 
+	public JavaContextType() {
+		setId(ID_STATEMENTS);
+		setName(ID_STATEMENTS);
+	}
+
 	@Override
 	protected void initializeContext(IJavaContext context) {
 		// Separate 'module' context type from 'java' context type
@@ -57,5 +64,21 @@ public class JavaContextType extends AbstractJavaContextTypeCore {
 		if (!getId().equals(JavaContextType.ID_ALL)) { // a specific context must also allow the templates that work everywhere
 			context.addCompatibleContextType(JavaContextType.ID_ALL);
 		}
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextTypeCore#initializeContextTypeResolvers()
+	 */
+	@Override
+	public void initializeContextTypeResolvers() {
+		super.initializeContextTypeResolvers();
+		// TODO: Some of the resolvers are defined in org.eclipse.jdt.ui/plugin.xml, now we have to add them manually.
+		// See: https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/dc995e7a0069e1eca58b19a4bc365032c50b0201/org.eclipse.jdt.ui/plugin.xml#L5674-L5752
+		addResolver("var", new VarResolver());
+	}
+
+	public synchronized void addResolver(String type, TemplateVariableResolver resolver) {
+		resolver.setType(type);
+		addResolver(resolver);
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContextTypeRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaContextTypeRegistry.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.text.templates.ContextTypeRegistry;
+
+/**
+ * A registry for context types used by code snippet templates.
+ *
+ * @author Fred Bricon
+ * @see JavaContextType
+ * @see CodeSnippetTemplate
+ * @see PostfixTemplate
+ */
+public class JavaContextTypeRegistry extends ContextTypeRegistry {
+
+	public JavaContextTypeRegistry() {
+		JavaContextType contextType = new JavaContextType();
+		contextType.initializeContextTypeResolvers();
+		addContextType(contextType);
+
+		JavaPostfixContextType postfixContextType = new JavaPostfixContextType();
+		postfixContextType.initializeContextTypeResolvers();
+		addContextType(postfixContextType);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaLanguageServerTemplateStore.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaLanguageServerTemplateStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Corporation and others.
+ * Copyright (c) 2019-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -32,8 +32,11 @@ public class JavaLanguageServerTemplateStore extends TemplateStoreCore {
 	protected void loadContributedTemplates() {
 		for (CodeSnippetTemplate snippet : CodeSnippetTemplate.values()) {
 			Template template = snippet.createTemplate();
-			TemplatePersistenceData data = new TemplatePersistenceData(template, true, snippet.getId());
-			add(data);
+			add(new TemplatePersistenceData(template, true, snippet.getId()));
+		}
+		for (PostfixTemplate snippet : PostfixTemplate.values()) {
+			Template template = snippet.createTemplate();
+			add(new TemplatePersistenceData(template, true, snippet.getId()));
 		}
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContext.java
@@ -1,0 +1,775 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Nicolaj Hoess and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nicolaj Hoess - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.text.edits.MalformedTreeException;
+import org.eclipse.text.edits.TextEdit;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.templates.Template;
+import org.eclipse.jface.text.templates.TemplateBuffer;
+import org.eclipse.jface.text.templates.TemplateException;
+import org.eclipse.jface.text.templates.TemplateVariable;
+
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.NamingConventions;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.ArrayAccess;
+import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.WildcardType;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.JavaPostfixContext
+ */
+public class JavaPostfixContext extends JavaContext {
+
+	private static final Object CONTEXT_TYPE_ID= "postfix"; //$NON-NLS-1$
+
+	private static final String OBJECT_SIGNATURE= "java.lang.Object"; //$NON-NLS-1$
+
+	private static final String ID_SEPARATOR= "��"; //$NON-NLS-1$
+
+	private static final Pattern INNER_EXPRESSION_PATTERN= Pattern.compile("\\$\\{([a-zA-Z]*):" + InnerExpressionResolver.INNER_EXPRESSION_VAR + "\\(([^\\$|\\{|\\}]*)\\)\\}"); //$NON-NLS-1$ //$NON-NLS-2$
+
+	private static final Pattern CLASS_NAME_PATTERN= Pattern.compile("[a-zA-Z0-9$_\\.]+"); //$NON-NLS-1$
+
+	private ASTNode selectedNode;
+
+	private Map<ASTNode, Region> nodeRegions;
+
+	private Map<TemplateVariable, int[]> variableOutOfRangeOffsets;
+
+	private boolean domInitialized;
+
+	private BodyDeclaration bodyDeclaration;
+
+	private ASTNode parentDeclaration;
+
+	private CompletionContext completionCtx;
+
+	public JavaPostfixContext(JavaPostfixContextType type, IDocument document, int offset, int length, ICompilationUnit compilationUnit, ASTNode currentNode, ASTNode parentNode, CompletionContext context) {
+		super(type, document, offset, length, compilationUnit);
+
+		completionCtx= context;
+		nodeRegions= new HashMap<>();
+		variableOutOfRangeOffsets= new HashMap<>();
+		nodeRegions.put(currentNode, calculateNodeRegion(currentNode));
+		nodeRegions.put(parentNode, calculateNodeRegion(parentNode));
+		selectedNode= findBestASTNodeSelection(currentNode);
+	}
+
+	/**
+	 * Determines and returns the <i>best</i> {@link ASTNode} to apply a postfix template in the
+	 * current context.<br/>
+	 * Examples for <i>best</i> {@link ASTNode}s:
+	 * <ul>
+	 * <li><code>new Integer(0).$</code> will return the {@link ASTNode} for
+	 * <code>new Integer(0)</code></li>
+	 * </ul>
+	 *
+	 * @param currentNode The {@link ASTNode} of the completion.
+	 * @return An {@link ASTNode} of the key set of {@link #nodeRegions}.
+	 */
+	private ASTNode findBestASTNodeSelection(ASTNode currentNode) {
+		// This implementation takes the longest ASTNode by means of string length
+		// which doesn't exceed the completion position.
+		// If future extensions of the postfix implementation inject more than two ASTNodes
+		// the selection should be more intelligent.
+		// Some examples which should be considered for future implementations:
+		// `1 + 1 + 1.$` should select `1 + 1 + 1` (note that the expression is not parenthesized).
+		// `foo("asdf" + true.$` should select `true` since `"asdf" + true` makes no sense for any template in this context.
+		// `"test" + true.$` should select `true` for "sif" template and `"test" + true` for "var" template.
+		ASTNode result= currentNode;
+		int currMax= getNodeBegin(currentNode) + getNodeLength(currentNode);
+		Set<ASTNode> nodes= nodeRegions.keySet();
+		int tokenLength= (completionCtx != null && completionCtx.getToken() != null) ? completionCtx.getToken().length : 0;
+		int invOffset= completionCtx != null ? completionCtx.getOffset() - tokenLength - 1 : getCompletionOffset();
+		for (ASTNode n : nodes) {
+			int end= getNodeBegin(n) + getNodeLength(n);
+			if (end > currMax && end <= invOffset) {
+				currMax= end;
+				result= n;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Adds a new field to the {@link AST} using the given type and variable name. The method
+	 * returns a {@link TextEdit} which can then be applied using the
+	 * {@link #applyTextEdit(TextEdit)} method.
+	 *
+	 * @param type fully qualified type name of the new field
+	 * @param varName suggested field name
+	 * @param publicField <code>true</code> if the new field should be public
+	 * @param staticField <code>true</code> if the new field should be static
+	 * @param finalField <code>true</code> if the new field should be final
+	 * @param value the initialization value of the new field. If this parameter is
+	 *            <code>null</code> or empty the field is not initialized.
+	 * @return a {@link TextEdit} which represents the changes which would be made, or
+	 *         <code>null</code> if the field can not be created.
+	 */
+	public TextEdit addField(String type, String varName, boolean publicField, boolean staticField, boolean finalField, String value) {
+		if (isReadOnly())
+			return null;
+
+		if (!domInitialized)
+			initDomAST();
+
+		boolean isStatic= isBodyStatic();
+		int modifiers= (!publicField) ? Modifier.PRIVATE : Modifier.PUBLIC;
+		if (isStatic || staticField) {
+			modifiers|= Modifier.STATIC;
+		}
+		if (finalField) {
+			modifiers|= Modifier.FINAL;
+		}
+
+		ASTRewrite rewrite= ASTRewrite.create(parentDeclaration.getAST());
+		addFieldDeclaration(rewrite, parentDeclaration, modifiers, varName, type, value);
+		TextEdit te= rewrite.rewriteAST(getDocument(), null);
+		return te;
+	}
+
+	private VariableDeclarationFragment addFieldDeclaration(ASTRewrite rewrite, ASTNode newTypeDecl, int modifiers, String varName, String qualifiedName, String value) {
+		ChildListPropertyDescriptor property= ASTNodes.getBodyDeclarationsProperty(newTypeDecl);
+		List<BodyDeclaration> decls= ASTNodes.getBodyDeclarations(newTypeDecl);
+		AST ast= newTypeDecl.getAST();
+
+		VariableDeclarationFragment newDeclFrag= ast.newVariableDeclarationFragment();
+		newDeclFrag.setName(ast.newSimpleName(varName));
+
+		Type type= createType(Signature.createTypeSignature(qualifiedName, true), ast);
+
+		if (value != null && value.trim().length() > 0) {
+			Expression e= createExpression(value);
+			Expression ne= (Expression) ASTNode.copySubtree(ast, e);
+			newDeclFrag.setInitializer(ne);
+		} else {
+			if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
+				newDeclFrag.setInitializer(ASTNodeFactory.newDefaultExpression(ast, type, 0));
+			}
+		}
+
+		FieldDeclaration newDecl= ast.newFieldDeclaration(newDeclFrag);
+		newDecl.setType(type);
+		newDecl.modifiers().addAll(ASTNodeFactory.newModifiers(ast, modifiers));
+
+		int insertIndex= findFieldInsertIndex(decls, getCompletionOffset(), modifiers);
+		rewrite.getListRewrite(newTypeDecl, property).insertAt(newDecl, insertIndex, null);
+
+		return newDeclFrag;
+	}
+
+	/**
+	 * Adds all imports for a fully qualified generic type name, i.e. this method calls
+	 * {@link #addImport(String)} for all "parts" of the given qualified name.
+	 *
+	 * @param className fully qualified name of a generic type name
+	 * @return returns unqualified name of the generic type
+	 */
+	public String addImportGenericClass(String className) {
+		Matcher m= CLASS_NAME_PATTERN.matcher(className);
+		List<String> classNames= new ArrayList<>();
+		Map<String, String> classNameMapping= new HashMap<>();
+		while (m.find()) {
+			classNames.add(className.substring(m.start(), m.end()));
+		}
+		/*
+		 * In case the import class looks like this:
+		 * a.b.c.Foo<b.c.Foo>
+		 * we have to consider that - if we do not care about ordering, the following could happen:
+		 * 1. trying to import b.c.Foo - import is resolved to Foo
+		 * 2. replacing b.c.Foo with Foo - a.Foo<Foo> --> not correct (should be a.b.c.Foo<Foo>)
+		 * 3. ...
+		 *
+		 * The solution to this is as follows:
+		 * 1. sorting the fully qualified class names by length
+		 * 2. replacing all occurring class names with unique identifiers ($$id$$)
+		 * 3. importing all class names and map the fully qualified identifier with the resolved identifier of the class
+		 * 4. replace the unique identifiers with the mapped values
+		 */
+		Collections.sort(classNames, (arg0, arg1) -> arg1.length() - arg0.length());
+		// Note: We only disable readonly mode when it's adding import, and re-enable it immediately.
+		// Because we do not want to execute extra apply text edit before a completion item is committed.
+		// This is specific to JDT.LS only. See: JavaContextCore#rewriteImports()
+		this.setReadOnly(false);
+		for (int i= 0; i < classNames.size(); i++) {
+			className= className.replace(classNames.get(i), ID_SEPARATOR + i + ID_SEPARATOR);
+			classNameMapping.put(classNames.get(i), addImport(classNames.get(i)));
+		}
+		for (int i= 0; i < classNames.size(); i++) {
+			className= className.replace(ID_SEPARATOR + i + ID_SEPARATOR, classNameMapping.get(classNames.get(i)));
+		}
+		this.setReadOnly(true);
+		return className;
+	}
+
+	/**
+	 * Applies a {@link TextEdit} to the {@link IDocument} of this context and updates the
+	 * completion offset variable.
+	 *
+	 * @param te {@link TextEdit} to apply
+	 * @return <code>true</code> if the method was successful, <code>false</code> otherwise
+	 */
+	public boolean applyTextEdit(TextEdit te) {
+		try {
+			te.apply(getDocument());
+			setCompletionOffset(getCompletionOffset() + ((te.getOffset() < getCompletionOffset()) ? te.getLength() : 0));
+			return true;
+		} catch (MalformedTreeException | BadLocationException e) {
+			// fall through returning false
+		}
+		return false;
+	}
+
+	private Region calculateNodeRegion(ASTNode node) {
+		if (node == null) {
+			return new Region(0, 0);
+		}
+		int start= getNodeBegin(node);
+		int end= getCompletionOffset() - getPrefixKey().length() - start - 1; // TODO Not entirely correct but good enough for our needs (calculation should be similar to getNodeBegin(..))
+		return new Region(start, end);
+	}
+
+	/*
+	 * @see TemplateContext#canEvaluate(Template templates)
+	 */
+	@Override
+	public boolean canEvaluate(Template template) {
+		if (!template.getContextTypeId().equals(JavaPostfixContext.CONTEXT_TYPE_ID))
+			return false;
+
+		if (isForceEvaluation())
+			return true;
+
+		if (selectedNode == null) // We can evaluate to true only if we have a valid inner expression
+			return false;
+
+		if (template.getName().toLowerCase().startsWith(getPrefixKey().toLowerCase()) == false) {
+			return false;
+		}
+
+		// We check if the template makes "sense" by checking the requirements/conditions for the template
+		// For this purpose we have to resolve the inner_expression variable of the template
+		// This approach is much faster then delegating this to the existing TemplateTranslator class
+		// (Maybe this hard-coded dependency to the inner expression variable is a little bit weird)
+		Matcher matcher= INNER_EXPRESSION_PATTERN.matcher(template.getPattern());
+		boolean result= true;
+
+		while (matcher.find()) {
+			String[] types= matcher.group(2).split(","); //$NON-NLS-1$
+			for (String s : types) {
+				if (!Arrays.asList(InnerExpressionResolver.FLAGS).contains(s)) {
+					result= false;
+					if (this.isNodeResolvingTo(selectedNode, s.trim()) == true) {
+						return true;
+					}
+				}
+			}
+		}
+		return result;
+	}
+
+	private boolean containsNestedCapture(String signature) {
+		return signature.length() > 1 && signature.indexOf(Signature.C_CAPTURE, 1) != -1;
+	}
+
+	private Expression createExpression(String expr) {
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setKind(ASTParser.K_EXPRESSION);
+		parser.setResolveBindings(true);
+		parser.setSource(expr.toCharArray());
+		ASTNode astNode= parser.createAST(new NullProgressMonitor());
+		return (Expression) astNode;
+	}
+
+	private Type createType(String typeSig, AST ast) {
+		int sigKind= Signature.getTypeSignatureKind(typeSig);
+		switch (sigKind) {
+			case Signature.BASE_TYPE_SIGNATURE:
+				return ast.newPrimitiveType(PrimitiveType.toCode(Signature.toString(typeSig)));
+			case Signature.ARRAY_TYPE_SIGNATURE:
+				Type elementType= createType(Signature.getElementType(typeSig), ast);
+				return ast.newArrayType(elementType, Signature.getArrayCount(typeSig));
+			case Signature.CLASS_TYPE_SIGNATURE:
+				String erasureSig= Signature.getTypeErasure(typeSig);
+
+				String erasureName= Signature.toString(erasureSig);
+				if (erasureSig.charAt(0) == Signature.C_RESOLVED) {
+					erasureName= addImport(erasureName);
+				}
+
+				Type baseType= ast.newSimpleType(ast.newName(erasureName));
+				String[] typeArguments= Signature.getTypeArguments(typeSig);
+				if (typeArguments.length > 0) {
+					ParameterizedType type= ast.newParameterizedType(baseType);
+					List<Type> argNodes= type.typeArguments();
+					for (String curr : typeArguments) {
+						if (containsNestedCapture(curr)) {
+							argNodes.add(ast.newWildcardType());
+						} else {
+							argNodes.add(createType(curr, ast));
+						}
+					}
+					return type;
+				}
+				return baseType;
+			case Signature.TYPE_VARIABLE_SIGNATURE:
+				return ast.newSimpleType(ast.newSimpleName(Signature.toString(typeSig)));
+			case Signature.WILDCARD_TYPE_SIGNATURE:
+				WildcardType wildcardType= ast.newWildcardType();
+				char ch= typeSig.charAt(0);
+				if (ch != Signature.C_STAR) {
+					Type bound= createType(typeSig.substring(1), ast);
+					wildcardType.setBound(bound, ch == Signature.C_EXTENDS);
+				}
+				return wildcardType;
+			case Signature.CAPTURE_TYPE_SIGNATURE:
+				return createType(typeSig.substring(1), ast);
+		}
+		return ast.newSimpleType(ast.newName(OBJECT_SIGNATURE));
+	}
+
+	@Override
+	public TemplateBuffer evaluate(Template template)
+			throws BadLocationException, TemplateException {
+		TemplateBuffer result= super.evaluate(template);
+
+		// After the template buffer has been created we are able to add out of range offsets
+		// This is not possible beforehand as it will result in an exception!
+		for (TemplateVariable tv : result.getVariables()) {
+			int[] outOfRangeOffsets= variableOutOfRangeOffsets.get(tv);
+			if (outOfRangeOffsets != null && outOfRangeOffsets.length > 0) {
+				int[] offsets= tv.getOffsets();
+				int[] newOffsets= Arrays.copyOf(offsets, offsets.length + outOfRangeOffsets.length);
+				System.arraycopy(outOfRangeOffsets, 0, newOffsets, offsets.length, outOfRangeOffsets.length);
+				tv.setOffsets(newOffsets);
+			}
+		}
+		return result;
+	}
+
+	private int findFieldInsertIndex(List<BodyDeclaration> decls, int currPos, int modifiers) {
+		for (int i= decls.size() - 1; i >= 0; i--) {
+			ASTNode curr= decls.get(i);
+			if (curr instanceof FieldDeclaration && currPos > curr.getStartPosition() + curr.getLength()
+					&& ((FieldDeclaration) curr).getModifiers() == modifiers) {
+				return i + 1;
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Returns the {@link Region} which represents the source region of the affected statement.
+	 *
+	 * @return the source region of the affected statement
+	 */
+	public Region getAffectedSourceRegion() {
+		return new Region(getCompletionOffset() - getPrefixKey().length() - nodeRegions.get(selectedNode).getLength() - 1, nodeRegions.get(selectedNode).getLength());
+	}
+
+	public String getAffectedStatement() {
+		Region r= getAffectedSourceRegion();
+		try {
+			return getDocument().get(r.getOffset(), r.getLength());
+		} catch (BadLocationException e) {
+			// fall through returning empty string
+		}
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
+	public int getEnd() {
+		return getCompletionOffset();
+	}
+
+	/**
+	 * Returns the fully qualified name the node of the current code completion invocation resolves
+	 * to.
+	 *
+	 * @return a fully qualified type signature or the name of the base type.
+	 */
+	public String getInnerExpressionTypeSignature() {
+		return resolveNodeToTypeString(selectedNode);
+	}
+
+	/**
+	 * Calculates the beginning position of a given {@link ASTNode}
+	 *
+	 * @param node the {@link ASTNode}
+	 * @return source position of the node or -1 if the given node is <code>null</code>
+	 */
+	protected int getNodeBegin(ASTNode node) {
+		if (node == null) {
+			return -1;
+		}
+		if (node.getParent() instanceof MethodInvocation) {
+			return ((MethodInvocation) node.getParent()).getStartPosition();
+		} else if (node.getParent() instanceof FieldAccess || node.getParent() instanceof SuperFieldAccess) {
+			return node.getParent().getStartPosition();
+		} else if (node instanceof Name) {
+			ASTNode n= node;
+			while (n.getParent() instanceof QualifiedName) {
+				n= n.getParent();
+			}
+			return ((Name) n).getStartPosition();
+		}
+		return node.getStartPosition();
+	}
+
+	/**
+	 * Calculates the length of a given {@link ASTNode}
+	 *
+	 * @param node the {@link ASTNode}
+	 * @return length of the node or -1 if the given node is <code>null</code>
+	 */
+	protected int getNodeLength(ASTNode node) {
+		if (node == null) {
+			return -1;
+		}
+		return node.getLength();
+	}
+
+	/**
+	 * Returns the current prefix of the key which was typed in. <br/>
+	 * Examples: <code>
+	 * <br/>
+	 * new Object().		=> getPrefixKey() returns ""<br/>
+	 * new Object().a		=> getPrefixKey() returns "a"<br/>
+	 * new object().asdf	=> getPrefixKey() returns "asdf"<br/>
+	 * </code>
+	 *
+	 * @return an empty string or a string which represents the prefix of the key which was typed in
+	 */
+	private String getPrefixKey() {
+		if (completionCtx != null) {
+			IDocument document= getDocument();
+			int start= completionCtx.getTokenStart();
+			int end= completionCtx.getTokenEnd();
+			try {
+				return document.get(start, end - start + 1);
+			} catch (BadLocationException e) {
+				// fall through returning empty string
+			}
+		}
+		return ""; //$NON-NLS-1$
+	}
+
+	@Override
+	public int getStart() {
+		int result= super.getStart();
+		result-= getAffectedSourceRegion().getLength() + 1;
+		return result;
+	}
+
+	private void initDomAST() {
+		if (isReadOnly())
+			return;
+
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setSource(getCompilationUnit());
+		parser.setResolveBindings(true);
+		ASTNode domAst= parser.createAST(new NullProgressMonitor());
+
+		NodeFinder nf= new NodeFinder(domAst, getCompletionOffset(), 1);
+		ASTNode cv= nf.getCoveringNode();
+
+		bodyDeclaration= ASTResolving.findParentBodyDeclaration(cv);
+		parentDeclaration= ASTResolving.findParentType(cv);
+		domInitialized= true;
+	}
+
+	/**
+	 * Returns <code>true</code> if the type or one of its supertypes of a given {@link ASTNode}
+	 * resolves to a given type signature. <br/>
+	 * Examples: <br/>
+	 * <code>
+	 * <br/>
+	 * isNodeResolvingTo(node of type java.lang.String, "java.lang.Object") returns true<br/>
+	 * isNodeResolvingTo(node of type java.lang.String, "java.lang.Iterable") returns false<br/>
+	 * </code>
+	 *
+	 * TODO Implement this method without using the recursive helper method if there are any
+	 * performance/stackoverflow issues
+	 *
+	 * @param node an ASTNode
+	 * @param signature a fully qualified type
+	 * @return true if the type of the given ASTNode itself or one of its superclass/superinterfaces
+	 *         resolves to the given signature. false otherwise.
+	 */
+	private boolean isNodeResolvingTo(ASTNode node, String signature) {
+		if (signature == null || signature.trim().length() == 0) {
+			return true;
+		}
+		ITypeBinding tb= resolveNodeToBinding(node);
+		if (tb != null && tb.isPrimitive()) {
+			return (new String(tb.getQualifiedName()).equals(signature));
+		} else {
+			return resolvesReferenceBindingTo(tb, signature);
+		}
+	}
+
+	private boolean isBodyStatic() {
+		boolean isAnonymous= parentDeclaration.getNodeType() == ASTNode.ANONYMOUS_CLASS_DECLARATION;
+		boolean isStatic= Modifier.isStatic(bodyDeclaration.getModifiers()) && !isAnonymous;
+		return isStatic;
+	}
+
+	public void registerOutOfRangeOffset(TemplateVariable var, int absoluteOffset) {
+		if (variableOutOfRangeOffsets.get(var) == null) {
+			variableOutOfRangeOffsets.put(var, new int[] { absoluteOffset });
+		} else {
+			int[] temp= variableOutOfRangeOffsets.get(var);
+			int[] newArr= new int[temp.length + 1];
+			System.arraycopy(temp, 0, newArr, 0, temp.length);
+			newArr[temp.length]= absoluteOffset;
+			variableOutOfRangeOffsets.put(var, newArr);
+		}
+	}
+
+	private ITypeBinding resolveNodeToBinding(ASTNode node) {
+		if (node instanceof StringLiteral) {
+			return ((StringLiteral) node).resolveTypeBinding();
+		}
+
+		ITypeBinding[] res= new ITypeBinding[1];
+		node.accept(new ASTVisitor() {
+
+			@Override
+			public boolean visit(MethodInvocation n) {
+				res[0]= n.resolveTypeBinding();
+				return false;
+			}
+
+			@Override
+			public boolean visit(SimpleName n) {
+				IBinding b= n.resolveBinding();
+				if (b instanceof IVariableBinding) {
+					IVariableBinding vb= (IVariableBinding) b;
+					res[0]= vb.getType();
+				} else if (b instanceof IMethodBinding) {
+					IMethodBinding mb= (IMethodBinding) b;
+					res[0]= mb.getReturnType();
+				}
+				return false;
+			}
+
+			@Override
+			public boolean visit(QualifiedName n) {
+				IBinding b= n.resolveBinding();
+				if (b instanceof IVariableBinding) {
+					IVariableBinding vb= (IVariableBinding) b;
+					res[0]= vb.getType();
+				}
+				return false;
+			}
+
+			@Override
+			public boolean visit(FieldAccess n) {
+				ITypeBinding tmp= n.getName().resolveTypeBinding();
+				if (tmp != null) {
+					res[0]= tmp;
+					return false;
+				}
+				res[0]= n.getExpression().resolveTypeBinding();
+				return false;
+			}
+
+			@Override
+			public boolean visit(Assignment n) {
+				ITypeBinding tmp= n.getLeftHandSide().resolveTypeBinding();
+				if (tmp != null) {
+					res[0]= tmp;
+					return false;
+				}
+				return true;
+			}
+
+			@Override
+			public boolean visit(BooleanLiteral n) {
+				res[0]= n.resolveTypeBinding();
+				return false;
+			}
+
+			@Override
+			public boolean visit(InfixExpression n) {
+				res[0]= n.resolveTypeBinding();
+				return false;
+			}
+
+			@Override
+			public boolean visit(ClassInstanceCreation n) {
+				res[0]= n.resolveTypeBinding();
+				return false;
+			}
+
+			@Override
+			public boolean visit(ArrayAccess n) {
+				res[0]= n.resolveTypeBinding();
+				return false;
+			}
+		});
+
+		return res[0] != null ? res[0] : null;
+	}
+
+	private String resolveNodeToTypeString(ASTNode node) {
+		ITypeBinding b= resolveNodeToBinding(node);
+		if (b == null) {
+			return OBJECT_SIGNATURE;
+		}
+		String result= b.getQualifiedName();
+		if (result.isEmpty() && b.isCapture()) {
+			for (ITypeBinding tb : b.getTypeBounds()) {
+				result= tb.getQualifiedName();
+				if (!result.isEmpty()) {
+					return result;
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * This is a recursive method which performs a depth first search in the inheritance graph of
+	 * the given {@link ITypeBinding}.
+	 *
+	 * @param sb a TypeBinding
+	 * @param signature a fully qualified type
+	 * @return <code>true</code> if the given TypeBinding itself or one of its
+	 *         superclass/superinterfaces resolves to the given signature, <code>false</code>
+	 *         otherwise.
+	 */
+	private boolean resolvesReferenceBindingTo(ITypeBinding sb, String signature) {
+		if (sb == null) {
+			return false;
+		}
+		if (new String(sb.getQualifiedName()).startsWith(signature) || (sb.isArray() && "array".equals(signature))) { //$NON-NLS-1$
+			return true;
+		}
+		if (Object.class.getName().equals(signature)) {
+			return true;
+		}
+
+		List<ITypeBinding> bindings= new ArrayList<>();
+		Collections.addAll(bindings, sb.getInterfaces());
+		bindings.add(sb.getSuperclass());
+		boolean result= false;
+		Iterator<ITypeBinding> it= bindings.iterator();
+		while (it.hasNext() && result == false) {
+			result= resolvesReferenceBindingTo(it.next(), signature);
+		}
+		return result;
+	}
+
+	public String[] suggestFieldName(String type, String[] excludes, boolean staticField, boolean finalField) throws IllegalArgumentException {
+		int dim= 0;
+		while (type.endsWith("[]")) { //$NON-NLS-1$
+			dim++;
+			type= type.substring(0, type.length() - 2);
+		}
+
+		IJavaProject project= getJavaProject();
+		int namingConventions= 0;
+		if (staticField && finalField) {
+			namingConventions= NamingConventions.VK_STATIC_FINAL_FIELD;
+		} else if (staticField && !finalField) {
+			namingConventions= NamingConventions.VK_STATIC_FIELD;
+		} else {
+			namingConventions= NamingConventions.VK_INSTANCE_FIELD;
+		}
+		if (project != null)
+			return StubUtility.getVariableNameSuggestions(namingConventions, project, type, dim, Arrays.asList(excludes), true);
+
+		return new String[] { Signature.getSimpleName(type).toLowerCase() };
+	}
+
+	public String[] suggestFieldName(String type, boolean finalField, boolean forceStatic) {
+		if (!domInitialized) {
+			initDomAST();
+		}
+		if (domInitialized) {
+			return suggestFieldName(type, ASTResolving.getUsedVariableNames(bodyDeclaration), (forceStatic) ? forceStatic : isBodyStatic(), finalField);
+		}
+		// If the dom is not initialized yet (template preview) we return a dummy name
+		return new String[] { "newField" }; //$NON-NLS-1$
+	}
+
+	@Override
+	public String[] suggestVariableNames(String type) throws IllegalArgumentException {
+		List<String> res= new ArrayList<>();
+		if (selectedNode instanceof Expression) {
+			ITypeBinding tb= resolveNodeToBinding(selectedNode);
+			List<String> excludes= Arrays.asList(computeExcludes());
+			String[] names= StubUtility.getVariableNameSuggestions(NamingConventions.VK_LOCAL, getJavaProject(), tb, (Expression)selectedNode, excludes);
+			res.addAll(Arrays.asList(names));
+		}
+		res.addAll(Arrays.asList(super.suggestVariableNames(type)));
+		return res.toArray(new String [0]);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContextType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContextType.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Nicolaj Hoess.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Nicolaj Hoess - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextTypeCore;
+import org.eclipse.jdt.internal.corext.template.java.CompilationUnitContext;
+import org.eclipse.jdt.internal.corext.template.java.IJavaContext;
+import org.eclipse.jdt.internal.corext.template.java.NameResolver;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.templates.TemplateVariableResolver;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.JavaPostfixContextType
+ */
+public class JavaPostfixContextType extends AbstractJavaContextTypeCore {
+	public static final String ID_ALL= "postfix"; //$NON-NLS-1$
+
+	public JavaPostfixContextType() {
+		this.setId(ID_ALL);
+		this.addResolver(new InnerExpressionResolver());
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextTypeCore#initializeContextTypeResolvers()
+	 */
+	@Override
+	public void initializeContextTypeResolvers() {
+		super.initializeContextTypeResolvers();
+		// TODO: Some of the resolvers are defined in org.eclipse.jdt.ui/plugin.xml, now we have to add them manually.
+		// See: https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/dc995e7a0069e1eca58b19a4bc365032c50b0201/org.eclipse.jdt.ui/plugin.xml#L5674-L5752
+		addResolver("newActualType",  new ActualTypeResolver());
+		addResolver("newName",  new NameResolver());
+		addResolver("newType", new TypeResolver());
+	}
+
+	public synchronized void addResolver(String type, TemplateVariableResolver resolver) {
+		resolver.setType(type);
+		addResolver(resolver);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.internal.corext.template.java.AbstractJavaContextType#initializeContext(org.eclipse.jdt.internal.corext.template.java.JavaContext)
+	 */
+	@Override
+	protected void initializeContext(IJavaContext context) {
+		if (!JavaPostfixContextType.ID_ALL.equals(getId())) { // a specific context must also allow the templates that work everywhere
+			context.addCompatibleContextType(JavaPostfixContextType.ID_ALL);
+		}
+	}
+
+	/*
+	 * @see org.eclipse.jdt.internal.corext.template.java.CompilationUnitContextType#createContext(org.eclipse.jface.text.IDocument, int, int, org.eclipse.jdt.core.ICompilationUnit)
+	 */
+	@Override
+	public CompilationUnitContext createContext(IDocument document, int offset, int length, ICompilationUnit compilationUnit) {
+		return createContext(document, offset, length, compilationUnit, null, null, null);
+	}
+
+	/*
+	 * @see org.eclipse.jdt.internal.corext.template.java.CompilationUnitContextType#createContext(org.eclipse.jface.text.IDocument, org.eclipse.jface.text.Position, org.eclipse.jdt.core.ICompilationUnit)
+	 */
+	@Override
+	public CompilationUnitContext createContext(IDocument document, Position completionPosition, ICompilationUnit compilationUnit) {
+		return createContext(document, completionPosition.getOffset(), completionPosition.getLength(), compilationUnit);
+	}
+
+	public JavaPostfixContext createContext(IDocument document, int offset, int length, ICompilationUnit compilationUnit, ASTNode currentNode, ASTNode parentNode, CompletionContext context) {
+		JavaPostfixContext javaContext= new JavaPostfixContext(this, document, offset, length, compilationUnit, currentNode, parentNode, context);
+		initializeContext(javaContext);
+		return javaContext;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/MultiVariableGuess.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/MultiVariableGuess.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariable;
+
+/**
+ * Global state for templates. Selecting a proposal for the master template variable
+ * will cause the value (and the proposals) for the slave variables to change.
+ * 
+ * Copied from org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariableGuess
+ * UI related code is removed.
+ *
+ * @see MultiVariable
+ */
+public class MultiVariableGuess {
+
+	private final Map<MultiVariable, Set<MultiVariable>> fDependencies= new HashMap<>();
+	private final Map<MultiVariable, MultiVariable> fBackwardDeps= new HashMap<>();
+	private final Map<MultiVariable, VariablePosition> fPositions= new HashMap<>();
+
+	public MultiVariableGuess() {
+	}
+
+	/**
+	 * @param position
+	 */
+	public void addSlave(VariablePosition position) {
+		fPositions.put(position.getVariable(), position);
+	}
+
+	/**
+	 * @param master
+	 * @param slave
+	 * @since 3.3
+	 */
+	public void addDependency(MultiVariable master, MultiVariable slave) {
+		// check for cycles and multi-slaves
+		if (fBackwardDeps.containsKey(slave))
+			throw new IllegalArgumentException("slave can only serve one master"); //$NON-NLS-1$
+		Object parent= master;
+		while (parent != null) {
+			parent= fBackwardDeps.get(parent);
+			if (parent == slave)
+				throw new IllegalArgumentException("cycle detected"); //$NON-NLS-1$
+		}
+
+		Set<MultiVariable> slaves= fDependencies.get(master);
+		if (slaves == null) {
+			slaves= new HashSet<>();
+			fDependencies.put(master, slaves);
+		}
+		fBackwardDeps.put(slave, master);
+		slaves.add(slave);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
@@ -51,18 +51,11 @@ public class PostfixCompletionProposalComputer {
 
 	public PostfixTemplateEngine computeCompletionEngine(CompletionContext jdtContext, IDocument document, int offset) {
 		if (jdtContext != null && jdtContext.isExtended()) {
-			int tokenLocation= jdtContext.getTokenLocation();
-			int tokenStart= jdtContext.getTokenStart();
-			int tokenKind= jdtContext.getTokenKind();
-			if ((tokenLocation == 0 && tokenStart > -1)
-					|| ((tokenLocation & CompletionContext.TL_MEMBER_START) != 0 && tokenKind == CompletionContext.TOKEN_KIND_NAME && tokenStart > -1)
-					|| (tokenLocation == 0 && isAfterTrigger(document, offset))) {
-				if (postfixCompletionTemplateEngine == null) {
-					postfixCompletionTemplateEngine = new PostfixTemplateEngine();
-				}
-				updateTemplateEngine(jdtContext);
-				return postfixCompletionTemplateEngine;
+			if (postfixCompletionTemplateEngine == null) {
+				postfixCompletionTemplateEngine = new PostfixTemplateEngine();
 			}
+			updateTemplateEngine(jdtContext);
+			return postfixCompletionTemplateEngine;
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+
+/**
+ * Copied from org.eclipse.jdt.internal.ui.text.template.contentassist.PostfixCompletionProposalComputer
+ * UI related code is removed.
+ */
+public class PostfixCompletionProposalComputer {
+
+	private PostfixTemplateEngine postfixCompletionTemplateEngine;
+
+	public PostfixTemplateEngine computeCompletionEngine(CompletionContext jdtContext, IDocument document, int offset) {
+		if (jdtContext != null && jdtContext.isExtended()) {
+			int tokenLocation= jdtContext.getTokenLocation();
+			int tokenStart= jdtContext.getTokenStart();
+			int tokenKind= jdtContext.getTokenKind();
+			if ((tokenLocation == 0 && tokenStart > -1)
+					|| ((tokenLocation & CompletionContext.TL_MEMBER_START) != 0 && tokenKind == CompletionContext.TOKEN_KIND_NAME && tokenStart > -1)
+					|| (tokenLocation == 0 && isAfterTrigger(document, offset))) {
+				if (postfixCompletionTemplateEngine == null) {
+					postfixCompletionTemplateEngine = new PostfixTemplateEngine();
+				}
+				updateTemplateEngine(jdtContext);
+				return postfixCompletionTemplateEngine;
+			}
+		}
+		return null;
+	}
+
+	private void updateTemplateEngine(CompletionContext jdtContext) {
+		IJavaElement enclosingElement= jdtContext.getEnclosingElement();
+		if (enclosingElement == null) {
+			return;
+		}
+
+		int tokenLength= jdtContext.getToken() != null ? jdtContext.getToken().length : 0;
+		int invOffset= jdtContext.getOffset() - tokenLength - 1;
+
+		ICompilationUnit cu= (ICompilationUnit) enclosingElement.getAncestor(IJavaElement.COMPILATION_UNIT);
+		CompilationUnit cuRoot= SharedASTProviderCore.getAST(cu, SharedASTProviderCore.WAIT_NO, null);
+		if (cuRoot == null) {
+			cuRoot= (CompilationUnit) createPartialParser(cu, invOffset).createAST(null);
+		}
+
+		if (enclosingElement instanceof IMember) {
+			ISourceRange sr;
+			try {
+				sr= ((IMember) enclosingElement).getSourceRange();
+				if (sr == null) {
+					return;
+				}
+			} catch (JavaModelException e) {
+				return;
+			}
+
+			ASTNode completionNode= NodeFinder.perform(cuRoot, sr);
+			if (completionNode == null) {
+				return;
+			}
+
+			ASTNode[] bestNode= new ASTNode[] { completionNode };
+			completionNode.accept(new ASTVisitor() {
+				@Override
+				public boolean visit(StringLiteral node) {
+					int start= node.getStartPosition();
+					if (invOffset > start && start >= bestNode[0].getStartPosition()) {
+						bestNode[0]= node;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(ExpressionStatement node) {
+					int start= node.getStartPosition();
+					if (invOffset > start && start >= bestNode[0].getStartPosition()) {
+						bestNode[0]= node;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(SimpleName node) {
+					int start= node.getStartPosition();
+					if (invOffset > start && start >= bestNode[0].getStartPosition()) {
+						bestNode[0]= node;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(QualifiedName node) {
+					int start= node.getStartPosition();
+					if (invOffset > start && start >= bestNode[0].getStartPosition()) {
+						bestNode[0]= node;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(BooleanLiteral node) {
+					int start= node.getStartPosition();
+					if (invOffset > start && start >= bestNode[0].getStartPosition()) {
+						bestNode[0]= node;
+					}
+					return true;
+				}
+
+				@Override
+				public boolean visit(MethodInvocation node) {
+					return visit((Expression)node);
+				}
+
+				@Override
+				public boolean visit(SuperMethodInvocation node) {
+					return visit((Expression)node);
+				}
+
+				@Override
+				public boolean visit(ClassInstanceCreation node) {
+					return visit((Expression)node);
+				}
+
+				/**
+				 * Does NOT override {@link ASTVisitor}
+				 * Handle {@link MethodInvocation}, {@link SuperMethodInvocation}
+				 * and {@link ClassInstanceCreation}
+				 */
+				public boolean visit(Expression node) {
+					/*
+					 * Do not consider a method invocation node as the best node
+					 * if it is RECOVERED. A recovered node may in fact be open
+					 * 'System.out.println(...' and the best node may be within
+					 * the invocation.
+					 *
+					 * See PostFixCompletionTest#testConcatenatedShorthandIfStatement()
+					 */
+					if ((node.getFlags() & ASTNode.RECOVERED) == 0) {
+						int start= node.getStartPosition();
+						int end= start + node.getLength() - 1;
+						if (invOffset > start && invOffset == end + 1) {
+							bestNode[0]= node;
+							return false;
+						}
+					}
+					return true;
+				}
+			});
+
+			completionNode= bestNode[0];
+			ASTNode completionNodeParent= findBestMatchingParentNode(completionNode);
+			postfixCompletionTemplateEngine.setASTNodes(completionNode, completionNodeParent);
+			postfixCompletionTemplateEngine.setContext(jdtContext);
+		}
+	}
+
+	/**
+	 * This method determines the best matching parent {@link ASTNode} of the given {@link ASTNode}.
+	 * Consider the following example for the definition of <i>best matching parent</i>:<br/>
+	 * <code>("two" + 2).var$</code> has <code>"two"</code> as completion {@link ASTNode}. The
+	 * parent node is <code>"two" + 2</code> which will result in a syntactically incorrect result,
+	 * if the template is applied, because the parentheses aren't taken into account.
+	 *
+	 * @param node The current {@link ASTNode}
+	 * @return {@link ASTNode} which either is the parent of the given node or another predecessor
+	 *         {@link ASTNode} in the abstract syntax tree.
+	 */
+	private ASTNode findBestMatchingParentNode(ASTNode node) {
+		ASTNode result= node.getParent();
+		if (result instanceof InfixExpression) {
+			ASTNode completionNodeGrandParent= result.getParent();
+			int safeGuard= 0;
+			while (completionNodeGrandParent instanceof ParenthesizedExpression && safeGuard++ < 64) {
+				result= completionNodeGrandParent;
+				completionNodeGrandParent= result.getParent();
+			}
+		}
+		if (node instanceof SimpleName && result instanceof SimpleType) {
+			ASTNode completionNodeGrandParent= result.getParent();
+			if (completionNodeGrandParent instanceof ClassInstanceCreation) {
+				result= completionNodeGrandParent;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Returns true if the given offset is directly after an assist trigger character.
+	 *
+	 * @param document the actual document of type {@link IDocument}
+	 * @param offset the current location in the document
+	 * @return <code>true</code> if the given offset is directly after an assist trigger character,
+	 *         <code>false</code> otherwise. If the given offset is out of the given document
+	 *         <code>false</code> is returned.
+	 */
+	private boolean isAfterTrigger(IDocument document, int offset) {
+		String triggers= ".";
+		try {
+			return triggers.contains(document.get(offset - 1, 1));
+		} catch (BadLocationException e) {
+			return false;
+		}
+	}
+
+	private static ASTParser createPartialParser(ICompilationUnit cu, int position) {
+		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setProject(cu.getJavaProject());
+		parser.setSource(cu);
+		parser.setFocalPosition(position);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		parser.setStatementsRecovery(true);
+		return parser;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixCompletionProposalComputer.java
@@ -38,7 +38,6 @@ import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
-import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 
 /**
@@ -214,24 +213,6 @@ public class PostfixCompletionProposalComputer {
 			}
 		}
 		return result;
-	}
-
-	/**
-	 * Returns true if the given offset is directly after an assist trigger character.
-	 *
-	 * @param document the actual document of type {@link IDocument}
-	 * @param offset the current location in the document
-	 * @return <code>true</code> if the given offset is directly after an assist trigger character,
-	 *         <code>false</code> otherwise. If the given offset is out of the given document
-	 *         <code>false</code> is returned.
-	 */
-	private boolean isAfterTrigger(IDocument document, int offset) {
-		String triggers= ".";
-		try {
-			return triggers.contains(document.get(offset - 1, 1));
-		} catch (BadLocationException e) {
-			return false;
-		}
 	}
 
 	private static ASTParser createPartialParser(ICompilationUnit cu, int position) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
@@ -22,7 +22,7 @@ public enum PostfixTemplate {
 	ELSE(PostfixPreferences.ELSE_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.ELSE_CONTENT, PostfixPreferences.ELSE_DESCRIPTION),
 	FOR(PostfixPreferences.FOR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FOR_CONTENT, PostfixPreferences.FOR_DESCRIPTION),
 	FORI(PostfixPreferences.FORI_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FORI_CONTENT, PostfixPreferences.FORI_DESCRIPTION),
-	FORR(PostfixPreferences.FORR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FORR_CONTENT, PostfixPreferences.FORI_DESCRIPTION),
+	FORR(PostfixPreferences.FORR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FORR_CONTENT, PostfixPreferences.FORR_DESCRIPTION),
 	NNULL(PostfixPreferences.NNULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NNULL_CONTENT, PostfixPreferences.NNULL_DESCRIPTION),
 	NULL(PostfixPreferences.NULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NULL_CONTENT, PostfixPreferences.NULL_DESCRIPTION),
 	SYSOUT(PostfixPreferences.SYSOUT_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.SYSOUT_CONTENT, PostfixPreferences.SYSOUT_DESCRIPTION),

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.jface.text.templates.Template;
+
+public enum PostfixTemplate {
+
+	//@formatter:on
+	CAST(PostfixPreferences.CAST_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.CAST_CONTENT, PostfixPreferences.CAST_DESCRIPTION),
+	IF(PostfixPreferences.IF_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.IF_CONTENT, PostfixPreferences.IF_DESCRIPTION),
+	ELSE(PostfixPreferences.ELSE_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.ELSE_CONTENT, PostfixPreferences.ELSE_DESCRIPTION),
+	FOR(PostfixPreferences.FOR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FOR_CONTENT, PostfixPreferences.FOR_DESCRIPTION),
+	FORI(PostfixPreferences.FORI_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FORI_CONTENT, PostfixPreferences.FORI_DESCRIPTION),
+	FORR(PostfixPreferences.FORR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.FORR_CONTENT, PostfixPreferences.FORI_DESCRIPTION),
+	NNULL(PostfixPreferences.NNULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NNULL_CONTENT, PostfixPreferences.NNULL_DESCRIPTION),
+	NULL(PostfixPreferences.NULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NULL_CONTENT, PostfixPreferences.NULL_DESCRIPTION),
+	SYSOUT(PostfixPreferences.SYSOUT_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.SYSOUT_CONTENT, PostfixPreferences.SYSOUT_DESCRIPTION),
+	THROW(PostfixPreferences.THROW_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.THROW_CONTENT, PostfixPreferences.THROW_DESCRIPTION),
+	VAR(PostfixPreferences.VAR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.VAR_CONTENT, PostfixPreferences.VAR_DESCRIPTION),
+	WHILE(PostfixPreferences.WHILE_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.WHILE_CONTENT, PostfixPreferences.WHILE_DESCRIPTION);
+	//@formatter:off
+
+	private final String templateId;
+	private final String contextType;
+	private final String defaultContent;
+	private final String description;
+
+	private PostfixTemplate(String templatesId, String contextType, String defaultContent, String description) {
+		this.templateId = templatesId;
+		this.contextType = contextType;
+		this.defaultContent = defaultContent;
+		this.description = description;
+	}
+
+	public Template createTemplate() {
+		return new Template(this.name().toLowerCase(), this.description, this.contextType, this.defaultContent, false);
+	}
+
+	public String getId() {
+		return this.templateId;
+	}
+}
+
+class PostfixPreferences {
+	// IDs
+	public static final String CAST_ID = "org.eclipse.jdt.postfixcompletion.cast";
+	public static final String ELSE_ID = "org.eclipse.jdt.ls.postfixcompletion.else";
+	public static final String FOR_ID = "org.eclipse.jdt.postfixcompletion.for";
+	public static final String FORI_ID = "org.eclipse.jdt.postfixcompletion.fori";
+	public static final String FORR_ID = "org.eclipse.jdt.postfixcompletion.forr";
+	public static final String IF_ID = "org.eclipse.jdt.ls.postfixcompletion.if";
+	public static final String NNULL_ID = "org.eclipse.jdt.postfixcompletion.nnull";
+	public static final String NULL_ID = "org.eclipse.jdt.postfixcompletion.null";
+	public static final String SYSOUT_ID = "org.eclipse.jdt.postfixcompletion.sysout";
+	public static final String THROW_ID = "org.eclipse.jdt.postfixcompletion.throw";
+	public static final String VAR_ID = "org.eclipse.jdt.postfixcompletion.var";
+	public static final String WHILE_ID = "org.eclipse.jdt.postfixcompletion.while";
+
+	// Default Contents
+	public static final String CAST_CONTENT = "(($${1})${inner_expression})$${0}";
+	public static final String ELSE_CONTENT = "if (!${i:inner_expression(boolean)}) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String FOR_CONTENT = "for (${type:newActualType(i)} $${1:${n:newName(i)}} : ${i:inner_expression(java.util.Collection,array)}) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String FORI_CONTENT = "for (int $${1:${index}} = 0; $${1:${index}} < ${i:inner_expression(array)}.length; $${1:${index}}++) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String FORR_CONTENT = "for (int $${1:${index}} = ${i:inner_expression(array)}.length - 1; $${1:${index}} >= 0; $${1:${index}}--) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String IF_CONTENT = "if (${i:inner_expression(boolean)}) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String NNULL_CONTENT = "if (${i:inner_expression(java.lang.Object,array)} != null) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String NULL_CONTENT = "if (${i:inner_expression(java.lang.Object,array)} == null) {\n" +
+		"\t$${0}\n" +
+	"}";
+	public static final String SYSOUT_CONTENT = "System.out.println(${i:inner_expression(java.lang.String)}${});$${0}";
+	public static final String THROW_CONTENT = "throw ${true:inner_expression(java.lang.Throwable)};";
+	public static final String VAR_CONTENT = "${field:newType(inner_expression)} $${1:${var:newName(inner_expression)}} = ${inner_expression};$${0}";
+	public static final String WHILE_CONTENT = "while (${i:inner_expression(boolean)}) {\n" +
+		"\t$${0}\n" +
+	"}";
+
+	// Descriptions
+	public static final String CAST_DESCRIPTION = "Casts the expression to a new type";
+	public static final String ELSE_DESCRIPTION = "Creates a negated if statement";
+	public static final String FOR_DESCRIPTION = "Creates a for statement";
+	public static final String FORI_DESCRIPTION = "Creates a for statement which iterates over an array";
+	public static final String FORR_DESCRIPTION = "Creates a for statement which iterates over an array in reverse order";
+	public static final String IF_DESCRIPTION = "Creates a if statement";
+	public static final String NNULL_DESCRIPTION = "Creates an if statement and checks if the expression does not resolve to null";
+	public static final String NULL_DESCRIPTION = "Creates an if statement which checks if expression resolves to null";
+	public static final String SYSOUT_DESCRIPTION = "Sends the affected string to a System.out.println(..) call";
+	public static final String THROW_DESCRIPTION = "Throws the given Exception";
+	public static final String VAR_DESCRIPTION = "Creates a new variable";
+	public static final String WHILE_DESCRIPTION = "Creates a while loop";
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.internal.core.manipulation.util.Strings;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.SnippetUtils;
-import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaPostfixContext;
+import org.eclipse.jdt.ls.core.internal.contentassist.SortTextHelper;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.templates.Template;
@@ -96,6 +96,7 @@ public class PostfixTemplateEngine {
 			// If the replace changes the text it most likely makes sense to specify a filter text to be used.
 			String filterText = textInRange.substring(0, textInRange.lastIndexOf('.') + 1) + template.getName();
 			item.setFilterText(filterText);
+			item.setSortText(SortTextHelper.convertRelevance(SortTextHelper.MAX_RELEVANCE_VALUE));
 			res.add(item);
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - extract to a base class
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.internal.core.manipulation.util.Strings;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.SnippetUtils;
+import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaPostfixContext;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.templates.Template;
+import org.eclipse.jface.text.templates.TemplateBuffer;
+import org.eclipse.jface.text.templates.TemplateException;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+public class PostfixTemplateEngine {
+	private ASTNode currentNode;
+
+	private ASTNode parentNode;
+
+	private CompletionContext completionCtx;
+
+	public void setASTNodes(ASTNode currentNode, ASTNode parentNode) {
+		this.currentNode= currentNode;
+		this.parentNode= parentNode;
+	}
+
+	public void setContext(CompletionContext context) {
+		this.completionCtx= context;
+	}
+
+	/**
+	 * Return the post fix completion items.
+	 * @param document The IDocument instance.
+	 * @param offset offset where the completion action happens.
+	 * @param compilationUnit the compilation unit.
+	 */
+	public List<CompletionItem> complete(IDocument document, int offset, ICompilationUnit compilationUnit) {
+		List<CompletionItem> res = new ArrayList<>();
+		JavaPostfixContextType type = (JavaPostfixContextType) JavaLanguageServerPlugin.getInstance()
+				.getTemplateContextRegistry().getContextType(JavaPostfixContextType.ID_ALL);
+		JavaPostfixContext context = type.createContext(document, offset, 0, compilationUnit, currentNode, parentNode, completionCtx);
+		int length = context.getEnd() - context.getStart();
+		Range range = null;
+		String textInRange = null;
+		try {
+			range = JDTUtils.toRange(compilationUnit, context.getStart(), length);
+			textInRange = document.get(context.getStart(), length);
+		} catch (BadLocationException  | JavaModelException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+			return res;
+		}
+
+		Template[] templates = JavaLanguageServerPlugin.getInstance().getTemplateStore().getTemplates(JavaPostfixContextType.ID_ALL);
+		Template[] availableTemplates = Arrays.stream(templates).filter(t -> context.canEvaluate(t)).toArray(Template[]::new);
+		for (Template template : availableTemplates) {
+			final CompletionItem item = new CompletionItem();
+			String content = evaluateGenericTemplate(context, template);
+			if (StringUtils.isBlank(content)) {
+				continue;
+			}
+			TextEdit textEdit = new TextEdit(range, content);
+			item.setTextEdit(Either.forLeft(textEdit));
+			item.setLabel(template.getName());
+			item.setKind(CompletionItemKind.Snippet);
+			item.setInsertTextFormat(InsertTextFormat.Snippet);
+			item.setDetail(template.getDescription());
+			item.setDocumentation(SnippetUtils.beautifyDocument(content));
+			// The filter text must be set when it comes to a replace edit, in LSP spec, it says:
+			// If the text edit is a replace edit then the range denotes the word used for filtering.
+			// If the replace changes the text it most likely makes sense to specify a filter text to be used.
+			String filterText = textInRange.substring(0, textInRange.lastIndexOf('.') + 1) + template.getName();
+			item.setFilterText(filterText);
+			res.add(item);
+		}
+
+		return res;
+	}
+
+	/**
+	 * @See org.eclipse.jdt.internal.ui.text.template.contentassist.TemplateProposal#apply(org.eclipse.jface.text.ITextViewer, char, int, int)
+	 */
+	private String evaluateGenericTemplate(JavaPostfixContext postfixContext, Template template) {
+		TemplateBuffer buffer = null;
+		try {
+			buffer = postfixContext.evaluate(template);
+		} catch (BadLocationException | TemplateException e) {
+			JavaLanguageServerPlugin.logException(e.getMessage(), e);
+			return null;
+		}
+		if (buffer == null) {
+			return null;
+		}
+		String content = buffer.getString();
+		if (Strings.containsOnlyWhitespaces(content)) {
+			return null;
+		}
+		return content;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/TypeResolver.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/TypeResolver.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2007, 2019 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import java.util.List;
+
+import org.eclipse.jface.text.templates.TemplateContext;
+import org.eclipse.jface.text.templates.TemplateVariable;
+import org.eclipse.jface.text.templates.TemplateVariableResolver;
+import org.eclipse.jdt.internal.corext.template.java.JavaVariable;
+import org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariable;
+
+/**
+ * Copied from org.eclipse.jdt.internal.corext.template.java.TypeResolver
+ */
+public class TypeResolver extends TemplateVariableResolver {
+	private final String fDefaultType;
+
+	/**
+	 * Default ctor for instantiation by the extension point.
+	 */
+	public TypeResolver() {
+		this("java.lang.Object"); //$NON-NLS-1$
+	}
+
+	TypeResolver(String defaultType) {
+		fDefaultType= defaultType;
+	}
+
+	@Override
+	public void resolve(TemplateVariable variable, TemplateContext context) {
+		List<String> params= variable.getVariableType().getParams();
+		String param= fDefaultType;
+		JavaContext jc= (JavaContext) context;
+		MultiVariable mv= (MultiVariable) variable;
+		if (params.size() != 0 && context instanceof JavaContext) {
+			param= params.get(0);
+			TemplateVariable ref = jc.getTemplateVariable(param);
+
+			if (ref instanceof JavaVariable) {
+				// Reference is another variable
+				JavaVariable refVar= (JavaVariable) ref;
+				jc.addDependency(refVar, mv);
+				param= refVar.getParamType();
+				if (param != null && "".equals(param) == false) { //$NON-NLS-1$
+					String reference;
+					if (jc instanceof JavaPostfixContext)
+						reference= ((JavaPostfixContext)jc).addImportGenericClass(param);
+					else
+						reference= jc.addImport(param);
+					mv.setValue(reference);
+					mv.setUnambiguous(true);
+					mv.setResolved(true);
+					return;
+				}
+			}
+		}
+
+		String reference= jc.addImport(param);
+		mv.setValue(reference);
+		mv.setUnambiguous(true);
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/VariablePosition.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/VariablePosition.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2011 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corext.template.java;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jdt.internal.ui.text.template.contentassist.MultiVariable;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.link.LinkedPosition;
+import org.eclipse.jface.text.link.LinkedPositionGroup;
+
+/**
+ * Copied from org.eclipse.jdt.internal.ui.text.template.contentassist.VariablePosition
+ * UI related code is removed.
+ */
+public class VariablePosition extends LinkedPosition {
+
+	private MultiVariableGuess fGuess;
+	private MultiVariable fVariable;
+
+	public VariablePosition(IDocument document, int offset, int length, MultiVariableGuess guess, MultiVariable variable) {
+		this(document, offset, length, LinkedPositionGroup.NO_STOP, guess, variable);
+	}
+
+	public VariablePosition(IDocument document, int offset, int length, int sequence, MultiVariableGuess guess, MultiVariable variable) {
+		super(document, offset, length, sequence);
+		Assert.isNotNull(guess);
+		Assert.isNotNull(variable);
+		fVariable = variable;
+		fGuess = guess;
+	}
+
+
+	/*
+	 * @see org.eclipse.jface.text.link.ProposalPosition#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object o) {
+		if (o instanceof VariablePosition && super.equals(o)) {
+			return fGuess.equals(((VariablePosition) o).fGuess);
+		}
+		return false;
+	}
+
+	/*
+	 * @see org.eclipse.jface.text.link.ProposalPosition#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return super.hashCode() | fGuess.hashCode();
+	}
+
+	/**
+	 * Returns the variable.
+	 *
+	 * @return the variable.
+	 */
+	public MultiVariable getVariable() {
+		return fVariable;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -173,7 +173,9 @@ public class CompletionHandler{
 					proposals.addAll(collector.getCompletionItems());
 					if (isSnippetStringSupported() && !UNSUPPORTED_RESOURCES.contains(unit.getResource().getName())) {
 						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector.getContext(), subMonitor));
-						proposals.addAll(getPostfixCompletions(params.getContext(), collector.getContext(), unit, offset));
+						if (isPostfixSupported()) {
+							proposals.addAll(getPostfixCompletions(params.getContext(), collector.getContext(), unit, offset));
+						}
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
 				} catch (OperationCanceledException e) {
@@ -242,8 +244,12 @@ public class CompletionHandler{
 	}
 
 	private boolean isSnippetStringSupported() {
-		return JavaLanguageServerPlugin.getPreferencesManager() != null && JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences() != null
-				&& JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isCompletionSnippetsSupported();
+		return this.manager != null &&  this.manager.getClientPreferences() != null
+				&& this.manager.getClientPreferences().isCompletionSnippetsSupported();
+	}
+
+	private boolean isPostfixSupported() {
+		return this.manager != null && this.manager.getPreferences().isPostfixCompletionEnabled();
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -45,7 +45,9 @@ import org.eclipse.jdt.ls.core.internal.corext.template.java.PostfixCompletionPr
 import org.eclipse.jdt.ls.core.internal.corext.template.java.PostfixTemplateEngine;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.syntaxserver.ModelBasedCompletionEngine;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.CompletionContext;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
@@ -171,13 +173,7 @@ public class CompletionHandler{
 					proposals.addAll(collector.getCompletionItems());
 					if (isSnippetStringSupported() && !UNSUPPORTED_RESOURCES.contains(unit.getResource().getName())) {
 						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector.getContext(), subMonitor));
-						// add post fix completion
-						PostfixCompletionProposalComputer computer = new PostfixCompletionProposalComputer();
-						IDocument document = JsonRpcHelpers.toDocument(unit.getBuffer());
-						PostfixTemplateEngine engine = computer.computeCompletionEngine(collector.getContext(), document, offset);
-						if (engine != null) {
-							proposals.addAll(engine.complete(document, offset, unit));
-						}
+						proposals.addAll(getPostfixCompletions(params.getContext(), collector.getContext(), unit, offset));
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
 				} catch (OperationCanceledException e) {
@@ -189,6 +185,52 @@ public class CompletionHandler{
 		CompletionList list = new CompletionList(proposals);
 		list.setIsIncomplete(!collector.isComplete() || completionForConstructor);
 		return list;
+	}
+
+	/**
+	 * Return the list of postfix completion items. The postfix completion calculation
+	 * will only happen when:
+	 * <ul>
+	 * <li>The completion is triggered by the trigger character '.'</li>
+	 * <li>The completion is triggered manually</li>
+	 * </ul>
+	 * @param lspCtx Completion context from LSP
+	 * @param jdtCtx Completion context from JDT
+	 * @param cu Compilation unit
+	 * @param offset offset of the completion
+	 */
+	private List<CompletionItem> getPostfixCompletions(CompletionContext lspCtx, org.eclipse.jdt.core.CompletionContext jdtCtx,
+			ICompilationUnit cu, int offset) {
+		if (lspCtx != null) {
+			String triggerCharacter = lspCtx.getTriggerCharacter();
+			if (triggerCharacter != null && !triggerCharacter.equals(".")) {
+				return Collections.emptyList();
+			}
+		}
+
+		char[] token = jdtCtx.getToken();
+		if (token == null) {
+			return Collections.emptyList();
+		}
+		int tokenStart = jdtCtx.getOffset() - token.length - 1;
+		if (tokenStart < 0) {
+			return Collections.emptyList();
+		}
+		try {
+			IDocument document = JsonRpcHelpers.toDocument(cu.getBuffer());
+			String tokenSequence = document.get(tokenStart, jdtCtx.getOffset() - tokenStart);
+			if (!tokenSequence.contains(".")) {
+				return Collections.emptyList();
+			}
+			PostfixCompletionProposalComputer computer = new PostfixCompletionProposalComputer();
+			PostfixTemplateEngine engine = computer.computeCompletionEngine(jdtCtx, document, offset);
+			if (engine != null) {
+				return engine.complete(document, offset, cu);
+			}
+		} catch (BadLocationException | JavaModelException e) {
+			return Collections.emptyList();
+		}
+		return Collections.emptyList();
 	}
 
 	private String[] getFavoriteStaticMembers() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -298,6 +298,11 @@ public class Preferences {
 	public static final String COMPLETION_ENABLED_KEY = "java.completion.enabled";
 
 	/**
+	 * Preference key to enable/disable postfix completion.
+	 */
+	public static final String POSTFIX_COMPLETION_KEY = "java.completion.postfix.enabled";
+
+	/**
 	 * Preference key to enable/disable the 'foldingRange'.
 	 */
 	public static final String FOLDINGRANGE_ENABLED_KEY = "java.foldingRange.enabled";
@@ -537,6 +542,7 @@ public class Preferences {
 	private boolean executeCommandEnabled;
 	private boolean autobuildEnabled;
 	private boolean completionEnabled;
+	private boolean postfixCompletionEnabled;
 	private boolean completionOverwrite;
 	private boolean foldingRangeEnabled;
 	private boolean selectionRangeEnabled;
@@ -939,6 +945,10 @@ public class Preferences {
 
 		boolean completionEnable = getBoolean(configuration, COMPLETION_ENABLED_KEY, true);
 		prefs.setCompletionEnabled(completionEnable);
+
+		boolean postfixEnabled = getBoolean(configuration, POSTFIX_COMPLETION_KEY, false);
+		prefs.setPostfixCompletionEnabled(postfixEnabled);
+
 		boolean completionOverwrite = getBoolean(configuration, JAVA_COMPLETION_OVERWRITE_KEY, true);
 		prefs.setCompletionOverwrite(completionOverwrite);
 
@@ -1319,6 +1329,14 @@ public class Preferences {
 	public Preferences setCompletionEnabled(boolean enabled) {
 		this.completionEnabled = enabled;
 		return this;
+	}
+
+	public boolean isPostfixCompletionEnabled() {
+		return postfixCompletionEnabled;
+	}
+
+	public void setPostfixCompletionEnabled(boolean postfixCompletionEnabled) {
+		this.postfixCompletionEnabled = postfixCompletionEnabled;
 	}
 
 	public Preferences setCompletionOverwrite(boolean completionOverwrite) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -783,6 +783,7 @@ public class Preferences {
 		executeCommandEnabled = true;
 		autobuildEnabled = true;
 		completionEnabled = true;
+		postfixCompletionEnabled = true;
 		completionOverwrite = true;
 		foldingRangeEnabled = true;
 		selectionRangeEnabled = true;
@@ -946,7 +947,7 @@ public class Preferences {
 		boolean completionEnable = getBoolean(configuration, COMPLETION_ENABLED_KEY, true);
 		prefs.setCompletionEnabled(completionEnable);
 
-		boolean postfixEnabled = getBoolean(configuration, POSTFIX_COMPLETION_KEY, false);
+		boolean postfixEnabled = getBoolean(configuration, POSTFIX_COMPLETION_KEY, true);
 		prefs.setPostfixCompletionEnabled(postfixEnabled);
 
 		boolean completionOverwrite = getBoolean(configuration, JAVA_COMPLETION_OVERWRITE_KEY, true);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaLanguageServerTemplateStoreTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaLanguageServerTemplateStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Corporation and others.
+ * Copyright (c) 2019-2022 Microsoft Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -23,18 +23,25 @@ import org.junit.Test;
 
 public class JavaLanguageServerTemplateStoreTest {
 
-    @Test
-    public void testTemplateStoreContent() {
-        JavaLanguageServerTemplateStore store = JavaLanguageServerPlugin.getInstance().getTemplateStore();
-        Template[] templates = store.getTemplates();
-        CodeSnippetTemplate[] snippets = CodeSnippetTemplate.values();
+	@Test
+	public void testTemplateStoreContent() {
+		JavaLanguageServerTemplateStore store = JavaLanguageServerPlugin.getInstance().getTemplateStore();
+		Template[] templates = store.getTemplates();
+		CodeSnippetTemplate[] snippets = CodeSnippetTemplate.values();
+		PostfixTemplate[] postfixes = PostfixTemplate.values();
 
-        assertEquals(templates.length, snippets.length);
+		assertEquals(templates.length, snippets.length + postfixes.length);
 
-        for (CodeSnippetTemplate snippet : snippets) {
-            TemplatePersistenceData templateData = store.getTemplateData(snippet.getId());
-            assertNotNull(templateData);
-            assertEquals(templateData.getTemplate().getName(), snippet.name().toLowerCase());
-        }
-    }
+		for (CodeSnippetTemplate snippet : snippets) {
+			TemplatePersistenceData templateData = store.getTemplateData(snippet.getId());
+			assertNotNull(templateData);
+			assertEquals(templateData.getTemplate().getName(), snippet.name().toLowerCase());
+		}
+		
+		for (PostfixTemplate postfix : postfixes) {
+			TemplatePersistenceData templateData = store.getTemplateData(postfix.getId());
+			assertNotNull(templateData);
+			assertEquals(templateData.getTemplate().getName(), postfix.name().toLowerCase());
+		}
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3191,8 +3191,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//@formatter:on
 		CompletionList list = requestCompletions(unit, "IConstantDefault.");
 		assertNotNull(list);
-		assertEquals(5, list.getItems().size());
-		CompletionItem ci = list.getItems().get(2);
+		assertEquals(3, list.getItems().size());
+		CompletionItem ci = list.getItems().get(0);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
 		assertEquals("ONE : int", ci.getLabel());
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
@@ -3200,7 +3200,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		String documentation = resolvedItem.getDocumentation().getLeft();
 		assertEquals("Value: 1", documentation);
 
-		ci = list.getItems().get(3);
+		ci = list.getItems().get(1);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
 		assertEquals("TEST : double", ci.getLabel());
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -119,6 +119,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//		sharedASTProvider.clearASTCreationCount();
 		javaClient = new JavaClientConnection(client);
 		lifeCycleHandler = new DocumentLifeCycleHandler(javaClient, preferenceManager, projectsManager, true);
+		preferences.setPostfixCompletionEnabled(false);
 	}
 
 	@After

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3191,8 +3191,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		//@formatter:on
 		CompletionList list = requestCompletions(unit, "IConstantDefault.");
 		assertNotNull(list);
-		assertEquals(3, list.getItems().size());
-		CompletionItem ci = list.getItems().get(0);
+		assertEquals(5, list.getItems().size());
+		CompletionItem ci = list.getItems().get(2);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
 		assertEquals("ONE : int", ci.getLabel());
 		CompletionItem resolvedItem = server.resolveCompletionItem(ci).join();
@@ -3200,7 +3200,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		String documentation = resolvedItem.getDocumentation().getLeft();
 		assertEquals("Value: 1", documentation);
 
-		ci = list.getItems().get(1);
+		ci = list.getItems().get(3);
 		assertEquals(CompletionItemKind.Constant, ci.getKind());
 		assertEquals("TEST : double", ci.getLabel());
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -1,0 +1,394 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
+
+	private JavaClientConnection javaClient;
+	private static String COMPLETION_TEMPLATE =
+			"{\n" +
+					"    \"id\": \"1\",\n" +
+					"    \"method\": \"textDocument/completion\",\n" +
+					"    \"params\": {\n" +
+					"        \"textDocument\": {\n" +
+					"            \"uri\": \"${file}\"\n" +
+					"        },\n" +
+					"        \"position\": {\n" +
+					"            \"line\": ${line},\n" +
+					"            \"character\": ${char}\n" +
+					"        }\n" +
+					"    },\n" +
+					"    \"jsonrpc\": \"2.0\"\n" +
+					"}";
+
+	@Before
+	public void setUp() {
+		mockLSP3Client();
+		CoreASTProvider sharedASTProvider = CoreASTProvider.getInstance();
+		sharedASTProvider.disposeAST();
+		javaClient = new JavaClientConnection(client);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		javaClient.disconnect();
+	}
+
+	@Test
+	public void test_cast() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		a.cast" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.cast");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("cast", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("((${1})a)${0}", edit.getNewText());
+		assertEquals("a.cast", item.getFilterText());
+	}
+
+	@Test
+	public void test_if() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(boolean a) {\n" +
+			"		a.if" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.if");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("if", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("if (a) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.if", item.getFilterText());
+	}
+
+	@Test
+	public void test_else() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(boolean a) {\n" +
+			"		a.else" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.else");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("else", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("if (!a) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.else", item.getFilterText());
+	}
+
+	@Test
+	public void test_for() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String[] a) {\n" +
+			"		a.for" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.for");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("for", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("for (String ${1:a2} : a) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.for", item.getFilterText());
+	}
+
+	@Test
+	public void test_fori() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String[] a) {\n" +
+			"		a.fori" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.fori");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("fori", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("for (int ${1:a2} = 0; ${1:a2} < a.length; ${1:a2}++) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.fori", item.getFilterText());
+	}
+
+	@Test
+	public void test_forr() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String[] a) {\n" +
+			"		a.forr" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.forr");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("forr", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("for (int ${1:a2} = a.length - 1; ${1:a2} >= 0; ${1:a2}--) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.forr", item.getFilterText());
+	}
+
+	@Test
+	public void test_nnull() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		a.nnull" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.nnull");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("nnull", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("if (a != null) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.nnull", item.getFilterText());
+	}
+
+	@Test
+	public void test_null() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		a.null" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.null");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("null", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("if (a == null) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.null", item.getFilterText());
+	}
+
+	@Test
+	public void test_sysout() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		a.sysout" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.sysout");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("sysout", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("System.out.println(a);${0}", edit.getNewText());
+		assertEquals("a.sysout", item.getFilterText());
+	}
+
+	@Test
+	public void test_throw() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod() {\n" +
+			"		Exception e;\n" +
+			"		e.throw" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "e.throw");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("throw", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("throw e;", edit.getNewText());
+		assertEquals("e.throw", item.getFilterText());
+	}
+
+	@Test
+	public void test_var() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		a.var" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.var");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("var", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("String ${1:a2} = a;${0}", edit.getNewText());
+		assertEquals("a.var", item.getFilterText());
+	}
+
+	@Test
+	public void test_while() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(boolean a) {\n" +
+			"		a.while" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "a.while");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("while", item.getLabel());
+		TextEdit edit = item.getTextEdit().getLeft();
+		assertEquals("while (a) {\n\t${0}\n}", edit.getNewText());
+		assertEquals("a.while", item.getFilterText());
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
+		return requestCompletions(unit, completeBehind, 0);
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
+		int[] loc = findCompletionLocation(unit, completeBehind, fromIndex);
+		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+	}
+
+	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {
+		return COMPLETION_TEMPLATE.replace("${file}", JDTUtils.toURI(unit))
+				.replace("${line}", String.valueOf(line))
+				.replace("${char}", String.valueOf(kar));
+	}
+
+	private void mockLSP3Client() {
+		mockLSPClient(true, true);
+	}
+
+	private void mockLSPClient(boolean isSnippetSupported, boolean isSignatureHelpSuported) {
+		// Mock the preference manager to use LSP v3 support.
+		when(preferenceManager.getClientPreferences().isCompletionSnippetsSupported()).thenReturn(isSnippetSupported);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -60,11 +60,13 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		CoreASTProvider sharedASTProvider = CoreASTProvider.getInstance();
 		sharedASTProvider.disposeAST();
 		javaClient = new JavaClientConnection(client);
+		preferences.setPostfixCompletionEnabled(true);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		javaClient.disconnect();
+		preferences.setPostfixCompletionEnabled(false);
 	}
 
 	@Test


### PR DESCRIPTION
- Reuse the headless part of code from jdt.ui.
- The supported templates in this PR are: cast, else, for, fori, forr, if, nnull, null, sysout, throw, var, while.

fix https://github.com/redhat-developer/vscode-java/issues/1455
fix https://github.com/eclipse/eclipse.jdt.ls/issues/863

requires https://github.com/redhat-developer/vscode-java/pull/2746

#### How to test
![postfix](https://user-images.githubusercontent.com/6193897/196589775-8d0404fa-d8c0-48c7-82fb-47a45b69c953.gif)

#### Performance analysis
We will only calculate the postfix completions when:
- The completion is triggered by the trigger character `.`
- The completion is triggered manually

In most cases, it just skips the postfix completion calculation.

Below is the CPU sampling when we trigger the completion for the code `args.|`, where `args` is a `String[]`:
![image](https://user-images.githubusercontent.com/6193897/196590139-40d20589-4e46-4408-a329-4de2242a9aeb.png)

Though it takes 36% of the CPU times, the time for completion after `.` is relatively fast, so the real response time is still very quick.

Overall, the impact of the completion performance is acceptable.

#### Known issues
- The postfix snippets always list at the top, no matter how I set the `sortText`. This seems a bug of VS Code, I've filed [an issue](https://github.com/microsoft/vscode/issues/163923).
- The implementation relies on the AST, which means, if the file contains some compilation errors, some of the postfix snippets will be unavailable. Same behavior can be observed in Eclipse as well.

#### Next step
1. Support more postfix templates, like the ones which will generate multiple text edits. See: https://github.com/eclipse/eclipse.jdt.ls/issues/863#issuecomment-1283290978. (Full list of the post fix templates can be found [here](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/master/org.eclipse.jdt.ui/templates/default-postfixtemplates.xml))
2. Revisit https://github.com/eclipse/eclipse.jdt.ls/pull/2110, each time when we modify the completion part, same changes need to apply to the intellicode extension. I hope to decouple them.

Signed-off-by: Sheng Chen <sheche@microsoft.com>