### PR TITLE
Support matching case for code completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionMatchCaseMode.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionMatchCaseMode.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+/**
+ * The mode for case matching when doing completion.
+ */
+public enum CompletionMatchCaseMode {
+	/**
+	 * Do not match case.
+	 */
+	OFF,
+	/**
+	 * Match case for the first letter.
+	 */
+	FIRSTLETTER;
+
+	public static CompletionMatchCaseMode fromString(String value, CompletionMatchCaseMode defaultMode) {
+		if (value != null) {
+			String val = value.toUpperCase();
+			try {
+				return valueOf(val);
+			} catch(Exception e) {
+				// fall back to default severity
+			}
+		}
+		return defaultMode;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -61,6 +61,7 @@ import org.eclipse.jdt.ls.core.internal.RuntimeEnvironment;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
 import org.eclipse.jdt.ls.core.internal.contentassist.TypeFilter;
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionMatchCaseMode;
 import org.eclipse.jdt.ls.core.internal.handlers.InlayHintsParameterMode;
 import org.eclipse.jdt.ls.core.internal.handlers.ProjectEncodingMode;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
@@ -307,6 +308,11 @@ public class Preferences {
 	 * Preference key to enable/disable postfix completion.
 	 */
 	public static final String POSTFIX_COMPLETION_KEY = "java.completion.postfix.enabled";
+
+	/**
+	 * Preference key to specify whether to match case when completion.
+	 */
+	public static final String COMPLETION_MATCH_CASE_MODE_KEY = "java.completion.matchCase";
 
 	/**
 	 * Preference key to enable/disable the 'foldingRange'.
@@ -556,6 +562,7 @@ public class Preferences {
 	private boolean autobuildEnabled;
 	private boolean completionEnabled;
 	private boolean postfixCompletionEnabled;
+	private CompletionMatchCaseMode completionMatchCaseMode;
 	private boolean completionOverwrite;
 	private boolean foldingRangeEnabled;
 	private boolean selectionRangeEnabled;
@@ -800,6 +807,7 @@ public class Preferences {
 		autobuildEnabled = true;
 		completionEnabled = true;
 		postfixCompletionEnabled = true;
+		completionMatchCaseMode = CompletionMatchCaseMode.OFF;
 		completionOverwrite = true;
 		foldingRangeEnabled = true;
 		selectionRangeEnabled = true;
@@ -969,6 +977,9 @@ public class Preferences {
 
 		boolean postfixEnabled = getBoolean(configuration, POSTFIX_COMPLETION_KEY, true);
 		prefs.setPostfixCompletionEnabled(postfixEnabled);
+
+		String completionMatchCaseMode = getString(configuration, COMPLETION_MATCH_CASE_MODE_KEY, null);
+		prefs.setCompletionMatchCaseMode(CompletionMatchCaseMode.fromString(completionMatchCaseMode, CompletionMatchCaseMode.OFF));
 
 		boolean completionOverwrite = getBoolean(configuration, JAVA_COMPLETION_OVERWRITE_KEY, true);
 		prefs.setCompletionOverwrite(completionOverwrite);
@@ -1372,6 +1383,14 @@ public class Preferences {
 
 	public void setPostfixCompletionEnabled(boolean postfixCompletionEnabled) {
 		this.postfixCompletionEnabled = postfixCompletionEnabled;
+	}
+
+	public CompletionMatchCaseMode getCompletionMatchCaseMode() {
+		return completionMatchCaseMode;
+	}
+
+	public void setCompletionMatchCaseMode(CompletionMatchCaseMode completionMatchCaseMode) {
+		this.completionMatchCaseMode = completionMatchCaseMode;
 	}
 
 	public Preferences setCompletionOverwrite(boolean completionOverwrite) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3568,6 +3568,47 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertTrue(items.get(0).getTextEdit().getLeft().getNewText().matches("\\(\\$\\{1:\\w+\\}\\, \\$\\{2:\\w+\\}\\) -> \\$\\{0\\}"));
 	}
 
+	@Test
+	public void testCompletion_MatchCaseOff() throws Exception {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+			//@formatter:off
+					"package org.sample",
+					"public class Test {",
+					"	public static void main(String[] args) {",
+					"		i",
+					"	}",
+					"}"));
+					//@formatter:on
+			CompletionList list = requestCompletions(unit, "		i");
+			assertFalse(list.getItems().isEmpty());
+			boolean hasUpperCase = list.getItems().stream()
+				.anyMatch(t -> Character.isUpperCase(t.getLabel().charAt(0)));
+			assertTrue(hasUpperCase);
+	}
+
+	@Test
+	public void testCompletion_MatchCaseFirstLetter() throws Exception {
+		try {
+			preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.FIRSTLETTER);
+			ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+			//@formatter:off
+					"package org.sample",
+					"public class Test {",
+					"	public static void main(String[] args) {",
+					"		i",
+					"	}",
+					"}"));
+					//@formatter:on
+			CompletionList list = requestCompletions(unit, "		i");
+			assertFalse(list.getItems().isEmpty());
+			boolean hasUpperCase = list.getItems().stream()
+				.anyMatch(t -> Character.isUpperCase(t.getLabel().charAt(0)));
+			assertFalse(hasUpperCase);
+		} finally {
+			preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.OFF);
+		}
+	}
+
 	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
 		return requestCompletions(unit, completeBehind, 0);
 	}


### PR DESCRIPTION
requires https://github.com/redhat-developer/vscode-java/pull/2834

This PR adds a new preference 'java.completion.matchCase' to specify the case matching
behavior when doing code completion. Available options are:

- FIRSTLETTER: Match case for the first letter only.
- OFF: Do not match the case.

Some profiling results when doing completion in petclinic:

#### Case 1, completion after `i`:
  | 1 | 2 | 3 | 4 | 5 | Avg.
-- | -- | -- | -- | -- | -- | --
firstLetter | 368 | 58 | 60 | 52 | 107 | 129
off | 421 | 115 | 88 | 85 | 90 | 159.8

#### Case 2, completion after `e`:
  | 1 | 2 | 3 | 4 | 5 | Avg.
-- | -- | -- | -- | -- | -- | --
firstLetter | 278 | 60 | 50 | 47 | 69 | 100.8
off | 405 | 160 | 101 | 135 | 104 | 181

#### Case 3, completion after `s`:
  | 1 | 2 | 3 | 4 | 5 | Avg.
-- | -- | -- | -- | -- | -- | --
firstLetter | 368 | 240 | 84 | 126 | 61 | 175.8
off | 530 | 221 | 166 | 152 | 151 | 244

Signed-off-by: sheche <sheche@microsoft.com>