### PR TITLE
Update target platform to 4.27-I-builds/I20230114-1800

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20221215-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20230114-1800"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Update the target platform to include the change https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/379 for `org.eclipse.jdt.junit.runtime`.

This allows to execute junit 5 parallel tests.

Signed-off-by: sheche <sheche@microsoft.com>