### PR TITLE
Update .project files from attempting project import with JDT-LS.

### DIFF
--- a/.project
+++ b/.project
@@ -16,12 +16,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217284</id>
+			<id>1675270185079</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "java",
+			"name": "Attach to JDT-LS (Standard)",
+			"request": "attach",
+			"hostName": "localhost",
+			"port": 1044,
+			"projectName": "org.eclipse.jdt.ls.core"
+		},
+		{
+			"type": "java",
+			"name": "Attach to JDT-LS (Syntax)",
+			"request": "attach",
+			"hostName": "localhost",
+			"port": 1045,
+			"projectName": "org.eclipse.jdt.ls.core"
+		}
+	]
+}

--- a/org.eclipse.jdt.ls.core/.project
+++ b/org.eclipse.jdt.ls.core/.project
@@ -33,12 +33,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217074</id>
+			<id>1675270185047</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/org.eclipse.jdt.ls.filesystem/.project
+++ b/org.eclipse.jdt.ls.filesystem/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1675270185050</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/org.eclipse.jdt.ls.filesystem/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ls.filesystem/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ls.filesystem/.settings/org.eclipse.m2e.core.prefs
+++ b/org.eclipse.jdt.ls.filesystem/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/org.eclipse.jdt.ls.logback.appender/.project
+++ b/org.eclipse.jdt.ls.logback.appender/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1675270185053</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/org.eclipse.jdt.ls.product/.project
+++ b/org.eclipse.jdt.ls.product/.project
@@ -16,12 +16,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217101</id>
+			<id>1675270185058</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/org.eclipse.jdt.ls.repository/.project
+++ b/org.eclipse.jdt.ls.repository/.project
@@ -16,12 +16,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217125</id>
+			<id>1675270185063</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/org.eclipse.jdt.ls.tests.syntaxserver/.project
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/.project
@@ -33,12 +33,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217152</id>
+			<id>1675270185074</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/org.eclipse.jdt.ls.tests/.project
+++ b/org.eclipse.jdt.ls.tests/.project
@@ -33,12 +33,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1617757217136</id>
+			<id>1675270185069</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>


### PR DESCRIPTION
- Add launch.json file for debugging a running JDT-LS instance

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

Noticed some local modifications occur when importing JDT-LS. Also wanted to add the launch.json I use to connect to a JDT-LS instance run in debug mode.