### PR TITLE
Make the debounce time of publish diagnostic job adaptive

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -118,8 +118,10 @@ public abstract class BaseDocumentLifeCycleHandler {
 				public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 					long startTime = System.nanoTime();
 					IStatus status = performValidation(monitor);
-					long elapsedTime = System.nanoTime() - startTime;
-					movingAverageForValidation.update(elapsedTime / 1_000_000);
+					if (status.getSeverity() != IStatus.CANCEL) {
+						long elapsedTime = System.nanoTime() - startTime;
+						movingAverageForValidation.update(elapsedTime / 1_000_000);
+					}
 					return status;
 				}
 
@@ -677,8 +679,10 @@ public abstract class BaseDocumentLifeCycleHandler {
 		public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 			long startTime = System.nanoTime();
 			IStatus status = publishDiagnostics(monitor);
-			long elapsedTime = System.nanoTime() - startTime;
-			movingAverageForDiagnostics.update(elapsedTime / 1_000_000);
+			if (status.getSeverity() != IStatus.CANCEL) {
+				long elapsedTime = System.nanoTime() - startTime;
+				movingAverageForDiagnostics.update(elapsedTime / 1_000_000);
+			}
 			return status;
 		}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -92,12 +92,23 @@ public abstract class BaseDocumentLifeCycleHandler {
 	 */
 	private static final long DOCUMENT_LIFECYCLE_MAX_DEBOUNCE = 400; /*ms*/
 
+	/**
+	 * The min & init value of adaptive debounce time for publish diagnostic job.
+	 */
+	private static final long PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE = 400; /*ms*/
+
+	/**
+	 * The max value of adaptive debounce time for publish diagnostic job.
+	 */
+	private static final long PUBLISH_DIAGNOSTICS_MAX_DEBOUNCE = 2000; /*ms*/
+
 	private CoreASTProvider sharedASTProvider;
 	private WorkspaceJob validationTimer;
 	private WorkspaceJob publishDiagnosticsJob;
 	private Set<ICompilationUnit> toReconcile = new HashSet<>();
 	private Map<String, Integer> documentVersions = new HashMap<>();
-	private MovingAverage movingAverage = new MovingAverage(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE);
+	private MovingAverage movingAverageForValidation = new MovingAverage(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE);
+	private MovingAverage movingAverageForDiagnostics = new MovingAverage(PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE);
 
 	public BaseDocumentLifeCycleHandler(boolean delayValidation) {
 		this.sharedASTProvider = CoreASTProvider.getInstance();
@@ -105,9 +116,10 @@ public abstract class BaseDocumentLifeCycleHandler {
 			this.validationTimer = new WorkspaceJob("Validate documents") {
 				@Override
 				public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
-					long start = System.currentTimeMillis();
+					long startTime = System.nanoTime();
 					IStatus status = performValidation(monitor);
-					movingAverage.update(System.currentTimeMillis() - start);
+					long elapsedTime = System.nanoTime() - startTime;
+					movingAverageForValidation.update(elapsedTime / 1_000_000);
 					return status;
 				}
 
@@ -156,7 +168,18 @@ public abstract class BaseDocumentLifeCycleHandler {
 	}
 
 	private long getDocumentLifecycleDelay() {
-		return Math.min(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE, Math.round(1.5 * movingAverage.value));
+		return Math.min(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE, Math.round(1.5 * movingAverageForValidation.value));
+	}
+
+	/**
+	 * @return the delay time of the publish diagnostics job. The value ranges in
+	 * ({@link #PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE}, {@link #PUBLISH_DIAGNOSTICS_MAX_DEBOUNCE}) ms.
+	 */
+	private long getPublishDiagnosticsDelay() {
+		return Math.min(
+			Math.max(PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE, Math.round(1.5 * movingAverageForDiagnostics.value)), 
+			PUBLISH_DIAGNOSTICS_MAX_DEBOUNCE
+		);
 	}
 
 	private ISchedulingRule getRule(Set<ICompilationUnit> units) {
@@ -209,7 +232,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 			if (monitor.isCanceled()) {
 				return Status.CANCEL_STATUS;
 			}
-			publishDiagnosticsJob.schedule(400);
+			publishDiagnosticsJob.schedule(getPublishDiagnosticsDelay());
 		} else {
 			return publishDiagnostics(new NullProgressMonitor());
 		}
@@ -652,7 +675,11 @@ public abstract class BaseDocumentLifeCycleHandler {
 
 		@Override
 		public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
-			return publishDiagnostics(monitor);
+			long startTime = System.nanoTime();
+			IStatus status = publishDiagnostics(monitor);
+			long elapsedTime = System.nanoTime() - startTime;
+			movingAverageForDiagnostics.update(elapsedTime / 1_000_000);
+			return status;
 		}
 
 		/* (non-Javadoc)


### PR DESCRIPTION
Now the debounce time of publish diagnostic jobs are adaptive. Ranging from [400, 2000] ms.

Signed-off-by: Sheng Chen <sheche@microsoft.com>

### How to test the impact of this change:

1. Add lombok dependency to petclinic project.
2. Toggle on the setting `java.trace.server` to `messages`, which will let the client print all the response time in the output channel.
3. Use this [attached file](https://github.com/eclipse/eclipse.jdt.ls/files/10694403/PetControllerTests.java.txt) to replace `PetControllerTests`.
4. Launch the language server.
   > Remember to add the lombok agent to the launch file when debugging.
5. After the projects are imported and no more output can be observed in the output channel, clear the output channel.
   > The project import traces are not related with this change, so we filter them out.
6. In the last method `void testProcessUpdateFormHasErrors26()`, do some modification to trigger different kinds of LSP requests. When I test it locally, I typed `System.out.println();` and then use `Backspace` to remove the typed characters one by one.
7. Wait until no more output can be observed, then we can analysis the average time cost to process each of the request. For example, copy the output to a file and scan it line by line. Regular Expression like `/\[Trace.*\] Received response \'.*\' in (\d+)ms/` can help us pick the time out.

### Test Result

By doing the above experiment according to the above steps with and without PR, the average time cost to process a request list below:

| | Time(ms) |
|---|---|
| Without the change | 633 |
| With the change | 325 |

> My machine is a Windows 10 with i7-10700 2.9GHz CPU.

----

Looks like the change works well from the customer's feedback: https://github.com/redhat-developer/vscode-java/issues/1765#issuecomment-1424727129

