### PR TITLE
Create cleanup actions for some existing quick assists.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InstanceofPatternMatch.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/InstanceofPatternMatch.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.PatternMatchingForInstanceofFixCore;
+
+/**
+ * Represents a cleanup that uses pattern matching for 'instanceof' cast checks
+ */
+public class InstanceofPatternMatch implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "instanceofPatternMatch";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return PatternMatchingForInstanceofFixCore.createCleanUp(unit);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.LambdaExpressionsFixCore;
+
+/**
+ * Represents a cleanup that converts an anonymous class creation to a lambda expression
+ */
+public class LambdaExpressionCleanup implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "lambdaExpression";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return LambdaExpressionsFixCore.createCleanUp(unit, true, false);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/SwitchExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/SwitchExpressionCleanup.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.SwitchExpressionsFixCore;
+
+/**
+ * Represents a cleanup that converts a switch statement to a switch expression
+ */
+public class SwitchExpressionCleanup implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "switchExpression";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return SwitchExpressionsFixCore.createCleanUp(unit);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/VariableDeclarationFixCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/VariableDeclarationFixCleanup.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
+import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+import org.eclipse.jdt.internal.corext.fix.VariableDeclarationFixCore;
+
+/**
+ * Represents a cleanup that adds the 'final' modifier where possible
+ */
+public class VariableDeclarationFixCleanup implements ISimpleCleanUp {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
+	 */
+	@Override
+	public String getIdentifier() {
+		return "addFinalModifier";
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#createFix(org.eclipse.jdt.core.manipulation.CleanUpContextCore)
+	 */
+	@Override
+	public ICleanUpFixCore createFix(CleanUpContextCore context) throws CoreException {
+		CompilationUnit unit = context.getAST();
+		if (unit == null) {
+			return null;
+		}
+		return VariableDeclarationFixCore.createCleanUp(unit, true, true, true);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getRequiredCompilerMarkers()
+	 */
+	@Override
+	public List<String> getRequiredCompilerMarkers() {
+		return Collections.emptyList();
+	}
+
+}


### PR DESCRIPTION
* Add final modifier where possible
* Convert switch statement to switch expression
* Use pattern matching for instanceof checks
* Convert anonymous function to lambda expression
* Add test cases, and set CleanUpsTest compliance to 19

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>