### PR TITLE
publish diagnostics when auto-build is disabled

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -216,7 +216,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 		return Status.OK_STATUS;
 	}
 
-	private IStatus publishDiagnostics(IProgressMonitor monitor) throws JavaModelException {
+	public IStatus publishDiagnostics(IProgressMonitor monitor) throws JavaModelException {
 		long start = System.currentTimeMillis();
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -31,6 +31,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
@@ -528,6 +529,8 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 				buildWorkspace(Either.forLeft(true));
 			} else if (autoBuildChanged && isAutobuildEnabled) {
 				buildWorkspace(Either.forLeft(false));
+			} else if (nullAnalysisOptionsUpdated && !isAutobuildEnabled) {
+				documentLifeCycleHandler.publishDiagnostics(new NullProgressMonitor());
 			}
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException(e.getMessage(), e);


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

This PR is a follow-up for https://github.com/eclipse/eclipse.jdt.ls/pull/2437. When auto-build is disabled and some configurations changed, which need re-validate and publish diagnostics (e.g., null analysis configuration changed), we can do the publish job for open editors (via BaseDocumentLifeCycleHandler.publishDiagnostics) without triggering a rebuild.

https://user-images.githubusercontent.com/45906942/217752513-969d49a7-51b5-4b63-9e19-d3d1b1896c42.mp4

