### PR TITLE
[DO NOT MERGE] Early startup of JDT LS extension bundles

### DIFF
--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -5,6 +5,7 @@
    <extension-point id="org.eclipse.jdt.ls.core.importers" name="JDT LS Project Importer" schema="schema/org.eclipse.jdt.ls.core.importers.exsd"/>
    <extension-point id="org.eclipse.jdt.ls.core.contentProvider" name="contentProvider" schema="schema/org.eclipse.jdt.ls.core.contentProvider.exsd"/>
    <extension-point id="org.eclipse.jdt.ls.core.buildSupport" name="Build Support" schema="schema/org.eclipse.jdt.ls.core.buildSupport.exsd"/>
+   <extension-point id="org.eclipse.jdt.ls.core.startup" name="org.eclipse.jdt.ls.core.startup" schema="schema/org.eclipse.jdt.ls.core.startup.exsd"/>
    <extension
          id="id1"
          point="org.eclipse.core.runtime.applications">

--- a/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.startup.exsd
+++ b/org.eclipse.jdt.ls.core/schema/org.eclipse.jdt.ls.core.startup.exsd
@@ -1,0 +1,104 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.jdt.ls.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.jdt.ls.core" id="org.eclipse.jdt.ls.core.startup" name="org.eclipse.jdt.ls.core.startup"/>
+      </appinfo>
+      <documentation>
+         [Enter description of this extension point.]
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="bundle" minOccurs="1" maxOccurs="unbounded"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="bundle">
+      <annotation>
+         <documentation>
+            Descriptor of a bundle to start at the Java LS initialization
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  Bundle id
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+
+</schema>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InitHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2021 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -30,6 +30,7 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -221,6 +222,13 @@ final public class InitHandler extends BaseInitHandler {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		if (workspace instanceof Workspace) {
 			((Workspace) workspace).getBuildManager().waitForAutoBuildOff();
+		}
+		IConfigurationElement[] elements = Platform.getExtensionRegistry().getConfigurationElementsFor("org.eclipse.jdt.ls.core.startup");
+		if (elements != null) {
+			for (IConfigurationElement b : elements) {
+				String bundleId = b.getAttribute("id");
+				startBundle(bundleId);
+			}
 		}
 		Job job = new WorkspaceJob("Initialize Workspace") {
 			@Override


### PR DESCRIPTION
Our extension of JDT LS, i.e. bundle, needs to start early to track workspace for projects having Spring Boot on the classpath. My understanding that currently our bundle is activated only when "Delegate Command Handlers" needs to be invoked.

Essentially, we'd like to achieve Spring Boot LS start when there is a project in the workspace with Spring Boot on classpath and shut it down when there are no projects in the workspace with Spring Boot on the classpath. Command: `executeClientCommand` protocol extension would be used to start/stop Spring Boot LS based on presence of spring boot projects in the workspace.

Feedback is very welcomed!