### PR TITLE
Fix signature help not working correctly for parameterized type

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.CompletionRequestor;
@@ -208,7 +209,12 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 
 	public String computeJavaDoc(CompletionProposal proposal) {
 		try {
-			IType type = unit.getJavaProject().findType(SignatureUtil.stripSignatureToFQN(String.valueOf(proposal.getDeclarationSignature())));
+			String fullyQualifiedName = SignatureUtil.stripSignatureToFQN(String.valueOf(proposal.getDeclarationSignature()));
+			IType type = unit.getJavaProject().findType(fullyQualifiedName);
+			if (type == null) {
+				// find secondary types if primary type search is missed.
+				type = unit.getJavaProject().findType(fullyQualifiedName, new NullProgressMonitor());
+			}
 			if (type != null) {
 				if (proposal instanceof InternalCompletionProposal) {
 					Binding binding = ((InternalCompletionProposal) proposal).getBinding();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpContext.java
@@ -304,7 +304,7 @@ public class SignatureHelpContext {
 		} else if (node instanceof ClassInstanceCreation) {
 			ITypeBinding binding = ((ClassInstanceCreation) node).getType().resolveBinding();
 			if (binding != null) {
-				this.methodName = binding.getName();
+				this.methodName = binding.getErasure().getName();
 			}
 		} else if (node instanceof SuperMethodInvocation) {
 			this.methodName = ((SuperMethodInvocation) node).getName().getIdentifier();
@@ -355,11 +355,11 @@ public class SignatureHelpContext {
 			ITypeBinding declaringType = methodBinding.getDeclaringClass();
 			List<String> typeNames = new ArrayList<>();
 			for (ITypeBinding mInterface : declaringType.getInterfaces()) {
-				String unqualifiedName = mInterface.getName().replaceAll("<.*>", "").replace(";", "");
+				String unqualifiedName = mInterface.getErasure().getName().replace(";", "");
 				typeNames.add(unqualifiedName);
 			}
 			while (declaringType != null) {
-				String unqualifiedName = declaringType.getName().replaceAll("<.*>", "").replace(";", "");
+				String unqualifiedName = declaringType.getErasure().getName().replace(";", "");
 				typeNames.add(unqualifiedName);
 				declaringType = declaringType.getSuperclass();
 			}
@@ -430,8 +430,8 @@ public class SignatureHelpContext {
 			}
 
 			this.parameterTypesFromBinding = Arrays.stream(methodBinding.getParameterTypes()).map(type -> {
-				String unqualifiedName = type.getName();
-				return unqualifiedName.replaceAll("<.*>", "").replace(";", "");
+				String unqualifiedName = type.getErasure().getName();
+				return unqualifiedName.replace(";", "");
 			}).toArray(String[]::new);
 		}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SignatureHelpHandlerTest.java
@@ -1129,6 +1129,30 @@ public class SignatureHelpHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void testSignatureHelp_erasureType() throws Exception {
+		when(preferenceManager.getPreferences().isSignatureHelpDescriptionEnabled()).thenReturn(true);
+		IPackageFragment pack1 = sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("	public void foo() {\n");
+		buf.append("		new V<String>();\n");
+		buf.append("	}\n");
+		buf.append("}\n");
+		buf.append("class V<T> {\n");
+		buf.append("	/** hi */\n");
+		buf.append("	public V() {}\n");
+		buf.append("	private V(String a) {}\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		SignatureHelp help = getSignatureHelp(cu, 3, 16);
+		assertNotNull(help);
+		assertEquals(1, help.getSignatures().size());
+		Either<String, MarkupContent> documentation = help.getSignatures().get(help.getActiveSignature()).getDocumentation();
+		assertEquals("hi", documentation.getLeft().trim());
+	}
+
+	@Test
 	public void testSignatureHelpInClassFile() throws Exception {
 		String uri = "jdt://contents/java.base/java.lang/String.class";
 		String payload = HOVER_TEMPLATE.replace("${file}", uri).replace("${line}", "10").replace("${char}", "10");


### PR DESCRIPTION
- Get erased type name for parameterized type binding.
- Try to search for secondary types when primary type search failed when resolving the method document.

fix https://github.com/redhat-developer/vscode-java/issues/2739

Signed-off-by: Sheng Chen <sheche@microsoft.com>