### PR TITLE
Only do full build for configuration change when auto build enabled

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -526,7 +526,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 			boolean autoBuildChanged = ProjectsManager.setAutoBuilding(isAutobuildEnabled);
 			if (jvmChanged || nullAnalysisOptionsUpdated && isAutobuildEnabled) {
 				buildWorkspace(Either.forLeft(true));
-			} else if (autoBuildChanged) {
+			} else if (autoBuildChanged && isAutobuildEnabled) {
 				buildWorkspace(Either.forLeft(false));
 			}
 		} catch (CoreException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -522,8 +522,9 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);
 		}
 		try {
-			boolean autoBuildChanged = ProjectsManager.setAutoBuilding(preferenceManager.getPreferences().isAutobuildEnabled());
-			if (jvmChanged || nullAnalysisOptionsUpdated) {
+			boolean isAutobuildEnabled = preferenceManager.getPreferences().isAutobuildEnabled();
+			boolean autoBuildChanged = ProjectsManager.setAutoBuilding(isAutobuildEnabled);
+			if (jvmChanged || nullAnalysisOptionsUpdated && isAutobuildEnabled) {
 				buildWorkspace(Either.forLeft(true));
 			} else if (autoBuildChanged) {
 				buildWorkspace(Either.forLeft(false));


### PR DESCRIPTION
When auto build is disabled, we should not do a full build for the change of the configurations since it might take a lot of time. This PR fixes that.
When auto build is enabled, we should do that to keep the state of the workspace update.

Signed-off-by: Shi Chen <chenshi@microsoft.com>