### PR TITLE
Skip postfix evaluation when the completion token is not a variable

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/JavaPostfixContext.java
@@ -313,6 +313,16 @@ public class JavaPostfixContext extends JavaContext {
 			return false;
 		}
 
+		if (selectedNode instanceof SimpleName) {
+			IBinding binding = ((SimpleName) selectedNode).resolveBinding();
+			// return false when the binding of the simple name is not a variable,
+			// and it's not a recovered AST. This is to make sure postfix will be
+			// skipped for cases like 'System.|'
+			if (!(binding instanceof IVariableBinding) && !binding.isRecovered()) {
+				return false;
+			}
+		}
+
 		// We check if the template makes "sense" by checking the requirements/conditions for the template
 		// For this purpose we have to resolve the inner_expression variable of the template
 		// This approach is much faster then delegating this to the existing TemplateTranslator class

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.jdt.ls.core.internal.handlers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +27,7 @@ import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
 import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.After;
@@ -368,6 +370,27 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		TextEdit edit = item.getTextEdit().getLeft();
 		assertEquals("while (a) {\n\t${0}\n}", edit.getNewText());
 		assertEquals("a.while", item.getFilterText());
+	}
+
+	@Test
+	public void test_canEvaluate() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod() {\n" +
+			"		System." +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "System.");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		assertFalse(items.stream().anyMatch(i -> i.getKind().equals(CompletionItemKind.Snippet)));
 	}
 
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {


### PR DESCRIPTION
For example, when trigger completion after `System.|`, the postfix completions should not appear.

Signed-off-by: Sheng Chen <sheche@microsoft.com>