### PR TITLE
Enable formatting support in syntax server

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BaseJDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/BaseJDTLanguageServer.java
@@ -75,6 +75,14 @@ public class BaseJDTLanguageServer {
 		}
 	}
 
+	protected void toggleCapability(boolean enabled, String id, String capability, Object options) {
+		if (enabled) {
+			registerCapability(id, capability, options);
+		} else {
+			unregisterCapability(id, capability);
+		}
+	}
+
 	protected <R> CompletableFuture<R> computeAsync(Function<IProgressMonitor, R> code) {
 		return CompletableFutures.computeAsync(cc -> code.apply(toMonitor(cc)));
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/FormatterHandler.java
@@ -70,11 +70,11 @@ public class FormatterHandler {
 		this.preferenceManager = preferenceManager;
 	}
 
-	List<? extends org.eclipse.lsp4j.TextEdit> formatting(DocumentFormattingParams params, IProgressMonitor monitor) {
+	public List<? extends org.eclipse.lsp4j.TextEdit> formatting(DocumentFormattingParams params, IProgressMonitor monitor) {
 		return format(params.getTextDocument().getUri(), params.getOptions(), (Range) null, monitor);
 	}
 
-	List<? extends org.eclipse.lsp4j.TextEdit> rangeFormatting(DocumentRangeFormattingParams params, IProgressMonitor monitor) {
+	public List<? extends org.eclipse.lsp4j.TextEdit> rangeFormatting(DocumentRangeFormattingParams params, IProgressMonitor monitor) {
 		return format(params.getTextDocument().getUri(), params.getOptions(), params.getRange(), monitor);
 	}
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -536,15 +536,6 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	}
 
 
-
-	private void toggleCapability(boolean enabled, String id, String capability, Object options) {
-		if (enabled) {
-			registerCapability(id, capability, options);
-		} else {
-			unregisterCapability(id, capability);
-		}
-	}
-
 	/* (non-Javadoc)
 	 * @see org.eclipse.lsp4j.services.WorkspaceService#didChangeWatchedFiles(org.eclipse.lsp4j.DidChangeWatchedFilesParams)
 	 */

--- a/org.eclipse.jdt.ls.filesystem/.classpath
+++ b/org.eclipse.jdt.ls.filesystem/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.eclipse.jdt.ls.tests.syntaxserver/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: org.eclipse.jdt.ls.core,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.jdt.launching,
  org.eclipse.ltk.core.refactoring,
- org.mockito.mockito-core;bundle-version="4.3.1"
+ org.mockito.mockito-core;bundle-version="4.3.1",
+ org.eclipse.jdt.ls.tests
 Bundle-Vendor: %Bundle-Vendor
 Bundle-Activator: org.eclipse.jdt.ls.core.internal.JavaSyntaxServerTestPlugin

--- a/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.jdt.ls.tests;singleton:=true
 Bundle-Version: 1.20.0.qualifier
+Export-Package: org.eclipse.jdt.ls.core.internal;x-friends:="org.eclipse.jdt.ls.tests.syntaxserver"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-Localization: plugin


### PR DESCRIPTION
Formatting support shouldn't impact the performance of the syntax server, so it should be safe to enable.
Clients can still disable it with the java.format.enabled=false preference.

Feature was requested in https://github.com/redhat-developer/vscode-java/issues/2926

Signed-off-by: Fred Bricon <fbricon@gmail.com>
