### PR TITLE
Use the Linux config on FreeBSD systems

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -54,14 +54,14 @@ def find_equinox_launcher(jdtls_base_directory):
 def get_shared_config_path(jdtls_base_path):
 	system = platform.system()
 
-	if system == 'Linux':
+	if system in ['Linux', 'FreeBSD']:
 		config_dir = 'config_linux'
 	elif system == 'Darwin':
 		config_dir = 'config_mac'
 	elif system == 'Windows':
 		config_dir = 'config_win'
 	else:
-		raise Exception("Unknown platform {} detected".format(platform))
+		raise Exception("Unknown platform {} detected".format(system))
 
 	return jdtls_base_path / config_dir
 


### PR DESCRIPTION
This addresses #2218 

jdtls would fail to start, exiting early in the python launch script.  FreeBSD was an unenumerated system, when determining which configuration to use.  This commit instructs jdtls to treat FreeBSD in the same manner as it does Linux.

Note, this may not work in all use cases on FreeBSD, but I was able to use it without issue from [Helix](https://helix-editor.com).  It will _probably_ work with neovim and others, but I have not personally tested other text editors.

At any rate, this change could offer a solution to other users of FreeBSD.

Signed-off-by: Loren Schlomer <me@schlomie.com>