### PR TITLE
Prevent the code action conversion from producing null code actions.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -50,8 +50,8 @@ import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.eclipse.jdt.ls.core.internal.text.correction.AssignToVariableAssistCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.CUCorrectionCommandProposal;
-import org.eclipse.jdt.ls.core.internal.text.correction.NonProjectFixProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.CodeActionComparator;
+import org.eclipse.jdt.ls.core.internal.text.correction.NonProjectFixProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.QuickAssistProcessor;
 import org.eclipse.jdt.ls.core.internal.text.correction.RefactoringCorrectionCommandProposal;
 import org.eclipse.jdt.ls.core.internal.text.correction.SourceAssistProcessor;
@@ -295,7 +295,7 @@ public class CodeActionHandler {
 			}
 			return Optional.of(Either.forRight(codeAction));
 		} else {
-			return Optional.of(Either.forLeft(command));
+			return Optional.ofNullable(command != null ? Either.forLeft(command) : null);
 		}
 	}
 


### PR DESCRIPTION
- Fixes #2327 
- We define a set of default code action kinds, which seem to be calculated regardless of whether the client even supports them
- If a client supports code action resolve, but has not registered code action support for a particular kind (eg. quickassist), we might return a null command
- Nesting the null within the union (Either) makes the Optional useless so we should return null directly

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>