### PR TITLE
Support quickfix for gradle jpms projects

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JDTDelegateCommandHandler.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.commands.BuildPathCommand;
@@ -33,7 +34,6 @@ import org.eclipse.jdt.ls.core.internal.handlers.CompletionHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.FormatterHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.ResolveSourceMappingHandler;
 import org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter;
-import org.eclipse.jdt.ls.core.internal.managers.GradleUtils;
 import org.eclipse.lsp4j.ResolveTypeHierarchyItemParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
@@ -126,7 +126,7 @@ public class JDTDelegateCommandHandler implements IDelegateCommandHandler {
 					String projectUri = (String) arguments.get(0);
 					String gradleVersion = arguments.size() > 1 ? (String) arguments.get(1) : null;
 					if (gradleVersion == null) {
-						gradleVersion = GradleUtils.CURRENT_GRADLE;
+						gradleVersion = GradleVersion.current().getVersion();
 					}
 					return GradleProjectImporter.upgradeGradleVersion(projectUri, gradleVersion, monitor);
 				case "java.project.resolveWorkspaceSymbol":

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.java
@@ -314,6 +314,8 @@ public final class CorrectionMessages extends NLS {
 	public static String NewCUCompletionUsingWizardProposal_tooltip_enclosingtype;
 	public static String NewCUCompletionUsingWizardProposal_tooltip_package;
 
+	public static String NotAccessibleType_upgrade_Gradle_label;
+
 	public static String JavaCorrectionProcessor_addquote_description;
 	public static String JavaCorrectionProcessor_error_quickfix_message;
 	public static String JavaCorrectionProcessor_error_status;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/CorrectionMessages.properties
@@ -397,6 +397,8 @@ NewCUCompletionUsingWizardProposal_dialogtitle=New
 NewCUCompletionUsingWizardProposal_tooltip_enclosingtype=Enclosing Type:
 NewCUCompletionUsingWizardProposal_tooltip_package=Package:
 
+NotAccessibleType_upgrade_Gradle_label=Upgrade Gradle version to 7.0.1
+
 JavaCorrectionProcessor_addquote_description=Insert missing quote
 JavaCorrectionProcessor_error_quickfix_message=An error occurred while computing quick fixes. Check log for details.
 JavaCorrectionProcessor_error_status=Exception while processing quick fixes or quick assists

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.proposals.AddImportCorrectio
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.CUCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeCorrectionProposal;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.GetterSetterCorrectionSubProcessor;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.GradleCompatibilityProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.IProposalRelevance;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.JavadocTagsSubProcessor;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.LocalCorrectionsSubProcessor;
@@ -53,6 +54,7 @@ import org.eclipse.jdt.ls.core.internal.corrections.proposals.UnresolvedElements
 import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jdt.ls.core.internal.text.correction.ModifierCorrectionSubProcessor;
 import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
 
 /**
  */
@@ -73,7 +75,7 @@ public class QuickFixProcessor {
 		return start;
 	}
 
-	public List<ChangeCorrectionProposal> getCorrections(IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
+	public List<ChangeCorrectionProposal> getCorrections(CodeActionParams params, IInvocationContext context, IProblemLocationCore[] locations) throws CoreException {
 		if (locations == null || locations.length == 0) {
 			return Collections.emptyList();
 		}
@@ -82,7 +84,7 @@ public class QuickFixProcessor {
 		for (int i = 0; i < locations.length; i++) {
 			IProblemLocationCore curr = locations[i];
 			if (handledProblems(curr, locations, handledProblems)) {
-				process(context, curr, resultingCollections);
+				process(params, context, curr, resultingCollections);
 			}
 		}
 		return resultingCollections;
@@ -105,7 +107,7 @@ public class QuickFixProcessor {
 		return handledProblems.add(problemId);
 	}
 
-	private void process(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) throws CoreException {
+	private void process(CodeActionParams params, IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) throws CoreException {
 		int id = problem.getProblemId();
 		if (id == 0) { // no proposals for none-problem locations
 			return;
@@ -550,6 +552,9 @@ public class QuickFixProcessor {
 			case IProblem.UnclosedCloseable:
 			case IProblem.PotentiallyUnclosedCloseable:
 				LocalCorrectionsSubProcessor.getTryWithResourceProposals(context, problem, proposals);
+				break;
+			case IProblem.NotAccessibleType:
+				GradleCompatibilityProcessor.getGradleCompatibilityProposals(context, problem, proposals);
 				break;
 			// case IProblem.MissingSynchronizedModifierInInheritedMethod:
 			// ModifierCorrectionSubProcessor.addSynchronizedMethodProposal(context,

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GradleCompatibilityProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GradleCompatibilityProcessor.java
@@ -76,18 +76,45 @@ public class GradleCompatibilityProcessor {
 		}
 	}
 
+	/**
+	 * Add proposal for a non-modular project. For a project doesn't have a module
+	 * description file (module-info.java), there should be nothing in the module
+	 * path. See: https://github.com/gradle/gradle/issues/16922
+	 * 
+	 * @param result
+	 *                      the classpath result
+	 * @param context
+	 *                      the invocation context
+	 * @param uri
+	 *                      the project uri
+	 * @param proposals
+	 *                      the current proposals
+	 */
 	private static void addProposalForNonModulerProject(ClasspathResult result, IInvocationContext context, URI uri, Collection<ChangeCorrectionProposal> proposals) {
-		// For a project doesn't have a module description file (module-info.java), there should be nothing in the module path.
-		// See: https://github.com/gradle/gradle/issues/16922
 		if (result.modulepaths.length > 0) {
 			addProposal(context, uri, proposals);
 		}
 	}
 
+	/**
+	 * Add proposal for a modular project. For a project has a module description
+	 * file (module-info.java), we should check that all the dependencies in
+	 * classpath don't contain module description (either description or automatic
+	 * description, the supported inferred modules in Gradle) See:
+	 * https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular)
+	 * 
+	 * @param javaProject
+	 *                        the java project
+	 * @param result
+	 *                        the classpath result
+	 * @param context
+	 *                        the invocation context
+	 * @param uri
+	 *                        the project uri
+	 * @param proposals
+	 *                        the current proposals
+	 */
 	private static void addProposalForModulerProject(IJavaProject javaProject, ClasspathResult result, IInvocationContext context, URI uri, Collection<ChangeCorrectionProposal> proposals) {
-		// For a project has a module description file (module-info.java), we should check that all the dependencies in classpath don't contain
-		// module description (either description or automatic description, the supported inferred modules in Gradle)
-		// See: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular)
 		for (String classpath : result.classpaths) {
 			try {
 				IPackageFragmentRoot packageFragmentRoot = javaProject.findPackageFragmentRoot(new Path(classpath));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GradleCompatibilityProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/GradleCompatibilityProcessor.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corrections.proposals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.buildship.core.internal.CorePlugin;
+import org.eclipse.buildship.core.internal.preferences.PersistentModel;
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IModuleDescription;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
+import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
+import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
+import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
+import org.eclipse.jdt.ls.core.internal.corrections.IInvocationContext;
+import org.eclipse.jdt.ls.core.internal.managers.GradleUtils;
+import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
+import org.eclipse.lsp4j.CodeActionKind;
+
+public class GradleCompatibilityProcessor {
+	public static void getGradleCompatibilityProposals(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) {
+		IJavaProject javaProject = context.getCompilationUnit().getJavaProject();
+		if (javaProject == null) {
+			return;
+		}
+		IProject project = javaProject.getProject();
+		if (!ProjectUtils.isGradleProject(project)) {
+			return;
+		}
+		PersistentModel model = CorePlugin.modelPersistence().loadModel(project);
+		if (!model.isPresent()) {
+			return;
+		}
+		GradleVersion gradleVersion = model.getGradleVersion();
+		if (gradleVersion != null && gradleVersion.compareTo(GradleVersion.version(GradleUtils.JPMS_SUPPORTED_VERSION)) < 0) {
+			IResource resource = javaProject.getResource();
+			if (resource == null) {
+				return;
+			}
+			URI uri = resource.getLocationURI();
+			if (uri == null) {
+				return;
+			}
+			try {
+				ClasspathResult result = ProjectCommand.getClasspathsFromJavaProject(javaProject, new ProjectCommand.ClasspathOptions());
+				IModuleDescription moduleDescription = javaProject.getModuleDescription();
+				if (moduleDescription == null) {
+					// For a project doesn't have a module description file (module-info.java), there should be nothing in the module path.
+					// See: https://github.com/gradle/gradle/issues/16922
+					if (result.modulepaths.length > 0) {
+						addProposal(context, uri, proposals);
+					}
+				} else {
+					// For a project has a module description file (module-info.java), we should check that all the dependencies in classpath don't contain
+					// module description (either description or automatic description, the supported inferred modules in Gradle)
+					// See: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular)
+					for (String classpath : result.classpaths) {
+						IPackageFragmentRoot packageFragmentRoot = javaProject.findPackageFragmentRoot(new Path(classpath));
+						if (packageFragmentRoot instanceof JarPackageFragmentRoot) {
+							// try to get module description
+							IModuleDescription jarModuleDescription = ((JarPackageFragmentRoot) packageFragmentRoot).getModuleDescription();
+							if (jarModuleDescription == null) {
+								// fall back to get automatic module description
+								jarModuleDescription = ((JarPackageFragmentRoot) packageFragmentRoot).getAutomaticModuleDescription();
+							}
+							if (jarModuleDescription != null) {
+								addProposal(context, uri, proposals);
+								break;
+							}
+						}
+					}
+				}
+			} catch (CoreException | URISyntaxException e) {
+				return;
+			}
+		}
+	}
+
+	private static void addProposal(IInvocationContext context, URI uri, Collection<ChangeCorrectionProposal> proposals) {
+		proposals.add(new CUCorrectionCommandProposal(CorrectionMessages.NotAccessibleType_upgrade_Gradle_label, CodeActionKind.QuickFix, context.getCompilationUnit(), IProposalRelevance.CONFIGURE_BUILD_PATH, "java.project.upgradeGradle",
+				Arrays.asList(uri.toString(), GradleUtils.JPMS_SUPPORTED_VERSION)));
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -159,7 +159,7 @@ public class CodeActionHandler {
 		if (containsKind(codeActionKinds, CodeActionKind.QuickFix)) {
 			try {
 				codeActions.addAll(nonProjectFixProcessor.getCorrections(params, context, locations));
-				List<ChangeCorrectionProposal> quickfixProposals = this.quickFixProcessor.getCorrections(context, locations);
+				List<ChangeCorrectionProposal> quickfixProposals = this.quickFixProcessor.getCorrections(params, context, locations);
 				this.quickFixProcessor.addAddAllMissingImportsProposal(context, quickfixProposals);
 				Set<ChangeCorrectionProposal> quickSet = new TreeSet<>(comparator);
 				quickSet.addAll(quickfixProposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
@@ -47,9 +47,11 @@ import org.gradle.tooling.model.build.GradleEnvironment;
 public class GradleUtils {
 
 	public static String MAX_SUPPORTED_JAVA = JavaCore.VERSION_17;
-	public static String CURRENT_GRADLE = "7.3.1";
 	// see https://github.com/gradle/gradle/pull/17397
 	public static String INVALID_TYPE_FIXED_VERSION = "7.2";
+	// see https://github.com/gradle/gradle/issues/890
+	// see https://github.com/gradle/gradle/issues/16922
+	public static String JPMS_SUPPORTED_VERSION = "7.0.1";
 
 	private static final String MESSAGE_DIGEST_ALGORITHM = "SHA-256";
 


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

related to https://github.com/redhat-developer/vscode-java/pull/2773

Gradle provides better JPMS support since 7.0, see: https://github.com/gradle/gradle/issues/890#issuecomment-756213083, which means the Gradle versions under 7.0 might cause some issues, and the user will see errors such as "xxx is not accessible".

See https://github.com/gradle/gradle/issues/16922, Gradle 7.0.1 added an extra fix about JPMS projects, so 7.0.1 is a better recommendation version IMO.

this PR provides a quickfix to help users upgrade the gradle version.

https://user-images.githubusercontent.com/45906942/199211128-69f2d809-992e-4415-a329-674913584b54.mp4

