### PR TITLE
Ease integration in Eclipse IDE

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -81,7 +81,7 @@ public class JavaClientConnection {
 
 	public JavaClientConnection(JavaLanguageClient client) {
 		this.client = client;
-		logHandler = new LogHandler();
+		logHandler = JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench() ? new LogHandler(status -> false) : new LogHandler();
 		logHandler.install(this);
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
@@ -142,6 +142,9 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 	 * @param isDiagnosticTagSupported
 	 */
 	private void collectNonJavaProblems(List<Diagnostic> diagnostics, boolean isDiagnosticTagSupported) {
+		if (JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			return;
+		}
 		if (cu != null) {
 			IResource resource;
 			IMarker[] markers;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -924,9 +924,11 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	 */
 	@Override
 	public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params) {
-		logInfo(">> java/didChangeWorkspaceFolders");
-		WorkspaceFolderChangeHandler handler = new WorkspaceFolderChangeHandler(pm, preferenceManager);
-		handler.update(params);
+		if (!JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			logInfo(">> java/didChangeWorkspaceFolders");
+			WorkspaceFolderChangeHandler handler = new WorkspaceFolderChangeHandler(pm, preferenceManager);
+			handler.update(params);
+		}
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -118,6 +118,10 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 	 */
 	@Override
 	public boolean visit(IResourceDelta delta) throws CoreException {
+		if (JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			// diagnostics are handled lower level and made visible in the workspace already
+			return false;
+		}
 		IResource resource = delta.getResource();
 		if (resource == null) {
 			return false;
@@ -192,6 +196,9 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 	}
 
 	private void publishMarkers(IProject project, IMarker[] markers) throws CoreException {
+		if (JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			return;
+		}
 		Range range = new Range(new Position(0, 0), new Position(0, 0));
 
 		List<IMarker> projectMarkers = new ArrayList<>(markers.length);
@@ -289,6 +296,9 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 	}
 
 	private void publishDiagnostics(List<IMarker> markers) {
+		if (JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			return;
+		}
 		Map<IResource, List<IMarker>> map = markers.stream().collect(Collectors.groupingBy(IMarker::getResource));
 		for (Map.Entry<IResource, List<IMarker>> entry : map.entrySet()) {
 			IResource resource = entry.getKey();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -101,20 +101,22 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 
 	@Override
 	public void initializeProjects(final Collection<IPath> rootPaths, IProgressMonitor monitor) throws CoreException, OperationCanceledException {
-		SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
-		cleanInvalidProjects(rootPaths, subMonitor.split(20));
-		createJavaProject(getDefaultProject(), subMonitor.split(10));
-		cleanupResources(getDefaultProject());
-		Collection<IPath> projectConfigurations = preferenceManager.getPreferences().getProjectConfigurations();
-		if (projectConfigurations == null) {
-			// old way to import project
-			importProjects(rootPaths, subMonitor.split(70));
-		} else {
-			importProjectsFromConfigurationFiles(rootPaths, projectConfigurations, monitor);
+		if (!JavaLanguageServerPlugin.getInstance().isRunningInEclipseWorkbench()) {
+			SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
+			cleanInvalidProjects(rootPaths, subMonitor.split(20));
+			createJavaProject(getDefaultProject(), subMonitor.split(10));
+			cleanupResources(getDefaultProject());
+			Collection<IPath> projectConfigurations = preferenceManager.getPreferences().getProjectConfigurations();
+			if (projectConfigurations == null) {
+				// old way to import project
+				importProjects(rootPaths, subMonitor.split(70));
+			} else {
+				importProjectsFromConfigurationFiles(rootPaths, projectConfigurations, monitor);
+			}
+			updateEncoding(monitor);
+			reportProjectsStatus();
+			subMonitor.done();
 		}
-		updateEncoding(monitor);
-		reportProjectsStatus();
-		subMonitor.done();
 	}
 
 	private void updateEncoding(IProgressMonitor monitor) throws CoreException {


### PR DESCRIPTION
Add a flag to be set by client to declare it's Eclipse IDE. When true:
* didChange won't forward TextEdit to underlying resource model
* Eclipse Log forwarding from LS to Eclipse IDE is disabled
* Markers forwarding from LS to Eclipse IDE disabled