### PR TITLE
Update m2e to use m2e snapshot

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -17,7 +17,7 @@
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
             <unit id="ch.qos.logback.classic" version="0.0.0"/>
-	        <repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
+	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandlerTest.java
@@ -256,8 +256,11 @@ public class WorkspaceDiagnosticsHandlerTest extends AbstractProjectsManagerBase
 		Optional<PublishDiagnosticsParams> pomDiags = allCalls.stream().filter(p -> p.getUri().endsWith("pom.xml")).findFirst();
 		assertTrue("No pom.xml errors were found", pomDiags.isPresent());
 		List<Diagnostic> diags = pomDiags.get().getDiagnostics();
-		assertEquals(diags.toString(), 1, diags.size());
-		assertEquals("Project build error: 'dependencies.dependency.version' for org.apache.commons:commons-lang3:jar is missing.", diags.get(0).getMessage());
+		// https://github.com/redhat-developer/vscode-java/issues/2857
+		// m2e 2.2.0 returns 3 markers
+		assertEquals(diags.toString(), 3, diags.size());
+		Diagnostic diag = diags.stream().filter(d -> d.getMessage().startsWith("Project build error")).findFirst().get();
+		assertEquals("Project build error: 'dependencies.dependency.version' for org.apache.commons:commons-lang3:jar is missing.", diag.getMessage());
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-java/issues/2857

Steps to reproduce:
- create a simple project via https://start.spring.io, selecting Java 17, Maven, Spring Boot 2.7.6 
- import it in VS Code
- remove the target folder
- right click pom.xml, select Reloads Projects
- check if target/classes/application.properties exists

The issue can be reproduced in Eclipse with the latest m2e [release](https://download.eclipse.org/technology/m2e/releases/latest/) but can't be reproduced with the latest m2e [snapshot](https://download.eclipse.org/technology/m2e/snapshots/latest/)
A related issue: https://github.com/eclipse-m2e/m2e-core/issues/1150

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>