### PR TITLE
fix multiple add missing imports at one line

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
@@ -94,7 +94,6 @@ import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
-import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.Messages;
 import org.eclipse.jdt.ls.core.internal.contentassist.TypeFilter;
 import org.eclipse.jdt.ls.core.internal.corrections.CorrectionMessages;
@@ -107,7 +106,6 @@ import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeMethodSignat
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeMethodSignatureProposal.InsertDescription;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeMethodSignatureProposal.RemoveDescription;
 import org.eclipse.jdt.ls.core.internal.corrections.proposals.ChangeMethodSignatureProposal.SwapDescription;
-import org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler;
 import org.eclipse.jdt.ls.core.internal.hover.JavaElementLabels;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -706,12 +704,6 @@ public class UnresolvedElementsSubProcessor {
 				if (!fullName.equals(resolvedTypeName)) {
 					proposals.add(createTypeRefChangeProposal(cu, fullName, node, relevance, elements.length));
 				}
-			}
-		}
-		if (proposals.size() > 0) {
-			CUCorrectionProposal proposal = OrganizeImportsHandler.getOrganizeImportsProposal(CorrectionMessages.UnresolvedElementsSubProcessor_add_allMissing_imports_description, CodeActionKind.QuickFix, cu, relevance, context.getASTRoot(), JavaLanguageServerPlugin.getPreferencesManager().getClientPreferences().isAdvancedOrganizeImportsSupported(), true);
-			if (proposal != null) {
-				proposals.add(proposal);
 			}
 		}
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -160,6 +160,7 @@ public class CodeActionHandler {
 			try {
 				codeActions.addAll(nonProjectFixProcessor.getCorrections(params, context, locations));
 				List<ChangeCorrectionProposal> quickfixProposals = this.quickFixProcessor.getCorrections(context, locations);
+				this.quickFixProcessor.addAddAllMissingImportsProposal(context, quickfixProposals);
 				Set<ChangeCorrectionProposal> quickSet = new TreeSet<>(comparator);
 				quickSet.addAll(quickfixProposals);
 				proposals.addAll(quickSet);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OrganizeImportsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/OrganizeImportsHandler.java
@@ -238,7 +238,7 @@ public final class OrganizeImportsHandler {
 		if (uri == null) {
 			return null;
 		}
-		return new CUCorrectionProposal(label, kind, cu, null, relevance + 10) {
+		return new CUCorrectionProposal(label, kind, cu, null, relevance) {
 			@Override
 			protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
 				TextEdit edit = OrganizeImportsHandler.organizeImports(cu, supportsChooseImports ? OrganizeImportsHandler.getChooseImportsFunction(uri.toString(), restoreExistingImports) : null, restoreExistingImports, new NullProgressMonitor());


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix #2333, for a scenario when multiple unresolved types in an annotation declaration, multiple "add all missing imports" are easily observed. This PR moves the logic of generating the quick fix to the end of quick fixes.

It also check all the existing relevance of `AddImportCorrectionProposal`s and assign the new "add all missing imports" equals the minimum value -1. In case of the wrong order. 