### PR TITLE
Share indexes among workspaces

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.CRC32;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
+import org.eclipse.jdt.internal.core.index.FileIndexLocation;
+import org.eclipse.jdt.internal.core.index.IndexLocation;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+
+public class IndexUtils {
+    public static void copyIndexesToSharedLocation() {
+        // common index location for all workspaces
+        final String SHARED_INDEX_LOCATION = System.getProperty("jdt.core.sharedIndexLocation");
+        if (StringUtils.isBlank(SHARED_INDEX_LOCATION)) {
+            return;
+        }
+
+        Set<IndexLocation> reusedIndexLocations = new HashSet<>();
+        IPath javaCoreStateLocation = JavaCore.getPlugin().getStateLocation();
+        for (IJavaProject javaProject : ProjectUtils.getJavaProjects()) {
+            try {
+                IClasspathEntry[] entries = ((JavaProject) javaProject).getResolvedClasspath();
+                for (IClasspathEntry entry : entries) {
+                    if (entry instanceof ClasspathEntry && entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+                        URL indexURL = ((ClasspathEntry) entry).getLibraryIndexLocation();
+                        if (indexURL == null) {
+                            continue;
+                        }
+
+                        IPath containerPath = entry.getPath();
+                        IndexLocation localIndexLocation = getLocalIndexLocation(javaCoreStateLocation, containerPath);
+                        IndexLocation sharedIndexLocation = IndexLocation.createIndexLocation(indexURL);
+                        if (sharedIndexLocation.equals(localIndexLocation) || reusedIndexLocations.contains(localIndexLocation)) {
+                            continue;
+                        }
+
+                        reusedIndexLocations.add(localIndexLocation);
+                        boolean needDeleteLocalIndex = false;
+                        File localIndexFile = localIndexLocation.getIndexFile();
+                        if (localIndexLocation.exists()) {
+                            File sharedIndexFile = sharedIndexLocation.getIndexFile();
+                            if (sharedIndexFile == null || localIndexFile == null) {
+                                continue;
+                            }
+
+                            File tmpFile = new File(sharedIndexFile.getParent(), sharedIndexFile.getName() + "." + System.currentTimeMillis());
+                            try {
+                                mkdirsFor(tmpFile);
+                                Files.copy(localIndexFile.toPath(), tmpFile.toPath(), LinkOption.NOFOLLOW_LINKS, StandardCopyOption.REPLACE_EXISTING);
+                                Files.deleteIfExists(sharedIndexFile.toPath());
+                                needDeleteLocalIndex = tmpFile.renameTo(sharedIndexFile);
+                            } catch (IOException e) {
+                                JavaLanguageServerPlugin.logError(String.format("Failed to copy the local index %s to the shared index %s: %s",
+                                    localIndexFile.getName(), sharedIndexFile.getName(), e.getMessage()));
+                            } finally {
+                                try {
+                                    Files.deleteIfExists(tmpFile.toPath());
+                                } catch (IOException e) {
+                                    // do nothing
+                                }
+                            }
+                        }
+
+                        if (needDeleteLocalIndex) {
+                            try {
+                                // Remove the local index after it has been copied to the shared index location.
+                                Files.deleteIfExists(localIndexFile.toPath());
+                            } catch (IOException e) {
+                                JavaLanguageServerPlugin.logError(String.format("Failed to delete the local index %s: %s",
+                                    localIndexFile.getName(), e.getMessage()));
+                            }
+                        }
+                    }
+                }
+            } catch (JavaModelException e) {
+                JavaLanguageServerPlugin.logException(e);
+            }
+        }
+    }
+
+    private static IndexLocation getLocalIndexLocation(IPath savedIndexPath, IPath containerPath) {
+        String pathString = containerPath.toOSString();
+        CRC32 checksumCalculator = new CRC32();
+        checksumCalculator.update(pathString.getBytes());
+        String fileName = Long.toString(checksumCalculator.getValue()) + ".index";
+        // to share the indexLocation between the indexLocations and indexStates tables, get the key from the indexStates table
+        return new FileIndexLocation(new File(savedIndexPath.toOSString(), fileName));
+    }
+
+    private static void mkdirsFor(File destination) {
+        //does destination directory exist ?
+        if ( destination.getParentFile() != null && !destination.getParentFile().exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            destination.getParentFile().mkdirs();
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
@@ -13,23 +13,36 @@
 
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.zip.CRC32;
 
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResourceChangeEvent;
+import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
+import org.eclipse.jdt.internal.core.JavaModel;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.index.FileIndexLocation;
@@ -42,109 +55,259 @@ import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 
 public class IndexUtils {
-    public static void copyIndexesToSharedLocation() {
-        IndexManager indexManager = JavaModelManager.getIndexManager();
-        // common index location for all workspaces
-        final String SHARED_INDEX_LOCATION = System.getProperty("jdt.core.sharedIndexLocation");
-        if (indexManager == null || StringUtils.isBlank(SHARED_INDEX_LOCATION)) {
-            return;
-        }
+	private static boolean resourceChangeRegistered = false;
+	private static Map<IPath, Long> externalTimeStamps = null;
 
-        JobHelpers.waitUntilIndexesReady(); // wait for index ready
+	public static void copyIndexesToSharedLocation() {
+		// common index location for all workspaces
+		final String SHARED_INDEX_LOCATION = System.getProperty("jdt.core.sharedIndexLocation");
+		if (JavaModelManager.getIndexManager() == null || StringUtils.isBlank(SHARED_INDEX_LOCATION)) {
+			return;
+		}
 
-        Set<IndexLocation> resolvedIndexLocations = new HashSet<>();
-        IPath javaCoreStateLocation = JavaCore.getPlugin().getStateLocation();
-        for (IJavaProject javaProject : ProjectUtils.getJavaProjects()) {
-            try {
-                IClasspathEntry[] entries = ((JavaProject) javaProject).getResolvedClasspath();
-                for (IClasspathEntry entry : entries) {
-                    if (entry instanceof ClasspathEntry && entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
-                        URL indexURL = ((ClasspathEntry) entry).getLibraryIndexLocation();
-                        if (indexURL == null) {
-                            continue;
-                        }
+		JobHelpers.waitUntilIndexesReady();
+		getExternalLibTimeStamps(); // init load of externalLibTimeStamps
+		registerResourceChangeListener();
+		copyIndexesToSharedLocation(ProjectUtils.getJavaProjects());
+	}
 
-                        IndexLocation sharedIndexLocation = IndexLocation.createIndexLocation(indexURL);
-                        IndexLocation localIndexLocation = getLocalIndexLocation(javaCoreStateLocation, entry.getPath());
-                        if (sharedIndexLocation.equals(localIndexLocation) || !resolvedIndexLocations.add(localIndexLocation)) {
-                            continue;
-                        }
+	private static synchronized void registerResourceChangeListener() {
+		if (resourceChangeRegistered) {
+			return;
+		}
+		resourceChangeRegistered = true;
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(new IResourceChangeListener() {
+			@Override
+			public void resourceChanged(IResourceChangeEvent event) {
+				IJavaProject [] projects = null;
+				Object obj = event.getSource();
+				if (obj instanceof IProject project) {
+					if (ProjectUtils.isJavaProject(project)) {
+						projects = new IJavaProject[]{ JavaCore.create(project) };
+					}
+				} else if (obj instanceof IWorkspace) {
+					projects = ProjectUtils.getJavaProjects();
+				}
 
-                        File localIndexFile = localIndexLocation.getIndexFile();
-                        if (localIndexLocation.exists()) {
-                            File sharedIndexFile = sharedIndexLocation.getIndexFile();
-                            if (sharedIndexFile == null || localIndexFile == null) {
-                                continue;
-                            }
+				if (projects != null && projects.length > 0) {
+					JavaModelManager.getIndexManager().waitForIndex(true, null);
+					copyIndexesToSharedLocation(projects);
+				}
+			}
+		}, IResourceChangeEvent.PRE_REFRESH);
+	}
 
-                            if (indexManager.getIndex(sharedIndexLocation) != null) {
-                                try {
-                                    // current classpath entry is using the shared index, delete the unused local index directly.
-                                    Files.deleteIfExists(localIndexFile.toPath());
-                                } catch (IOException e) {
-                                    JavaLanguageServerPlugin.logError(String.format("Failed to delete the local index %s: %s",
-                                        localIndexFile.getName(), e.getMessage()));
-                                }
-                            } else {
-                                Index localIndex = indexManager.getIndex(localIndexLocation);
-                                if (localIndex == null || localIndex.hasChanged()) {
-                                    continue;
-                                } else {
-                                    ReadWriteMonitor monitor = localIndex.monitor;
-                                    if (monitor == null) { // index got deleted since acquired
-                                        continue;
-                                    }
+	private static void copyIndexesToSharedLocation(IJavaProject[] javaProjects) {
+		Set<ClasspathEntry> processedEntries = new HashSet<>();
+		Set<ClasspathEntry> deferredEntries = new HashSet<>();
+		for (IJavaProject javaProject : javaProjects) {
+			try {
+				if (javaProject == null || !javaProject.exists()) {
+					continue;
+				}
 
-                                    try {
-                                        monitor.enterRead();
-                                        copyIndex(localIndexFile, sharedIndexFile);
-                                    } finally {
-                                        monitor.exitRead();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            } catch (JavaModelException e) {
-                JavaLanguageServerPlugin.logException(e);
-            }
-        }
-    }
+				IClasspathEntry[] entries = ((JavaProject) javaProject).getResolvedClasspath();
+				for (IClasspathEntry entry : entries) {
+					if (entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+						processLibraryIndex(javaProject.getProject(), (ClasspathEntry) entry, processedEntries, deferredEntries);
+					}
+				}
+			} catch (JavaModelException e) {
+				JavaLanguageServerPlugin.logException(e);
+			}
+		}
 
-    private static boolean copyIndex(File from, File to) {
-        File tmpFile = new File(to.getParent(), to.getName() + "." + System.currentTimeMillis());
-        try {
-            mkdirsFor(tmpFile);
-            Files.copy(from.toPath(), tmpFile.toPath(), LinkOption.NOFOLLOW_LINKS, StandardCopyOption.REPLACE_EXISTING);
-            Files.deleteIfExists(to.toPath());
-            return tmpFile.renameTo(to);
-        } catch (IOException e) {
-            JavaLanguageServerPlugin.logError(String.format("Failed to copy the local index %s to the shared index %s: %s",
-                from.getName(), to.getName(), e.getMessage()));
-        } finally {
-            try {
-                Files.deleteIfExists(tmpFile.toPath());
-            } catch (IOException e) {
-                // do nothing
-            }
-        }
+		if (!deferredEntries.isEmpty()) {
+			JobHelpers.waitUntilIndexesReady();
+			processedEntries = new HashSet<>();
+			for (ClasspathEntry entry : deferredEntries) {
+				processLibraryIndex(entry, processedEntries);
+			}
+		}
+	}
 
-        return false;
-    }
+	private static void processLibraryIndex(ClasspathEntry libraryEntry, Set<ClasspathEntry> processedEntries) {
+		processLibraryIndex(null, libraryEntry, processedEntries, null);
+	}
 
-    private static IndexLocation getLocalIndexLocation(IPath savedIndexPath, IPath containerPath) {
-        String pathString = containerPath.toOSString();
-        CRC32 checksumCalculator = new CRC32();
-        checksumCalculator.update(pathString.getBytes());
-        String fileName = Long.toString(checksumCalculator.getValue()) + ".index";
-        // to share the indexLocation between the indexLocations and indexStates tables, get the key from the indexStates table
-        return new FileIndexLocation(new File(savedIndexPath.toOSString(), fileName));
-    }
+	private static void processLibraryIndex(IProject project, ClasspathEntry libraryEntry, Set<ClasspathEntry> processedEntries, Set<ClasspathEntry> deferredEntries) {
+		if (!processedEntries.add(libraryEntry)) {
+			return;
+		}
 
-    private static void mkdirsFor(File destination) {
-        if ( destination.getParentFile() != null && !destination.getParentFile().exists()) {
-            destination.getParentFile().mkdirs();
-        }
-    }
+		IPath libraryPath = libraryEntry.getPath();
+		Object libraryFile = JavaModel.getTarget(libraryPath, true);
+		/**
+		 * If the library is a jar inside the workspace, it will be resolved to a IFile.
+		 * If it is an external jar, it will be resolved to a java.io.File.
+		 *
+		 * Currently JDT only supports shared indexes for external jars, we can skip
+		 * the processing of non-external jars.
+		 */
+		boolean isExternalJar = libraryFile instanceof File;
+		if (!isExternalJar) {
+			return;
+		}
+
+		IndexLocation sharedIndexLocation = getSharedIndexLocation(libraryEntry);
+		IndexLocation localIndexLocation = getLocalIndexLocation(libraryPath);
+		if (sharedIndexLocation == null || Objects.equals(sharedIndexLocation, localIndexLocation)) {
+			return;
+		}
+
+		long lastModifiedTime = ((File) libraryFile).lastModified();
+		File localIndexFile = localIndexLocation.getIndexFile();
+		IndexManager indexManager = JavaModelManager.getIndexManager();
+		// shared index is currently in use.
+		if (indexManager.getIndex(sharedIndexLocation) != null) {
+			Long oldTimestamp = getExternalLibTimeStamps().get(libraryPath);
+			long newTimeStamp = getLibTimeStamp((File) libraryFile);
+			boolean libChanged = oldTimestamp != null && oldTimestamp.longValue() != newTimeStamp;
+			if (!libChanged || sharedIndexLocation.lastModified() == lastModifiedTime) {
+				try {
+					Files.deleteIfExists(localIndexFile.toPath());
+				} catch (IOException e) {
+					JavaLanguageServerPlugin.logError(String.format("Failed to delete the local index %s: %s",
+						localIndexFile.getName(), e.getMessage()));
+				}
+
+				return;
+			}
+
+			if (project == null || deferredEntries == null) {
+				return;
+			}
+
+			// The shared index is outdated, remove it so that it is forced to be re-indexed in local workspace.
+			indexManager.removeIndex(libraryPath);
+			indexManager.indexLibrary(libraryPath, project, localIndexLocation.getUrl(), true);
+			deferredEntries.add(libraryEntry);
+			return;
+		}
+
+		// local index is currently in use.
+		if (lastModifiedTime > 0 && localIndexLocation.exists()) {
+			File sharedIndexFile = sharedIndexLocation.getIndexFile();
+			if (sharedIndexFile == null || localIndexFile == null) {
+				return;
+			}
+
+			Index localIndex = indexManager.getIndex(localIndexLocation);
+			if (localIndex == null || localIndex.hasChanged()) {
+				return;
+			}
+
+			ReadWriteMonitor monitor = localIndex.monitor;
+			if (monitor == null) { // index got deleted since acquired
+				return;
+			}
+
+			try {
+				monitor.enterRead();
+				copyIndexFile(localIndexFile, sharedIndexFile, lastModifiedTime);
+				getExternalLibTimeStamps().put(libraryPath, getLibTimeStamp((File) libraryFile));
+			} finally {
+				monitor.exitRead();
+			}
+		}
+	}
+
+	private static boolean copyIndexFile(File from, File to, long lastModified) {
+		long toFileModifiedTime = to.lastModified();
+		// The file contents are not changed, skip the file copy
+		if (toFileModifiedTime != 0 && toFileModifiedTime == lastModified) {
+			return false;
+		}
+
+		File tmpFile = new File(to.getParent(), to.getName() + "." + System.currentTimeMillis());
+		try {
+			mkdirsFor(tmpFile);
+			Files.copy(from.toPath(), tmpFile.toPath(), LinkOption.NOFOLLOW_LINKS, StandardCopyOption.REPLACE_EXISTING);
+			Files.deleteIfExists(to.toPath());
+			boolean success = tmpFile.renameTo(to);
+			// Keep the lastModified timestamp of the shared index same as the original library file.
+			to.setLastModified(lastModified);
+			return success;
+		} catch (IOException e) {
+			JavaLanguageServerPlugin.logError(String.format("Failed to copy the local index %s to the shared index %s: %s",
+				from.getName(), to.getName(), e.getMessage()));
+		} finally {
+			try {
+				Files.deleteIfExists(tmpFile.toPath());
+			} catch (IOException e) {
+				// do nothing
+			}
+		}
+
+		return false;
+	}
+
+	private static IndexLocation getSharedIndexLocation(ClasspathEntry libraryEntry) {
+		URL indexURL = libraryEntry.getLibraryIndexLocation();
+		if (indexURL == null) {
+			return null;
+		}
+
+		return IndexLocation.createIndexLocation(indexURL);
+	}
+
+	private static IndexLocation getLocalIndexLocation(IPath libraryPath) {
+		String pathString = libraryPath.toOSString();
+		CRC32 checksumCalculator = new CRC32();
+		checksumCalculator.update(pathString.getBytes());
+		String fileName = Long.toString(checksumCalculator.getValue()) + ".index";
+		IPath statePath = JavaCore.getPlugin().getStateLocation();
+		return new FileIndexLocation(new File(statePath.toOSString(), fileName));
+	}
+
+	private static void mkdirsFor(File destination) {
+		if (destination.getParentFile() != null && !destination.getParentFile().exists()) {
+			destination.getParentFile().mkdirs();
+		}
+	}
+
+	private synchronized static Map<IPath, Long> getExternalLibTimeStamps() {
+		if (externalTimeStamps == null) {
+			Map<IPath, Long> timeStamps = new HashMap<>();
+			File timestampsFile = getExternalLibTimeStampsFile();
+			DataInputStream in = null;
+			try {
+				in = new DataInputStream(new BufferedInputStream(new FileInputStream(timestampsFile)));
+				int size = in.readInt();
+				while (size-- > 0) {
+					String key = in.readUTF();
+					long timestamp = in.readLong();
+					timeStamps.put(Path.fromPortableString(key), Long.valueOf(timestamp));
+				}
+			} catch (IOException e) {
+				if (timestampsFile.exists()) {
+					JavaLanguageServerPlugin.logException("Unable to read external time stamps", e);
+				}
+			} finally {
+				if (in != null) {
+					try {
+						in.close();
+					} catch (IOException e) {
+						// nothing we can do: ignore
+					}
+				}
+			}
+
+			externalTimeStamps = timeStamps;
+		}
+
+		return externalTimeStamps;
+	}
+
+	private static File getExternalLibTimeStampsFile() {
+		return JavaCore.getPlugin().getStateLocation().append("externalLibsTimeStamps").toFile();
+	}
+
+	/*
+	 * Answer a combination of the lastModified stamp and the size.
+	 * Used for detecting external JAR changes
+	 */
+	private static long getLibTimeStamp(File file) {
+		return file.lastModified() + file.length();
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/IndexUtils.java
@@ -50,6 +50,8 @@ public class IndexUtils {
             return;
         }
 
+        JobHelpers.waitUntilIndexesReady(); // wait for index ready
+
         Set<IndexLocation> resolvedIndexLocations = new HashSet<>();
         IPath javaCoreStateLocation = JavaCore.getPlugin().getStateLocation();
         for (IJavaProject javaProject : ProjectUtils.getJavaProjects()) {
@@ -75,7 +77,6 @@ public class IndexUtils {
                                 continue;
                             }
 
-                            JobHelpers.waitUntilIndexesReady(); // wait for index ready
                             if (indexManager.getIndex(sharedIndexLocation) != null) {
                                 try {
                                     // current classpath entry is using the shared index, delete the unused local index directly.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -284,11 +284,11 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 					// before send the service ready notification, make sure all bundles are synchronized
 					synchronizeBundles();
 
-					IndexUtils.copyIndexesToSharedLocation();
-
 					client.sendStatus(ServiceStatus.ServiceReady, "ServiceReady");
 					status = ServiceStatus.ServiceReady;
 					pm.projectsImported(monitor);
+
+					IndexUtils.copyIndexesToSharedLocation();
 				} catch (OperationCanceledException | CoreException e) {
 					logException(e.getMessage(), e);
 					return Status.CANCEL_STATUS;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -284,6 +284,8 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 					// before send the service ready notification, make sure all bundles are synchronized
 					synchronizeBundles();
 
+					IndexUtils.copyIndexesToSharedLocation();
+
 					client.sendStatus(ServiceStatus.ServiceReady, "ServiceReady");
 					status = ServiceStatus.ServiceReady;
 					pm.projectsImported(monitor);

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20221206-1800"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20221215-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SharedIndexTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SharedIndexTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+* Copyright (c) 2022 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
+import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.Test;
+
+public class SharedIndexTest extends AbstractProjectsManagerBasedTest {
+
+	@Test
+	public void testSharedIndex() throws Exception {
+		final String sharedIndexKey = "jdt.core.sharedIndexLocation";
+		Field SHARED_INDEX_LOCATION = ClasspathEntry.class.getDeclaredField("SHARED_INDEX_LOCATION");
+		SHARED_INDEX_LOCATION.setAccessible(true);
+		try {
+			Path newIndexPath = Paths.get(getWorkingProjectDirectory().toString(), ".index");
+			System.setProperty(sharedIndexKey, newIndexPath.toString());
+			SHARED_INDEX_LOCATION.set(ClasspathEntry.class, newIndexPath.toString());
+
+			IJavaProject javaProject = newEmptyProject();
+			IndexUtils.copyIndexesToSharedLocation();
+			IClasspathEntry[] entries = ((JavaProject) javaProject).getResolvedClasspath();
+				for (IClasspathEntry entry : entries) {
+					if (entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
+						URL expectedIndexUrl = ((ClasspathEntry) entry).getLibraryIndexLocation();
+						File sharedIndexFile = null;
+						try {
+							URI localFileURI = new URI(expectedIndexUrl.toExternalForm());
+							sharedIndexFile = new File(localFileURI);
+						} catch(Exception ex) {
+							sharedIndexFile = new File(expectedIndexUrl.getPath());
+						}
+
+						assertTrue("shared index file should exist", sharedIndexFile.exists());
+						assertTrue("library index should be generated in shared location", sharedIndexFile.toPath().startsWith(newIndexPath.toAbsolutePath()));
+					}
+				}
+		} finally {
+			System.clearProperty(sharedIndexKey);
+			SHARED_INDEX_LOCATION.set(ClasspathEntry.class, null);
+		}
+	}
+}


### PR DESCRIPTION
The upstream PR https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/152349/ allows reusing library indexes from a common location if they exist. If the common index is not hit, then it will fallback to create indexes in local workspace instead of writing back to the common location.

This PR attempts to solve the writing problem and support copying local library indexes back to the common location after the projects have been imported.

To avoid conflicts between two processes writing to a shared index, each Java process first copies the local index (e.g. 1977137404.index) to a unique tmp file (e.g. 1977137404.index.\<timestamp\>) on the shared folder, and then renames the tmp file name to the desired index file name. Because renaming is atomic, it does not leave a file with corrupted contents.

> One known issue is that current sync behavior between local indexes and shared location is incremental. It's because IndexManager keeps indexes in memory until JobManager is idle and then writes them back to disk. This means that when we open a fresh workspace, its local indexes may still be in memory after the project has been imported. Copying the local indexes may not do anything. But the good part is that if you reload the same workspace a few times, these local indexes will eventually be saved to disk and get chance to be synced up with the shared location.

JobHelpers.waitUntilIndexesReady() can force the indexes to be saved.

