### PR TITLE
Add clean up to invert equals calls on null

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -41,6 +41,7 @@ public class CleanUpRegistry {
 		cleanUpsList.add(new AddOverrideAnnotationCleanUp());
 		cleanUpsList.add(new AddDeprecatedAnnotationCleanUp());
 		cleanUpsList.add(new StringConcatToTextBlockCleanUp());
+		cleanUpsList.add(new InvertEqualsCleanUp());
 
 		// Store in a Map so that they can be accessed by ID quickly
 		cleanUps = new HashMap<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InvertEqualsCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InvertEqualsCleanUp.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.InvertEqualsFixCore;
+
+/**
+ * Represents a clean up that inverts calls to Object.equals(Object) and
+ * String.equalsIgnoreCase(String) to avoid useless null pointer exception.
+ */
+public class InvertEqualsCleanUp implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "invertEquals";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix()
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return InvertEqualsFixCore.createCleanUp(unit);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -221,6 +221,25 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 		assertEquals(0, textEdits.size());
 	}
 
+	@Test
+	public void testInvertEqualsCleanUp() throws Exception {
+		String contents = "" + //
+				"package test1;\n" + //
+				"public class A {\n" + //
+				"    String message;\n" + //
+				"    boolean result1 = message.equals(\"text\");\n" + //
+				"    boolean result2 = message.equalsIgnoreCase(\"text\")" + //
+				"}\n";
+		ICompilationUnit unit = pack1.createCompilationUnit("A.java", contents, false, monitor);
+		String uri = unit.getUnderlyingResource().getLocationURI().toString();
+
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("invertEquals"), monitor);
+		assertEquals(1, textEdits.size());
+		assertEquals(te("\"text\".equals(message);\n" + //
+				"    boolean result2 = \"text\".equalsIgnoreCase(message", r(3, 22, 4, 53)), //
+				textEdits.get(0));
+	}
+
 	private static TextEdit te(String contents, Range range) {
 		TextEdit textEdit = new TextEdit();
 		textEdit.setNewText(contents);


### PR DESCRIPTION
See: https://www.eclipse.org/eclipse/news/4.19/jdt.php#invert-equals

![Peek 2022-11-21 13-53](https://user-images.githubusercontent.com/73968480/203368319-664d684f-ce46-4470-8c42-2752856fa6fd.gif)



Signed-off-by: Jessica He <jhe@redhat.com>