### PR TITLE
avoid add missing imports on paste within a file

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/PasteEventHandler.java
@@ -254,6 +254,9 @@ public class PasteEventHandler {
 		Range range = params.getLocation().getRange();
 		String originalDocumentUri = params.getCopiedDocumentUri();
 		String insertText = params.getText();
+		if (params.getLocation().getUri().equals(originalDocumentUri)) {
+			return new DocumentPasteEdit(insertText);
+		}
 		int offset = JsonRpcHelpers.toOffset(cu, range.getStart().getLine(), range.getStart().getCharacter());
 		int length = JsonRpcHelpers.toOffset(cu, range.getEnd().getLine(), range.getEnd().getCharacter()) - offset;
 		Function<ImportSelection[], ImportCandidate[]> chooseFunc = null;


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

fix #2441, since copy/paste within a file is a frequent action and we should not do add missing imports here to avoid unnecessary calculation.