### PR TITLE
Fix output folder cannot be the same as the source folder

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/singlefile/simple2/src/App.java
+++ b/org.eclipse.jdt.ls.tests/projects/singlefile/simple2/src/App.java
@@ -1,0 +1,3 @@
+public class App {
+    public static void main(String[] args) {}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/InvisibleProjectImporterTest.java
@@ -260,11 +260,11 @@ public class InvisibleProjectImporterTest extends AbstractInvisibleProjectBasedT
 		assertTrue("Output path should be excluded from source path", isOutputExcluded);
 	}
 
-	@Test(expected = CoreException.class)
+	@Test
 	public void testSpecifyingOutputPathEqualToSourcePath() throws Exception {
 		Preferences preferences = preferenceManager.getPreferences();
 		preferences.setInvisibleProjectOutputPath("src");
-		copyAndImportFolder("singlefile/simple", "src/App.java");
+		copyAndImportFolder("singlefile/simple2", "src/App.java");
 		waitForBackgroundJobs();
 	}
 


### PR DESCRIPTION
- Remove the classpath checking logic and leverage ClasspathEntry.validateClasspath() to do the checking job.

fix https://github.com/redhat-developer/vscode-java/issues/2786

Signed-off-by: sheche <sheche@microsoft.com>