### PR TITLE
Do not mandate LanguageServerApplication running

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -13,7 +13,7 @@
             thread="main"
             visible="true">
          <run
-               class="org.eclipse.jdt.ls.core.internal.LanguageServer">
+               class="org.eclipse.jdt.ls.core.internal.LanguageServerApplication">
          </run>
       </application>
    </extension>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaLanguageServerPlugin.java
@@ -122,7 +122,7 @@ public class JavaLanguageServerPlugin extends Plugin {
 
 	private ISourceDownloader sourceDownloader;
 
-	private LanguageServer languageServer;
+	private LanguageServerApplication languageServer;
 	private ProjectsManager projectsManager;
 	private DigestStore digestStore;
 	private ContentProviderManager contentProviderManager;
@@ -140,7 +140,7 @@ public class JavaLanguageServerPlugin extends Plugin {
 
 	private ExecutorService executorService;
 
-	public static LanguageServer getLanguageServer() {
+	public static LanguageServerApplication getLanguageServer() {
 		return pluginInstance == null ? null : pluginInstance.languageServer;
 	}
 
@@ -457,7 +457,7 @@ public class JavaLanguageServerPlugin extends Plugin {
 		}
 	}
 
-	static void startLanguageServer(LanguageServer newLanguageServer) throws IOException {
+	static void startLanguageServer(LanguageServerApplication newLanguageServer) throws IOException {
 		if (pluginInstance != null) {
 			pluginInstance.languageServer = newLanguageServer;
 			pluginInstance.startConnection();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServerApplication.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServerApplication.java
@@ -15,44 +15,44 @@ package org.eclipse.jdt.ls.core.internal;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 
-public class LanguageServer implements IApplication {
+public class LanguageServerApplication implements IApplication {
 
-  private volatile boolean shutdown;
-  private long parentProcessId;
-  private final Object waitLock = new Object();
+	private volatile boolean shutdown;
+	private long parentProcessId;
+	private final Object waitLock = new Object();
 
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
 
-    JavaLanguageServerPlugin.startLanguageServer(this);
-    synchronized(waitLock){
-          while (!shutdown) {
-            try {
-              context.applicationRunning();
-              JavaLanguageServerPlugin.logInfo("Main thread is waiting");
-              waitLock.wait();
-            } catch (InterruptedException e) {
-              JavaLanguageServerPlugin.logException(e.getMessage(), e);
-            }
-          }
-    }
+		JavaLanguageServerPlugin.startLanguageServer(this);
+		synchronized (waitLock) {
+			while (!shutdown) {
+				try {
+					context.applicationRunning();
+					JavaLanguageServerPlugin.logInfo("Main thread is waiting");
+					waitLock.wait();
+				} catch (InterruptedException e) {
+					JavaLanguageServerPlugin.logException(e.getMessage(), e);
+				}
+			}
+		}
 		return IApplication.EXIT_OK;
 	}
 
 	@Override
 	public void stop() {
-    synchronized(waitLock){
-      waitLock.notifyAll();
-    }
+		synchronized (waitLock) {
+			waitLock.notifyAll();
+		}
 	}
 
 	public void exit() {
-    shutdown = true;
-    JavaLanguageServerPlugin.logInfo("Shutdown received... waking up main thread");
-    synchronized(waitLock){
-      waitLock.notifyAll();
-    }
-  }
+		shutdown = true;
+		JavaLanguageServerPlugin.logInfo("Shutdown received... waking up main thread");
+		synchronized (waitLock) {
+			waitLock.notifyAll();
+		}
+	}
 
 	public void setParentProcessId(long pid) {
 		this.parentProcessId = pid;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ParentProcessWatcher.java
@@ -36,11 +36,11 @@ public final class ParentProcessWatcher implements Runnable, Function<MessageCon
 	private static final boolean isJava1x = System.getProperty("java.version").startsWith("1.");
 	private static final int POLL_DELAY_SECS = 10;
 	private volatile long lastActivityTime;
-	private final LanguageServer server;
+	private final LanguageServerApplication server;
 	private ScheduledFuture<?> task;
 	private ScheduledExecutorService service;
 
-	public ParentProcessWatcher(LanguageServer server ) {
+	public ParentProcessWatcher(LanguageServerApplication server) {
 		this.server = server;
 		if (ProcessHandle.current().parent().isPresent()) {
 			this.server.setParentProcessId(ProcessHandle.current().parent().get().pid());

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseInitHandler.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JVMConfigurator;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.LanguageServerApplication;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
@@ -151,8 +152,9 @@ public abstract class BaseInitHandler {
 		}
 
 		Integer processId = param.getProcessId();
-		if (processId != null) {
-			JavaLanguageServerPlugin.getLanguageServer().setParentProcessId(processId.longValue());
+		LanguageServerApplication application = JavaLanguageServerPlugin.getLanguageServer();
+		if (processId != null && application != null) {
+			application.setParentProcessId(processId.longValue());
 		}
 
 		return initializationOptions;


### PR DESCRIPTION
Remove an execution path that only works if IApplication is running; so JDT-LS can be used in different deployments.

Part of https://github.com/eclipse/eclipse.jdt.ls/issues/2311