### PR TITLE
Add setting for clean ups to be applied upon document save

### DIFF
--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -32,6 +32,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.jdt.apt.pluggable.core;bundle-version="1.2.0";resolution:=optional,
  org.eclipse.m2e.apt.core;bundle-version="1.3.0";resolution:=optional
 Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests,org.eclipse.jdt.ls.tests.syntaxserver",
+ org.eclipse.jdt.ls.core.internal.cleanup;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.codemanipulation;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.commands;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.contentassist;x-friends:="org.eclipse.jdt.ls.tests",

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddDeprecatedAnnotationCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddDeprecatedAnnotationCleanUp.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
+
+/**
+ * A cleanup that adds the deprecated annotation to classes/fields/methods that
+ * are marked deprecated in the javadoc.
+ */
+public class AddDeprecatedAnnotationCleanUp implements ISimpleCleanUp {
+
+	private static final List<String> COMPILER_OPTS = Arrays.asList(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION);
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "addDeprecated";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createMarkerBasedFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) {
+		return Java50FixCore.createCleanUp(context.getAST(), false, false, true, false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerOptions()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return COMPILER_OPTS;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddOverrideAnnotationCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/AddOverrideAnnotationCleanUp.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
+
+/**
+ * A cleanup that adds the override annotation to all methods that override any
+ * parent method.
+ */
+public class AddOverrideAnnotationCleanUp implements ISimpleCleanUp {
+
+	private static final List<String> COMPILER_OPTS = Arrays.asList(JavaCore.COMPILER_PB_MISSING_OVERRIDE_ANNOTATION);
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "addOverride";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createMarkerBasedFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) {
+		return Java50FixCore.createCleanUp(context.getAST(), true, true, false, false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerOptions()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return COMPILER_OPTS;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+
+/**
+ * Represents a store of all the clean ups that can be performed on save in
+ * eclipse.jdt.ls.
+ */
+public class CleanUpRegistry {
+
+	private Map<String, ISimpleCleanUp> cleanUps;
+
+	public CleanUpRegistry() {
+		List<ISimpleCleanUp> cleanUpsList = new ArrayList<>();
+		cleanUpsList.add(new MemberAccessUsesThisCleanUp());
+		cleanUpsList.add(new StaticAccessUsesClassNameCleanUp());
+		cleanUpsList.add(new AddOverrideAnnotationCleanUp());
+		cleanUpsList.add(new AddDeprecatedAnnotationCleanUp());
+
+		// Store in a Map so that they can be accessed by ID quickly
+		cleanUps = new HashMap<>();
+		cleanUpsList.forEach(cleanUp -> {
+			cleanUps.put(cleanUp.getIdentifier(), cleanUp);
+		});
+	}
+
+	/**
+	 * Returns a non-null list of text edits to clean up the given text document
+	 * according to the clean ups that are enabled.
+	 *
+	 * @param textDocumentId
+	 *            the text document to get the clean up edits for
+	 * @param cleanUpEnabled
+	 *            the list of enabled clean ups
+	 * @param monitor
+	 *            the progress monitor
+	 * @return a non-null list of text edits to clean up the given text document
+	 *         according to the clean ups that are enabled
+	 */
+	public List<TextEdit> getEditsForAllActiveCleanUps(TextDocumentIdentifier textDocumentId, List<String> cleanUpEnabled, IProgressMonitor monitor) {
+
+		IJavaProject javaProject = JDTUtils.resolveCompilationUnit(textDocumentId.getUri()).getJavaProject();
+
+		List<ISimpleCleanUp> cleanUpsToRun = cleanUpEnabled.stream() //
+				.distinct() //
+				.map(cleanUpId -> {
+					return cleanUps.get(cleanUpId);
+				}) //
+				.toList();
+		if (cleanUpsToRun.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<String> compilerOptsToEnable = cleanUpsToRun.stream() //
+				.flatMap(cleanUp -> {
+					return cleanUp.getRequiredCompilerMarkers().stream();
+				}) //
+				.toList();
+
+		// enable required compiler markers that are currently ignored
+		Map<String, String> opts = javaProject.getOptions(true);
+		for (String compilerOpt : compilerOptsToEnable) {
+			String currentOptValue = opts.get(compilerOpt);
+			if (currentOptValue == null || currentOptValue.equals(JavaCore.IGNORE)) {
+				opts.put(compilerOpt, JavaCore.WARNING);
+			}
+		}
+
+		// build the context after setting the compiler options so that the built AST has all the required markers
+		CleanUpContextCore context = CleanUpUtils.getCleanUpContext(textDocumentId, opts, monitor);
+
+		List<TextEdit> textEdits = new ArrayList<>();
+		for (ISimpleCleanUp cleanUp : cleanUpsToRun) {
+			textEdits.addAll(CleanUpUtils.getTextEditFromCleanUp(cleanUp, context, monitor));
+		}
+
+		return textEdits;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpUtils.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.TextEditConverter;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+
+/**
+ * Functions for working with JDT ICleanUpCore and ISimpleCleanUp.
+ */
+public class CleanUpUtils {
+
+	private CleanUpUtils() {
+	}
+
+	/**
+	 * Returns the clean up context for the given text document.
+	 *
+	 * @param textDocumentId
+	 *            the text document to get the clean up context for
+	 * @param compilerOpts
+	 *            the compiler options to use for the AST
+	 * @param monitor
+	 *            the progress monitor
+	 * @return the clean up context for the given text document
+	 */
+	public static CleanUpContextCore getCleanUpContext(TextDocumentIdentifier textDocumentId, Map<String, String> compilerOpts, IProgressMonitor monitor) {
+		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(textDocumentId.getUri());
+		CompilationUnit ast = createASTWithOpts(unit, compilerOpts, monitor);
+		return new CleanUpContextCore(unit, ast);
+	}
+
+	/**
+	 * Returns a non-null list of text edits for the given clean up.
+	 *
+	 * @param cleanUp
+	 *            the clean up to get the edits for
+	 * @param context
+	 *            the context to perform the clean up on
+	 * @param monitor
+	 *            the progress monitor
+	 * @return a non-null list of text edits for the given clean up
+	 */
+	public static List<TextEdit> getTextEditFromCleanUp(ISimpleCleanUp cleanUp, CleanUpContextCore context, IProgressMonitor monitor) {
+
+		try {
+			ICleanUpFixCore fix = cleanUp.createFix(context);
+			if (fix == null) {
+				return Collections.emptyList();
+			}
+			CompilationUnitChange cleanUpChange = fix.createChange(monitor);
+			org.eclipse.text.edits.TextEdit jdtEdit = cleanUpChange.getEdit();
+			if (jdtEdit == null) {
+				return Collections.emptyList();
+			}
+			TextEditConverter converter = new TextEditConverter(context.getCompilationUnit(), jdtEdit);
+			List<TextEdit> lspEdit = converter.convert();
+			return lspEdit != null ? lspEdit : Collections.emptyList();
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.logError(String.format("Failed to create text edit for clean up %s", cleanUp.getIdentifier()));
+		}
+		return Collections.emptyList();
+	}
+
+	private static CompilationUnit createASTWithOpts(ICompilationUnit cu, Map<String, String> opts, IProgressMonitor monitor) {
+		ASTParser astParser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+		astParser.setSource(cu);
+		astParser.setResolveBindings(true);
+		astParser.setStatementsRecovery(IASTSharedValues.SHARED_AST_STATEMENT_RECOVERY);
+		astParser.setBindingsRecovery(IASTSharedValues.SHARED_BINDING_RECOVERY);
+		astParser.setCompilerOptions(opts);
+		return (CompilationUnit) astParser.createAST(monitor);
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/ISimpleCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/ISimpleCleanUp.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+
+/**
+ * Represents a cleanup change that doesn't need any further configuration (eg.
+ * UI interaction), and can simply be enabled or disabled.
+ */
+public interface ISimpleCleanUp {
+
+	/**
+	 * Returns the unique identifier for this clean up.
+	 *
+	 * @return the unique identifier for this clean up
+	 */
+	String getIdentifier();
+
+	/**
+	 * Returns the cleanup fix for the given source file.
+	 *
+	 * @param context
+	 *            the context for the clean up (the compilation unit and the AST)
+	 * @return the cleanup fix for the given source file
+	 */
+	ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException;
+
+	/**
+	 * Returns a list of all compiler markers (i.e. info, warning, error) that are
+	 * needed in order to perform this clean up.
+	 *
+	 * @return a list of all compiler markers (i.e. info, warning, error) that are
+	 *         needed in order to perform this clean up
+	 */
+	List<String> getRequiredCompilerMarkers();
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/MemberAccessUsesThisCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/MemberAccessUsesThisCleanUp.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
+
+/**
+ * Represents a clean up that prefixes all (non-static) field and method
+ * accesses with {@code this}.
+ */
+public class MemberAccessUsesThisCleanUp implements ISimpleCleanUp {
+
+	public MemberAccessUsesThisCleanUp() {
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "qualifyMembers";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix()
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return CodeStyleFixCore.createCleanUp(unit, //
+				true, //
+				false, //
+				false, //
+				false, //
+				true, //
+				false, //
+				false, //
+				false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StaticAccessUsesClassNameCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/StaticAccessUsesClassNameCleanUp.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
+
+/**
+ * Represents a clean up that prefixes all static member accesses with the
+ * classes name.
+ */
+public class StaticAccessUsesClassNameCleanUp implements ISimpleCleanUp {
+
+	public StaticAccessUsesClassNameCleanUp() {
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "qualifyStaticMembers";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix()
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return CodeStyleFixCore.createCleanUp(unit, //
+				false, //
+				false, //
+				true, //
+				false, //
+				false, //
+				true, //
+				false, //
+				false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -466,6 +466,11 @@ public class Preferences {
 	public static final String JAVA_COMPILE_NULLANALYSIS_NULLABLE = "java.compile.nullAnalysis.nullable";
 	public static final String JAVA_COMPILE_NULLANALYSIS_MODE = "java.compile.nullAnalysis.mode";
 
+	/**
+	 * Preference key for list of cleanups to run on save
+	 */
+	public static final String JAVA_CLEANUPS_ACTIONS_ON_SAVE = "java.cleanup.actionsOnSave";
+
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting";
@@ -606,6 +611,7 @@ public class Preferences {
 	private List<String> nonnullTypes;
 	private List<String> nullableTypes;
 	private FeatureStatus nullAnalysisMode;
+	private List<String> cleanUpActionsOnSave;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -828,6 +834,7 @@ public class Preferences {
 		nonnullTypes = new ArrayList<>();
 		nullableTypes = new ArrayList<>();
 		nullAnalysisMode = FeatureStatus.disabled;
+		cleanUpActionsOnSave = new ArrayList<>();
 	}
 
 	private static void initializeNullAnalysisClasspathStorage() {
@@ -1169,7 +1176,19 @@ public class Preferences {
 		prefs.setNullableTypes(nullableTypes);
 		String nullAnalysisMode = getString(configuration, JAVA_COMPILE_NULLANALYSIS_MODE, null);
 		prefs.setNullAnalysisMode(FeatureStatus.fromString(nullAnalysisMode, FeatureStatus.disabled));
+		List<String> cleanupActionsOnSave = getList(configuration, JAVA_CLEANUPS_ACTIONS_ON_SAVE, Collections.emptyList());
+		prefs.setCleanUpActionsOnSave(cleanupActionsOnSave);
 		return prefs;
+	}
+
+	/**
+	 * Sets the new value of the enabled clean ups.
+	 *
+	 * @param enabledCleanUps
+	 *            the new list of enabled clean ups
+	 */
+	private void setCleanUpActionsOnSave(List<String> enabledCleanUps) {
+		this.cleanUpActionsOnSave = enabledCleanUps;
 	}
 
 	public Preferences setJavaHome(String javaHome) {
@@ -2049,6 +2068,15 @@ public class Preferences {
 
 	/**
 	 * update the null analysis options of all projects based on the null analysis mode
+	 * Returns the list of enabled clean ups.
+	 *
+	 * @return the list of enabled clean ups
+	 */
+	public List<String> getCleanUpActionsOnSave() {
+		return this.cleanUpActionsOnSave;
+	}
+
+	/**
 	 * @return whether the options are changed or not
 	 */
 	public boolean updateAnnotationNullAnalysisOptions() {
@@ -2206,4 +2234,5 @@ public class Preferences {
 		}
 		return options;
 	}
+
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -1,0 +1,238 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.correction.TestOptions;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractMavenBasedTest;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for clean ups.
+ */
+public class CleanUpsTest extends AbstractMavenBasedTest {
+
+	public static CleanUpRegistry registry = new CleanUpRegistry();
+
+	private IJavaProject javaProject;
+	private IPackageFragmentRoot fSourceFolder;
+	private IProject project;
+	private IPackageFragment pack1;
+
+	@Before
+	public void setup() throws Exception {
+		importProjects("maven/quickstart");
+		project = WorkspaceHelper.getProject("quickstart");
+		javaProject = JavaCore.create(project);
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, String.valueOf(99));
+		javaProject.setOptions(options);
+		fSourceFolder = javaProject.getPackageFragmentRoot(javaProject.getProject().getFolder("src/main/java"));
+		File src = fSourceFolder.getResource().getLocation().toFile();
+		src.mkdirs();
+		project.getProject().refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		pack1 = fSourceFolder.createPackageFragment("test1", false, monitor);
+	}
+
+	@After
+	public void teardown() throws Exception {
+		pack1.delete(false, null);
+	}
+
+	@Test
+	public void testNoCleanUp() throws Exception {
+
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A implements Runnable {\n" + //
+				"    public void run() {} \n" + //
+				"    /**\n" + //
+				"     * @deprecated\n" + //
+				"     */\n" + //
+				"    public void destroy() {} \n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Collections.emptyList(), null);
+		assertEquals(0, textEdits.size());
+	}
+
+	@Test
+	public void testOverrideCleanUp() throws Exception {
+
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, monitor);
+
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A implements Runnable {\n" + //
+				"    public void run() {} \n" + //
+				"    /**\n" + //
+				"     * @deprecated\n" + //
+				"     */\n" + //
+				"    public void destroy() {} \n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("addOverride"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("@Override\n    ", r(2, 4, 2, 4)), textEdits.get(0));
+	}
+
+	@Test
+	public void testDeprecatedCleanUp() throws Exception {
+
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A implements Runnable {\n" + //
+				"    public void run() {} \n" + //
+				"    /**\n" + //
+				"     * @deprecated\n" + //
+				"     */\n" + //
+				"    public void destroy() {} \n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("addDeprecated"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("@Deprecated\n    ", r(6, 4, 6, 4)), textEdits.get(0));
+	}
+
+	@Test
+	public void testUseThisCleanUp() throws Exception {
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A {\n" + //
+				"    private int value;\n" + //
+				"    public int getValue() {\n" + //
+				"        return value;\n" + //
+				"    }\n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("qualifyMembers"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("this.value", r(4, 15, 4, 20)), textEdits.get(0));
+	}
+
+	@Test
+	public void testUseClassNameCleanUp1() throws Exception {
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A {\n" + //
+				"    private static final int VALUE = 10;\n" + //
+				"    public int getValue() {\n" + //
+				"        return VALUE;\n" + //
+				"    }\n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("qualifyStaticMembers"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("A.VALUE", r(4, 15, 4, 20)), textEdits.get(0));
+	}
+
+	@Test
+	public void testUseClassNameCleanUp2() throws Exception {
+		String contents = "" + //
+				"package test1;\n" + //
+				"import static java.lang.System.out;\n" + //
+				"public class A {\n" + //
+				"    private static final int VALUE = 10;\n" + //
+				"    public int getValue() {\n" + //
+				"        out.println(\"moo\");\n" + //
+				"        return A.VALUE;\n" + //
+				"    }\n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("qualifyStaticMembers"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("System.out", r(5, 8, 5, 11)), textEdits.get(0));
+	}
+
+	@Test
+	public void testAccessCleanUpsDontInterfere() throws Exception {
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A {\n" + //
+				"    private static final int NUMBER = 10;\n" + //
+				"    private static final int value;\n" + //
+				"    public int getValue() {\n" + //
+				"        return this.value;\n" + //
+				"    }\n" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("qualifyStaticMembers", "qualifyMembers"), monitor);
+		assertEquals(0, textEdits.size());
+
+		contents = "" + //
+				"package test1;\n" + //
+				"public class A {\n" + //
+				"    private static final int NUMBER = 10;\n" + //
+				"    private static final int value;\n" + //
+				"    public int getValue() {\n" + //
+				"        return A.NUMBER;\n" + //
+				"    }\n" + //
+				"}\n";
+		unit = pack1.createCompilationUnit("A.java", contents, true, monitor);
+
+		textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("qualifyStaticMembers", "qualifyMembers"), monitor);
+		assertEquals(0, textEdits.size());
+	}
+
+	private static TextEdit te(String contents, Range range) {
+		TextEdit textEdit = new TextEdit();
+		textEdit.setNewText(contents);
+		textEdit.setRange(range);
+		return textEdit;
+	}
+
+	private static Range r(int beginLine, int beginChar, int endLine, int endChar) {
+		Position start = new Position(beginLine, beginChar);
+		Position end = new Position(endLine, endChar);
+		Range range = new Range(start, end);
+		return range;
+	}
+
+}


### PR DESCRIPTION
- Add new setting `java.cleanup.actionsOnSave` to list which clean ups to run
- Add clean up to prefix all member accesses with `this`
- Add clean up to prefix all static member accesses with class name
- Add clean up to insert missing `@Override`
- Add clean up to insert missing `@Deprecated`

See redhat-developer/vscode-java#2144

Signed-off-by: David Thompson <davthomp@redhat.com>
