### PR TITLE
Log user friendly error if client does not support _java.reloadBundles.command

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -384,10 +384,19 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	 */
 	private void synchronizeBundles() {
 		try {
-			List<String> bundlesToRefresh = (ArrayList<String>) JavaLanguageServerPlugin.getInstance()
+			Object commandResult = JavaLanguageServerPlugin.getInstance()
 				.getClientConnection().executeClientCommand("_java.reloadBundles.command");
-			if (bundlesToRefresh.size() > 0) {
-				BundleUtils.loadBundles(bundlesToRefresh);
+			if (commandResult instanceof List<?> list) {
+				List<String> bundlesToRefresh = (List<String>) commandResult;
+				if (bundlesToRefresh.size() > 0) {
+					BundleUtils.loadBundles(bundlesToRefresh);
+				}
+			} else if (commandResult instanceof Map<?, ?> m) {
+				String message = (String) m.get("message");
+				JavaLanguageServerPlugin.logError(message);
+			} else {
+				JavaLanguageServerPlugin.logError(
+					"Unexpected result from executeClientCommand: " + commandResult);
 			}
 		} catch (Exception e) {
 			JavaLanguageServerPlugin.logException(e);


### PR DESCRIPTION
The result of `executeClientCommand` could be a map in the LSP
`ResponseError` format.
Previously this resulted in a ClassCastException which got logged:

	class com.google.gson.internal.LinkedTreeMap cannot be cast to class java.util.ArrayList (com.google.gson.internal.LinkedTreeMap

This gave users the impression that there's a bug.
This changes the logic to instead log the message returned by the
client.

In neovim for example it results in:

	Command _java.reloadBundles.command not supported on client
