### PR TITLE
Add an option to enable/disable null analysis

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/ClasspathUpdateHandler.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.FeatureStatus;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.extended.ProjectBuildParams;
 
@@ -54,7 +55,7 @@ public class ClasspathUpdateHandler implements IElementChangedListener {
 		if (connection != null && uris != null && !uris.isEmpty()) {
 			for (String uri : uris) {
 				PreferenceManager preferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
-				if (preferenceManager.getPreferences().isAnnotationNullAnalysisEnabled()) {
+				if (preferenceManager.getPreferences().getNullAnalysisMode().equals(FeatureStatus.automatic)) {
 					IProject project = ProjectUtils.getProjectFromUri(uri);
 					if (project != null) {
 						IJavaProject javaProject = ProjectUtils.getJavaProject(project);
@@ -62,7 +63,7 @@ public class ClasspathUpdateHandler implements IElementChangedListener {
 							WorkspaceJob job = new WorkspaceJob("Classpath Update Job") {
 								@Override
 								public IStatus runInWorkspace(IProgressMonitor monitor) {
-									if (!preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions(javaProject) || !preferenceManager.getPreferences().isAutobuildEnabled()) {
+									if (!preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions(javaProject, true) || !preferenceManager.getPreferences().isAutobuildEnabled()) {
 										// When the project's compiler options didn't change or auto build is disabled, rebuilding is not required.
 										return Status.OK_STATUS;
 									}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -492,7 +492,9 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 			@SuppressWarnings("unchecked")
 			Preferences prefs = Preferences.createFrom((Map<String, Object>) settings);
 			prefs.setRootPaths(rootPaths);
-			boolean nullAnalysisConfigurationsChanged = !prefs.getNullableTypes().equals(preferenceManager.getPreferences().getNullableTypes()) || !prefs.getNonnullTypes().equals(preferenceManager.getPreferences().getNonnullTypes());
+			boolean nullAnalysisConfigurationsChanged =!prefs.getNullableTypes().equals(preferenceManager.getPreferences().getNullableTypes())
+				|| !prefs.getNonnullTypes().equals(preferenceManager.getPreferences().getNonnullTypes())
+				|| !prefs.getNullAnalysisMode().equals(preferenceManager.getPreferences().getNullAnalysisMode());
 			preferenceManager.update(prefs);
 			if (nullAnalysisConfigurationsChanged) {
 				// trigger rebuild all the projects when the null analysis configuration changed **and** the compiler options updated

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/StandardProjectsManager.java
@@ -645,8 +645,6 @@ public class StandardProjectsManager extends ProjectsManager {
 		protobufSupport.onDidProjectsImported(monitor);
 		IFrameworkSupport androidSupport = new AndroidSupport();
 		androidSupport.onDidProjectsImported(monitor);
-		if (this.preferenceManager.getPreferences().isAnnotationNullAnalysisEnabled()) {
-			this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
-		}
+		this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -52,6 +52,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.core.manipulation.CodeStyleConfiguration;
 import org.eclipse.jdt.internal.core.manipulation.MembersOrderPreferenceCacheCommon;
+import org.eclipse.jdt.ls.core.internal.ActionableNotification;
 import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -63,6 +64,7 @@ import org.eclipse.jdt.ls.core.internal.contentassist.TypeFilter;
 import org.eclipse.jdt.ls.core.internal.handlers.InlayHintsParameterMode;
 import org.eclipse.jdt.ls.core.internal.handlers.ProjectEncodingMode;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.MessageType;
 
 /**
@@ -462,6 +464,7 @@ public class Preferences {
 
 	public static final String JAVA_COMPILE_NULLANALYSIS_NONNULL = "java.compile.nullAnalysis.nonnull";
 	public static final String JAVA_COMPILE_NULLANALYSIS_NULLABLE = "java.compile.nullAnalysis.nullable";
+	public static final String JAVA_COMPILE_NULLANALYSIS_MODE = "java.compile.nullAnalysis.mode";
 
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
@@ -602,6 +605,7 @@ public class Preferences {
 	private boolean androidSupportEnabled;
 	private List<String> nonnullTypes;
 	private List<String> nullableTypes;
+	private FeatureStatus nullAnalysisMode;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -823,6 +827,7 @@ public class Preferences {
 		avoidVolatileChanges = true;
 		nonnullTypes = new ArrayList<>();
 		nullableTypes = new ArrayList<>();
+		nullAnalysisMode = FeatureStatus.disabled;
 	}
 
 	private static void initializeNullAnalysisClasspathStorage() {
@@ -1162,6 +1167,8 @@ public class Preferences {
 		prefs.setNonnullTypes(nonnullTypes);
 		List<String> nullableTypes = getList(configuration, JAVA_COMPILE_NULLANALYSIS_NULLABLE, Collections.emptyList());
 		prefs.setNullableTypes(nullableTypes);
+		String nullAnalysisMode = getString(configuration, JAVA_COMPILE_NULLANALYSIS_MODE, null);
+		prefs.setNullAnalysisMode(FeatureStatus.fromString(nullAnalysisMode, FeatureStatus.disabled));
 		return prefs;
 	}
 
@@ -2032,26 +2039,51 @@ public class Preferences {
 		this.nullableTypes = nullableTypes;
 	}
 
-	public boolean isAnnotationNullAnalysisEnabled() {
-		return !this.nonnullTypes.isEmpty() || !this.nullableTypes.isEmpty();
+	public void setNullAnalysisMode(FeatureStatus nullAnalysisMode) {
+		this.nullAnalysisMode = nullAnalysisMode;
+	}
+
+	public FeatureStatus getNullAnalysisMode() {
+		return this.nullAnalysisMode;
 	}
 
 	/**
+	 * update the null analysis options of all projects based on the null analysis mode
 	 * @return whether the options are changed or not
 	 */
 	public boolean updateAnnotationNullAnalysisOptions() {
+		switch (this.getNullAnalysisMode()) {
+			case automatic:
+				return this.updateAnnotationNullAnalysisOptions(true);
+			case interactive:
+				if (this.hasAnnotationNullAnalysisTypes()) {
+					String cmd = "java.compile.nullAnalysis.setMode";
+					ActionableNotification updateNullAnalysisStatusNotification = new ActionableNotification().withSeverity(MessageType.Info)
+							.withMessage("Null annotation types are detected in your project. Do you want to enable the null analysis for this project?")
+							.withCommands(Arrays.asList(new Command("Enable", cmd, Arrays.asList(FeatureStatus.automatic)), new Command("Disable", cmd, Arrays.asList(FeatureStatus.disabled))));
+					JavaLanguageServerPlugin.getProjectsManager().getConnection().sendActionableNotification(updateNullAnalysisStatusNotification);
+				}
+				return false;
+			default:
+				return this.updateAnnotationNullAnalysisOptions(false);
+		}
+	}
+
+	private boolean updateAnnotationNullAnalysisOptions(boolean enabled) {
 		boolean isChanged = false;
 		for (IJavaProject javaProject : ProjectUtils.getJavaProjects()) {
-			isChanged |= updateAnnotationNullAnalysisOptions(javaProject);
+			isChanged |= updateAnnotationNullAnalysisOptions(javaProject, enabled);
 		}
 		return isChanged;
 	}
 
 	/**
+	 * update the null analysis options of given project
 	 * @param javaProject the java project to update the annotation-based null analysis options
+	 * @param enabled specific whether the null analysis is enabled
 	 * @return whether the options of the given project are changed or not
 	 */
-	public boolean updateAnnotationNullAnalysisOptions(IJavaProject javaProject) {
+	public boolean updateAnnotationNullAnalysisOptions(IJavaProject javaProject, boolean enabled) {
 		if (javaProject.getElementName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
 			return false;
 		}
@@ -2059,9 +2091,14 @@ public class Preferences {
 		if (projectInheritOptions == null) {
 			return false;
 		}
-		String nonnullType = getAnnotationType(javaProject, this.nonnullTypes, nonnullClasspathStorage);
-		String nullableType = getAnnotationType(javaProject, this.nullableTypes, nullableClasspathStorage);
-		Map<String, String> projectNullAnalysisOptions = generateProjectNullAnalysisOptions(nonnullType, nullableType);
+		Map<String, String> projectNullAnalysisOptions;
+		if (enabled) {
+			String nonnullType = getAnnotationType(javaProject, this.nonnullTypes, nonnullClasspathStorage);
+			String nullableType = getAnnotationType(javaProject, this.nullableTypes, nullableClasspathStorage);
+			projectNullAnalysisOptions = generateProjectNullAnalysisOptions(nonnullType, nullableType);
+		} else {
+			projectNullAnalysisOptions = generateProjectNullAnalysisOptions(null, null);
+		}
 		boolean shouldUpdate = !projectNullAnalysisOptions.entrySet().stream().allMatch(e -> e.getValue().equals(projectInheritOptions.get(e.getKey())));
 		if (shouldUpdate) {
 			// get existing project options
@@ -2074,6 +2111,23 @@ public class Preferences {
 			}
 		}
 		return shouldUpdate;
+	}
+
+	private boolean hasAnnotationNullAnalysisTypes() {
+		if (this.nonnullTypes.isEmpty() && this.nullableTypes.isEmpty()) {
+			return false;
+		}
+		for (IJavaProject javaProject : ProjectUtils.getJavaProjects()) {
+			if (javaProject.getElementName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
+				continue;
+			}
+			String nonnullType = getAnnotationType(javaProject, this.nonnullTypes, nonnullClasspathStorage);
+			String nullableType = getAnnotationType(javaProject, this.nullableTypes, nullableClasspathStorage);
+			if (nonnullType != null || nullableType != null) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private String getAnnotationType(IJavaProject javaProject, List<String> annotationTypes, Map<String, List<String>> classpathStorage) {
@@ -2123,6 +2177,12 @@ public class Preferences {
 		return null;
 	}
 
+	/**
+	 * generates the null analysis options of the given nonnull type and nullable type
+	 * @param nonnullType the given nonnull type
+	 * @param nullableType the given nullable type
+	 * @return the map contains the null analysis options, if both given types are null, will return default null analysis options
+	 */
 	private Map<String, String> generateProjectNullAnalysisOptions(String nonnullType, String nullableType) {
 		Map<String, String> options = new HashMap<>();
 		if (nonnullType == null && nullableType == null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -2059,7 +2059,7 @@ public class Preferences {
 				if (this.hasAnnotationNullAnalysisTypes()) {
 					String cmd = "java.compile.nullAnalysis.setMode";
 					ActionableNotification updateNullAnalysisStatusNotification = new ActionableNotification().withSeverity(MessageType.Info)
-							.withMessage("Null annotation types are detected in your project. Do you want to enable the null analysis for this project?")
+							.withMessage("Null annotation types have been detected in the project. Do you wish to enable null analysis for this project?")
 							.withCommands(Arrays.asList(new Command("Enable", cmd, Arrays.asList(FeatureStatus.automatic)), new Command("Disable", cmd, Arrays.asList(FeatureStatus.disabled))));
 					JavaLanguageServerPlugin.getProjectsManager().getConnection().sendActionableNotification(updateNullAnalysisStatusNotification);
 				}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/MavenProjectImporterTest.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
 import org.eclipse.jdt.ls.core.internal.handlers.BuildWorkspaceHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.ProgressReporterManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.FeatureStatus;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.After;
 import org.junit.Test;
@@ -372,6 +373,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 	public void testNullAnalysisDisabled() throws Exception {
 		this.preferenceManager.getPreferences().setNonnullTypes(ImmutableList.of("javax.annotation.Nonnull", "org.eclipse.jdt.annotation.NonNull"));
 		this.preferenceManager.getPreferences().setNullableTypes(ImmutableList.of("org.eclipse.jdt.annotation.Nullable", "javax.annotation.Nonnull"));
+		this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.automatic);
 		try {
 			IProject project = importMavenProject("null-analysis");
 			assertIsJavaProject(project);
@@ -385,6 +387,7 @@ public class MavenProjectImporterTest extends AbstractMavenBasedTest {
 		} finally {
 			this.preferenceManager.getPreferences().setNonnullTypes(Collections.emptyList());
 			this.preferenceManager.getPreferences().setNullableTypes(Collections.emptyList());
+			this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.disabled);
 			this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
 		}
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/NullAnalysisTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.catalog.CatalogFeatures.Feature;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -30,6 +32,7 @@ import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.BuildWorkspaceHandler;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractGradleBasedTest;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences.FeatureStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -44,6 +47,7 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 		try {
 			this.preferenceManager.getPreferences().setNonnullTypes(ImmutableList.of("javax.annotation.Nonnull", "org.eclipse.jdt.annotation.NonNull"));
 			this.preferenceManager.getPreferences().setNullableTypes(ImmutableList.of("javax.annotation.Nullable", "org.eclipse.jdt.annotation.Nullable"));
+			this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.automatic);
 			IProject project = importGradleProject("null-analysis");
 			assertIsJavaProject(project);
 			if (this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions()) {
@@ -71,6 +75,7 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 			this.preferenceManager.getPreferences().setNonnullTypes(Collections.emptyList());
 			this.preferenceManager.getPreferences().setNullableTypes(Collections.emptyList());
 			this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
+			this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.disabled);
 		}
 	}
 
@@ -79,6 +84,7 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 		try {
 			this.preferenceManager.getPreferences().setNonnullTypes(ImmutableList.of("javax.annotation.Nonnull", "org.eclipse.jdt.annotation.NonNull"));
 			this.preferenceManager.getPreferences().setNullableTypes(ImmutableList.of("org.eclipse.jdt.annotation.Nullable", "javax.annotation.Nonnull"));
+			this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.automatic);
 			IProject project = importGradleProject("null-analysis");
 			assertIsJavaProject(project);
 			if (this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions()) {
@@ -105,14 +111,16 @@ public class NullAnalysisTest extends AbstractGradleBasedTest {
 		} finally {
 			this.preferenceManager.getPreferences().setNonnullTypes(Collections.emptyList());
 			this.preferenceManager.getPreferences().setNullableTypes(Collections.emptyList());
+			this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.disabled);
 			this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions();
 		}
 	}
 
 	@Test
 	public void testNullAnalysisDisabled() throws Exception {
-		this.preferenceManager.getPreferences().setNonnullTypes(Collections.emptyList());
-		this.preferenceManager.getPreferences().setNullableTypes(Collections.emptyList());
+		this.preferenceManager.getPreferences().setNonnullTypes(ImmutableList.of("javax.annotation.Nonnull", "org.eclipse.jdt.annotation.NonNull"));
+		this.preferenceManager.getPreferences().setNullableTypes(ImmutableList.of("javax.annotation.Nullable", "org.eclipse.jdt.annotation.Nullable"));
+		this.preferenceManager.getPreferences().setNullAnalysisMode(FeatureStatus.disabled);
 		IProject project = importGradleProject("null-analysis");
 		assertIsJavaProject(project);
 		if (this.preferenceManager.getPreferences().updateAnnotationNullAnalysisOptions()) {


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

related to https://github.com/redhat-developer/vscode-java/pull/2747

add new preference `java.compile.nullAnalysis.mode`, which type is `FeatureStatus`. 

- When set to `interactive` (default), a notification will show once null annotation types are detected when project is imported or null analysis related configuration changed.
- When set to `automatic`, the null analysis will be enabled.
- When set to `disabled`, the null analysis will be disabled.