### PR TITLE
QuickFix for annotation missing attributes

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/QuickFixProcessor.java
@@ -300,10 +300,9 @@ public class QuickFixProcessor {
 			// LocalCorrectionsSubProcessor.addMissingHashCodeProposals(context,
 			// problem, proposals);
 			// break;
-			// case IProblem.MissingValueForAnnotationMember:
-			// LocalCorrectionsSubProcessor.addValueForAnnotationProposals(context,
-			// problem, proposals);
-			// break;
+			case IProblem.MissingValueForAnnotationMember:
+				LocalCorrectionsSubProcessor.addValueForAnnotationProposals(context, problem, proposals);
+				break;
 			// case IProblem.BodyForNativeMethod:
 			// ModifierCorrectionSubProcessor.addNativeMethodProposals(context,
 			// problem, proposals);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
@@ -191,6 +191,7 @@ public interface IProposalRelevance {
 	public static final int REMOVE_REDUNDANT_NULLNESS_ANNOTATION= 5;
 	public static final int REPLACE_WITH_UNQUALIFIED_ENUM_CONSTANT= 5;
 	public static final int OVERRIDE_DEFAULT_METHOD= 5;
+	public static final int ADD_MISSING_ANNOTATION_ATTRIBUTES = 5;
 
 	public static final int ADD_MISSING_TAG= 4;
 	public static final int INSERT_FALL_THROUGH= 4;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/LocalCorrectionsSubProcessor.java
@@ -90,6 +90,7 @@ import org.eclipse.jdt.internal.corext.dom.Selection;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
+import org.eclipse.jdt.internal.corext.fix.MissingAnnotationAttributesFixCore;
 import org.eclipse.jdt.internal.corext.fix.SealedClassFixCore;
 import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
 import org.eclipse.jdt.internal.corext.fix.UnusedCodeFixCore;
@@ -1097,6 +1098,21 @@ public class LocalCorrectionsSubProcessor {
 				IType permittedType = SealedClassFixCore.getPermittedType(selectedNode);
 				ICompilationUnit unit = permittedType.getCompilationUnit();
 				CUCorrectionProposal proposal = new CUCorrectionProposal(label, CodeActionKind.QuickFix, unit, change, IProposalRelevance.DECLARE_SEALED_AS_DIRECT_SUPER_TYPE);
+				proposals.add(proposal);
+			} catch (CoreException e) {
+				// do nothing
+			}
+		}
+	}
+
+	public static void addValueForAnnotationProposals(IInvocationContext context, IProblemLocationCore problem, Collection<ChangeCorrectionProposal> proposals) {
+		MissingAnnotationAttributesFixCore fix = MissingAnnotationAttributesFixCore.addMissingAnnotationAttributesProposal(context.getASTRoot(), problem);
+		if (fix != null) {
+			String label = fix.getDisplayString();
+			CompilationUnitChange change;
+			try {
+				change = fix.createChange(null);
+				CUCorrectionProposal proposal = new CUCorrectionProposal(label, CodeActionKind.QuickFix, context.getCompilationUnit(), change, IProposalRelevance.ADD_MISSING_ANNOTATION_ATTRIBUTES);
 				proposals.add(proposal);
 			} catch (CoreException e) {
 				// do nothing

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20221205-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20221206-1800"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AnnotationMissingAttributeQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/AnnotationMissingAttributeQuickFixTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.corrections.proposals.LocalCorrectionsSubProcessor;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * {@link LocalCorrectionsSubProcessor#addValueForAnnotationProposals}.
+ */
+public class AnnotationMissingAttributeQuickFixTest extends AbstractQuickFixTest {
+
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject = newEmptyProject();
+		fJProject.setOptions(TestOptions.getDefaultOptions());
+		fSourceFolder = fJProject.getPackageFragmentRoot(fJProject.getProject().getFolder("src"));
+	}
+
+	@Test
+	public void testOneAttribute() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public @interface C {\n");
+		buf.append("  String value();\n");
+		buf.append("}\n");
+		pack.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("  @C\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+		ICompilationUnit classCU = pack.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		// FIXME: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/334
+		buf.append("  @C(value = \"\")\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Add missing attributes", buf.toString());
+
+		assertCodeActions(classCU, expected);
+	}
+
+	@Test
+	public void testOneRequiredAttribute() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public @interface C {\n");
+		buf.append("  String value();\n");
+		buf.append("  String otherValue() default \"prefix\";\n");
+		buf.append("}\n");
+		pack.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("  @C\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+		ICompilationUnit classCU = pack.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("  @C(value = \"\")\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Add missing attributes", buf.toString());
+
+		assertCodeActions(classCU, expected);
+	}
+
+	@Test
+	public void testMultipleRequiredAttributes() throws Exception {
+		IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public @interface C {\n");
+		buf.append("  String value1();\n");
+		buf.append("  String value2();\n");
+		buf.append("  String otherValue() default \"prefix\";\n");
+		buf.append("}\n");
+		pack.createCompilationUnit("C.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("  @C\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+		ICompilationUnit classCU = pack.createCompilationUnit("A.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("public class A {\n");
+		buf.append("  @C(value1 = \"\", value2 = \"\")\n");
+		buf.append("  int myInt = 0;\n");
+		buf.append("}\n");
+
+		Expected expected = new Expected("Add missing attributes", buf.toString());
+
+		assertCodeActions(classCU, expected);
+	}
+
+}


### PR DESCRIPTION
Requires eclipse-jdt/eclipse.jdt.ui#335

Closes #1860

Signed-off-by: David Thompson <davthomp@redhat.com>
