### PR TITLE
Only do context sensitive import rewrite when resolving completion items

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -95,22 +95,23 @@ public class CompletionProposalReplacementProvider {
 	/**
 	 * whether the provider is used during `completionItem/resolve` request.
 	 */
-	private boolean isResolving;
+	private boolean isResolvingRequest;
 
-	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset, Preferences preferences, ClientPreferences clientPrefs, boolean isResolving) {
+	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset,
+			Preferences preferences, ClientPreferences clientPrefs, boolean isResolvingRequest) {
 		super();
 		this.compilationUnit = compilationUnit;
 		this.context = context;
 		this.offset = offset;
 		this.preferences = preferences == null ? new Preferences() : preferences;
 		this.client = clientPrefs;
-		this.isResolving = isResolving;
+		this.isResolvingRequest = isResolvingRequest;
 	}
 
 	/**
 	 * Update the replacement.
 	 * 
-	 * When {@link #isResolving} is <code>true</code>, additionalTextEdits will also be resolved.
+	 * When {@link #isResolvingRequest} is <code>true</code>, additionalTextEdits will also be resolved.
 	 * @param proposal
 	 * @param item
 	 * @param trigger
@@ -199,7 +200,7 @@ public class CompletionProposalReplacementProvider {
 			item.setTextEdit(Either.forLeft(new org.eclipse.lsp4j.TextEdit(insertReplaceEdit.getInsert(), text)));
 		}
 
-		if (!isImportCompletion(proposal) && (!client.isResolveAdditionalTextEditsSupport() || isResolving)) {
+		if (!isImportCompletion(proposal) && (!client.isResolveAdditionalTextEditsSupport() || isResolvingRequest)) {
 			addImports(additionalTextEdits);
 			if(!additionalTextEdits.isEmpty()){
 				item.setAdditionalTextEdits(additionalTextEdits);
@@ -1030,7 +1031,7 @@ public class CompletionProposalReplacementProvider {
 			// This is because 'ContextSensitiveImportRewriteContext.findInContext()'' is a very
 			// heavy operation. If we do that when listing the completion items, the performance
 			// will downgrade a lot.
-			if (isResolving) {
+			if (isResolvingRequest) {
 				CompilationUnit cu = SharedASTProviderCore.getAST(compilationUnit, SharedASTProviderCore.WAIT_NO, new NullProgressMonitor());
 				if (cu != null) {
 					context = new ContextSensitiveImportRewriteContext(cu, this.offset, this.importRewrite);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -338,7 +338,14 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		this.context = context;
 		response.setContext(context);
 		this.descriptionProvider = new CompletionProposalDescriptionProvider(unit, context);
-		this.proposalProvider = new CompletionProposalReplacementProvider(unit, context, response.getOffset(), preferenceManager.getPreferences(), preferenceManager.getClientPreferences());
+		this.proposalProvider = new CompletionProposalReplacementProvider(
+			unit,
+			context,
+			response.getOffset(),
+			preferenceManager.getPreferences(),
+			preferenceManager.getClientPreferences(),
+			false
+		);
 	}
 
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -138,8 +138,15 @@ public class CompletionResolveHandler {
 		}
 
 		if (manager.getClientPreferences().isResolveAdditionalTextEditsSupport()) {
-			CompletionProposalReplacementProvider proposalProvider = new CompletionProposalReplacementProvider(unit, completionResponse.getContext(), completionResponse.getOffset(), manager.getPreferences(), manager.getClientPreferences());
-			proposalProvider.updateAdditionalTextEdits(completionResponse.getProposals().get(proposalId), param, '\0');
+			CompletionProposalReplacementProvider proposalProvider = new CompletionProposalReplacementProvider(
+				unit,
+				completionResponse.getContext(),
+				completionResponse.getOffset(),
+				manager.getPreferences(),
+				manager.getClientPreferences(),
+				true
+			);
+			proposalProvider.updateReplacement(completionResponse.getProposals().get(proposalId), param, '\0');
 		}
 		if (data.containsKey(DATA_FIELD_DECLARATION_SIGNATURE)) {
 			String typeName = stripSignatureToFQN(String.valueOf(data.get(DATA_FIELD_DECLARATION_SIGNATURE)));

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3504,7 +3504,10 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testCompletion_withConflictingTypeNames() throws Exception{
+	public void testCompletion_withConflictingTypeNames() throws Exception {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isResolveAdditionalTextEditsSupport()).thenReturn(true);
 		getWorkingCopy("src/java/List.java",
 			"package util;\n" +
 			"public class List {\n" +
@@ -3528,7 +3531,8 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<CompletionItem> items = list.getItems().stream().filter(p -> "java.util.List".equals(p.getDetail()))
 			.collect(Collectors.toList());
 		assertFalse("java.util.List not found",items.isEmpty());
-		assertEquals("java.util.List", items.get(0).getTextEdit().getLeft().getNewText());
+		CompletionItem resolved = server.resolveCompletionItem(list.getItems().get(0)).join();
+		assertEquals("java.util.List", resolved.getTextEdit().getLeft().getNewText());
 	}
 
 	@Test


### PR DESCRIPTION
This change fixes the performance downgrade introduced by https://github.com/eclipse/eclipse.jdt.ls/pull/2232.

### How to reproduce the performance downgrade?
1. Prepare a large java file, for example, the attached file in https://github.com/eclipse/eclipse.jdt.ls/pull/2443.
2. Manually trigger the completion via keyboard shortcut (`ctrl` + `space`) after `S`
   ![image](https://user-images.githubusercontent.com/6193897/217990740-dbc453c7-9e2c-45a4-8d1d-856095eff477.png)
3. A very long-time lag can be observed. While if the completion is triggered directly by typing `S`, the time is normal.

### Why same completion requests can result different performance?
The request is the same, but at the server side, state of `SharedASTProviderCore` is different.
- When the completion is triggered directly by typing `S`, the document is changed, `SharedASTProviderCore` is not ready to give a parsed AST tree.
- When it's triggered by `ctrl` + `space`, usually the `SharedASTProviderCore` is ready

This causes the argument passed to `importRewrite.addImport()` are different.

To verify this, we can set a breakpoint at 
https://github.com/eclipse/eclipse.jdt.ls/blob/438e6192cc327960f82d3086bc5f374a5cfaeca7/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java#L1039

Usually, if the `textDocument/completion` request is sent by typing `S`, the breakpoint won't be hit.

It raises another question: **if the `context` is `null` when the completion is triggered by typing events, why the fix still works**?

The answer is: The text edit will be **corrected** during `completionItem/resolve` request. When the resolving request comes, especially when the item is not the first one, `SharedASTProviderCore` has enough time to prepare the AST, so the context won't be `null`.

Same thing applies to triggering completion via `ctrl` + `space`. This `non-null` context causes much more calculation to get a more accurate completion. As a tradeoff, we lose the performance.

### About LSP violation
Unfortunately, updating text edit during `completionItem/resolve` request violates the LSP spec.

> All other properties (usually sortText, filterText, insertText and textEdit) must be provided in the [textDocument/completion](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion) response and must not be changed during resolve.

A direct idea is to append additional text edit during resolve request to avoid such violation. Unfortunately, this is still unacceptable:

> Additional text edits should be used to change text unrelated to the current cursor position (for example adding an import statement at the top of the file if the completion item will insert an unqualified type).

So far, I couldn't figure out a way to fix the perf downgrade as well as the spec violation. Current change fixes the perf issue but the spec violation is still there.

Considering that the case mentioned in https://github.com/eclipse/eclipse.jdt.ls/pull/2232 is a rare case, and usually the resolve response should be arrived before user commits a completion item. I think it's acceptable.

Signed-off-by: Sheng Chen <sheche@microsoft.com>