### PR TITLE
 Skip generated methods when calculating the document symbols

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentSymbolHandler.java
@@ -44,6 +44,7 @@ import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.SourceMethod;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
@@ -115,7 +116,9 @@ public class DocumentSymbolHandler {
 			if (type != IJavaElement.TYPE && type != IJavaElement.FIELD && type != IJavaElement.METHOD) {
 				continue;
 			}
-
+			if (element instanceof SourceMethod method && JDTUtils.isGenerated(method)) {
+				continue;
+			}
 			Location location = JDTUtils.toLocation(element);
 			if (location != null) {
 				SymbolInformation si = new SymbolInformation();
@@ -160,6 +163,9 @@ public class DocumentSymbolHandler {
 	private DocumentSymbol toDocumentSymbol(IJavaElement unit, IProgressMonitor monitor) {
 		int type = unit.getElementType();
 		if (type != TYPE && type != FIELD && type != METHOD && type != PACKAGE_DECLARATION && type != COMPILATION_UNIT) {
+			return null;
+		}
+		if (unit instanceof SourceMethod method && JDTUtils.isGenerated(method)) {
 			return null;
 		}
 		if (monitor.isCanceled()) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -141,7 +141,7 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 		testClass("org.apache.commons.lang3.stringutils", 6579, 20);
 	}
 
-	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.20/lombok-1.18.20.jar)
+	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.24/lombok-1.18.24.jar)
 	// https://github.com/redhat-developer/vscode-java/issues/2805
 	@Test
 	public void testLombok() throws Exception {


### PR DESCRIPTION
Fixes #2446 

We can skip generated methods when calculating the document symbols.

Signed-off-by: Snjezana Peco <snjezana.peco@redhat.com>