### PR TITLE
Update target platform to latest 4.27-I-builds.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -28,7 +28,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20230212-1800"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/I20230215-0610"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>


### PR DESCRIPTION
In https://github.com/eclipse-jdt/eclipse.jdt.core/pull/679#issuecomment-1430282575 , we encountered test failures in dependent extensions (lsp4mp.jdt & quarkus.jdt). The failures implied some change to how local variable type signatures were being resolved.

While I didn't find any impact in JDT-LS, it would be good to pick up the fixes included in the more recent 4.27-I-builds (from jdt.core) to ensure we don't regress in some kind of local variable type signature logic.