### PR TITLE
Do not forget existing project options when setting null analysis options

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -2055,16 +2055,23 @@ public class Preferences {
 		if (javaProject.getElementName().equals(ProjectsManager.DEFAULT_PROJECT_NAME)) {
 			return false;
 		}
-		Map<String, String> projectOptions = javaProject.getOptions(true);
-		if (projectOptions == null) {
+		Map<String, String> projectInheritOptions = javaProject.getOptions(true);
+		if (projectInheritOptions == null) {
 			return false;
 		}
 		String nonnullType = getAnnotationType(javaProject, this.nonnullTypes, nonnullClasspathStorage);
 		String nullableType = getAnnotationType(javaProject, this.nullableTypes, nullableClasspathStorage);
 		Map<String, String> projectNullAnalysisOptions = generateProjectNullAnalysisOptions(nonnullType, nullableType);
-		boolean shouldUpdate = !projectNullAnalysisOptions.entrySet().stream().allMatch(e -> e.getValue().equals(projectOptions.get(e.getKey())));
+		boolean shouldUpdate = !projectNullAnalysisOptions.entrySet().stream().allMatch(e -> e.getValue().equals(projectInheritOptions.get(e.getKey())));
 		if (shouldUpdate) {
-			javaProject.setOptions(projectNullAnalysisOptions);
+			// get existing project options
+			Map<String, String> projectOptions = javaProject.getOptions(false);
+			if (projectOptions != null) {
+				projectOptions.putAll(projectNullAnalysisOptions);
+				javaProject.setOptions(projectOptions);
+			} else {
+				return false;
+			}
 		}
 		return shouldUpdate;
 	}


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix https://github.com/redhat-developer/vscode-java/issues/2764

`IJavaProject.setOptions()` will replace existing options with default values if not exist in the map, so the source level information will be lost after we set null analysis options.

```
Sets the project custom options. All and only the options explicitly included in the given table are remembered; all previous option settings are forgotten, including ones not explicitly mentioned.
```
We should merge the non-inherit project options before setting it.