### PR TITLE
Fix the missing filter text for completion items

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -231,6 +232,11 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 					String decorators = rankingResult.getDecorators();
 					if (!decorators.isEmpty()) {
 						item.setLabel(decorators + " " + item.getLabel());
+						// when the item has decorators, set the filter text to avoid client takes the
+						// decorators into consideration when filtering.
+						if (StringUtils.isEmpty(item.getFilterText())) {
+							item.setFilterText(item.getInsertText());
+						}
 					}
 					Map<String, String> itemData = (Map<String, String>) item.getData();
 					Map<String, String> rankingData = rankingResult.getData();

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionRankingProviderTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionRankingProviderTest.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -85,6 +86,7 @@ public class CompletionRankingProviderTest extends AbstractCompilationUnitBasedT
 		CompletionItem recommended = list.getItems().get(0);
 		assertTrue(recommended.getLabel().startsWith("★"));
 		assertTrue(((Map)recommended.getData()).containsKey("foo"));
+		assertEquals(recommended.getFilterText(), recommended.getInsertText());
 		assertTrue(((Map)recommended.getData()).containsKey(CompletionRanking.COMPLETION_EXECUTION_TIME));
 	}
 


### PR DESCRIPTION
- when the item has decorators, set the filter text to avoid client takes the decorators into consideration when filtering.

fix https://github.com/redhat-developer/vscode-java/issues/2917

Signed-off-by: Sheng Chen <sheche@microsoft.com>