### PR TITLE
Update types filter according to import declarations

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2023 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -200,7 +200,8 @@ public class CompletionProposalReplacementProvider {
 			item.setTextEdit(Either.forLeft(new org.eclipse.lsp4j.TextEdit(insertReplaceEdit.getInsert(), text)));
 		}
 
-		if (!isImportCompletion(proposal) && (!client.isResolveAdditionalTextEditsSupport() || isResolvingRequest)) {
+		if (!CompletionProposalUtils.isImportCompletion(proposal) && (!client.isResolveAdditionalTextEditsSupport() ||
+				isResolvingRequest)) {
 			addImports(additionalTextEdits);
 			if(!additionalTextEdits.isEmpty()){
 				item.setAdditionalTextEdits(additionalTextEdits);
@@ -959,7 +960,7 @@ public class CompletionProposalReplacementProvider {
 		String replacement = String.valueOf(proposal.getCompletion());
 
 		/* No import rewriting ever from within the import section. */
-		if (isImportCompletion(proposal)) {
+		if (CompletionProposalUtils.isImportCompletion(proposal)) {
 			return replacement;
 		}
 
@@ -1055,21 +1056,6 @@ public class CompletionProposalReplacementProvider {
 
 		/* Default: use the fully qualified type name. */
 		return qualifiedTypeName;
-	}
-
-	private boolean isImportCompletion(CompletionProposal proposal) {
-		char[] completion = proposal.getCompletion();
-		if (completion.length == 0) {
-			return false;
-		}
-
-		char last = completion[completion.length - 1];
-		/*
-		 * Proposals end in a semicolon when completing types in normal imports
-		 * or when completing static members, in a period when completing types
-		 * in static imports.
-		 */
-		return last == SEMICOLON || last == '.';
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2022 Red Hat Inc. and others.
+ * Copyright (c) 2016-2023 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,9 +13,9 @@
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,7 +32,6 @@ import org.eclipse.jdt.core.CompletionRequestor;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IImportDeclaration;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
@@ -69,22 +68,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	private boolean isComplete = true;
 	private PreferenceManager preferenceManager;
 	private CompletionProposalReplacementProvider proposalProvider;
-	/**
-	 * stores all the imported types from static imports and single type import declarations.
-	 * For example:
-	 * <ul>
-	 *   <li>import java.awt.List; -> java.awt.List</li>
-	 *   <li>import static java.awt.List.*; -> java.awt.List</li>
-	 *   <li>import static java.awt.List.ERROR; -> java.awt.List</li>
-	 * </ul>
-	 */
-	private Set<String> importedTypes = new HashSet<>();
-	/**
-	 * stores all the imported package or type names from an on demand import declaration.
-	 * For example:
-	 *   import java.awt.*; -> java.awt
-	 */
-	private Set<String> onDemandImportedPackagesOrTypes = new HashSet<>();
 
 	static class ProposalComparator implements Comparator<CompletionProposal> {
 
@@ -168,16 +151,10 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		fIsTestCodeExcluded = !isTestSource(unit.getJavaProject(), unit);
 		setRequireExtendedContext(true);
 		try {
-			for (IImportDeclaration importDeclaration : this.unit.getImports()) {
-				String elementName = importDeclaration.getElementName();
-				if (isStaticImport(importDeclaration)) {
-					importedTypes.add(elementName.substring(0, elementName.lastIndexOf('.')));
-				} else if (importDeclaration.isOnDemand()) {
-					onDemandImportedPackagesOrTypes.add(elementName.substring(0, elementName.lastIndexOf('.')));
-				} else {
-					importedTypes.add(elementName);
-				}
-			}
+			List<String> importedElements = Arrays.stream(this.unit.getImports())
+					.map(t -> t.getElementName())
+					.toList();
+			TypeFilter.getDefault().removeFilterIfMatched(importedElements);
 		} catch (JavaModelException e) {
 			JavaLanguageServerPlugin.logException("Failed to get imports during completion", e);
 		}
@@ -518,7 +495,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 	protected boolean isTypeFiltered(CompletionProposal proposal) {
 		char[] declaringType = getDeclaringType(proposal);
-		return declaringType != null && !this.isImported(declaringType) && TypeFilter.isFiltered(declaringType);
+		return declaringType != null && TypeFilter.isFiltered(declaringType);
 	}
 
 	/**
@@ -571,7 +548,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 
 	@Override
 	public boolean isIgnored(char[] fullTypeName) {
-		return fullTypeName != null && !this.isImported(fullTypeName) && TypeFilter.isFiltered(fullTypeName);
+		return fullTypeName != null && TypeFilter.isFiltered(fullTypeName);
 	}
 
 	/**
@@ -600,34 +577,5 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		}
 
 		return true;
-	}
-
-	private boolean isStaticImport(IImportDeclaration importElement) {
-		try {
-			return Flags.isStatic(importElement.getFlags());
-		} catch (JavaModelException e) {
-			JavaLanguageServerPlugin.log(e);
-		}
-		return false;
-	}
-
-	/**
-	 * Check if the type appears in the import declarations.
-	 */
-	private boolean isImported(char[] fullyQualifiedName) {
-		String typeName = new String(fullyQualifiedName);
-		if (this.importedTypes.contains(typeName)) {
-			return true;
-		}
-
-		int lastDotIdx = typeName.lastIndexOf('.');
-		if (lastDotIdx >= 0) {
-			String typeParent = typeName.substring(0, lastDotIdx);
-			if (this.onDemandImportedPackagesOrTypes.contains(typeParent)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -479,7 +479,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			case CompletionProposal.CONSTRUCTOR_INVOCATION:
 			case CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION:
 			case CompletionProposal.JAVADOC_TYPE_REF:
-			case CompletionProposal.PACKAGE_REF:
 			case CompletionProposal.TYPE_REF:
 				return isTypeFiltered(proposal);
 			case CompletionProposal.METHOD_REF:
@@ -494,6 +493,10 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 	}
 
 	protected boolean isTypeFiltered(CompletionProposal proposal) {
+		// always includes type completions for import declarations.
+		if (CompletionProposalUtils.isImportCompletion(proposal)) {
+			return false;
+		}
 		char[] declaringType = getDeclaringType(proposal);
 		return declaringType != null && TypeFilter.isFiltered(declaringType);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
@@ -13,15 +13,26 @@
 
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
-import org.eclipse.jdt.internal.ui.util.StringMatcher;
+import org.eclipse.jdt.core.CompletionProposal;
 
-public class StringMatcherEx extends StringMatcher {
+public class CompletionProposalUtils {
 
-    public StringMatcherEx(String pattern, boolean ignoreCase, boolean ignoreWildCards) {
-        super(pattern, ignoreCase, ignoreWildCards);
-    }
+	private static final char SEMICOLON = ';';
 
-    public boolean endsWithWildcard() {
-        return fPattern.endsWith(".*") || fPattern.endsWith(".?");
-    }
+	private CompletionProposalUtils() {}
+
+	public static boolean isImportCompletion(CompletionProposal proposal) {
+		char[] completion = proposal.getCompletion();
+		if (completion.length == 0) {
+			return false;
+		}
+
+		char last = completion[completion.length - 1];
+		/*
+		 * Proposals end in a semicolon when completing types in normal imports
+		 * or when completing static members, in a period when completing types
+		 * in static imports.
+		 */
+		return last == SEMICOLON || last == '.';
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/StringMatcherEx.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/StringMatcherEx.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.contentassist;
+
+import org.eclipse.jdt.internal.ui.util.StringMatcher;
+
+public class StringMatcherEx extends StringMatcher {
+
+    public StringMatcherEx(String pattern, boolean ignoreCase, boolean ignoreWildCards) {
+        super(pattern, ignoreCase, ignoreWildCards);
+    }
+
+    public boolean endsWithWildcard() {
+        return fPattern.endsWith(".*") || fPattern.endsWith(".?");
+    }
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/TypeFilter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/TypeFilter.java
@@ -13,9 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.preferences.DefaultScope;
@@ -77,25 +76,23 @@ public class TypeFilter {
 		}
 	}
 
+	/**
+	 * Remove the type filter if any of the imported element matches.
+	 */
 	public synchronized void removeFilterIfMatched(Collection<String> importedElements) {
 		if (importedElements == null || importedElements.isEmpty()) {
 			return;
 		}
 
-		StringMatcher[] matchers= getStringMatchers();
-		Set<StringMatcher> newMatchers = new HashSet<>();
-		for (String importedElement : importedElements) {
-			for (int i= 0; i < matchers.length; i++) {
-				StringMatcher cur= matchers[i];
-				if (!cur.match(importedElement)) {
-					newMatchers.add(cur);
+		StringMatcher[] matchers = getStringMatchers();
+		this.fStringMatchers = Arrays.stream(matchers).filter(m -> {
+			for (String importedElement : importedElements) {
+				if (m.match(importedElement)) {
+					return false;
 				}
 			}
-		}
-		
-		if (this.fStringMatchers.length != newMatchers.size()) {
-			this.fStringMatchers = newMatchers.toArray(StringMatcher[]::new);
-		}
+			return true;
+		}).toArray(size -> new StringMatcher[size]);
 	}
 
 	private StringMatcher[] fStringMatchers;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/TypeFilter.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/TypeFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000-2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
 import org.eclipse.jdt.core.search.TypeNameMatch;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.ui.util.StringMatcher;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 /**
@@ -81,14 +82,11 @@ public class TypeFilter {
 			return;
 		}
 
-		StringMatcherEx[] matchers= getStringMatchers();
-		Set<StringMatcherEx> newMatchers = new HashSet<>();
+		StringMatcher[] matchers= getStringMatchers();
+		Set<StringMatcher> newMatchers = new HashSet<>();
 		for (String importedElement : importedElements) {
 			for (int i= 0; i < matchers.length; i++) {
-				StringMatcherEx cur= matchers[i];
-				if (cur.endsWithWildcard()) {
-					importedElement += ".";
-				}
+				StringMatcher cur= matchers[i];
 				if (!cur.match(importedElement)) {
 					newMatchers.add(cur);
 				}
@@ -96,27 +94,27 @@ public class TypeFilter {
 		}
 		
 		if (this.fStringMatchers.length != newMatchers.size()) {
-			this.fStringMatchers = newMatchers.toArray(StringMatcherEx[]::new);
+			this.fStringMatchers = newMatchers.toArray(StringMatcher[]::new);
 		}
 	}
 
-	private StringMatcherEx[] fStringMatchers;
+	private StringMatcher[] fStringMatchers;
 
 	public TypeFilter() {
 		fStringMatchers= null;
 	}
 
-	private synchronized StringMatcherEx[] getStringMatchers() {
+	private synchronized StringMatcher[] getStringMatchers() {
 		if (fStringMatchers == null) {
 			String str = getPreference(TYPEFILTER_ENABLED);
 			StringTokenizer tok= new StringTokenizer(str, ";"); //$NON-NLS-1$
 			int nTokens= tok.countTokens();
 
-			fStringMatchers= new StringMatcherEx[nTokens];
+			fStringMatchers= new StringMatcher[nTokens];
 			for (int i= 0; i < nTokens; i++) {
 				String curr= tok.nextToken();
 				if (curr.length() > 0) {
-					fStringMatchers[i]= new StringMatcherEx(curr, false, false);
+					fStringMatchers[i]= new StringMatcher(curr, false, false);
 				}
 			}
 		}
@@ -132,9 +130,9 @@ public class TypeFilter {
 	 * @return <code>true</code> iff the given type is filtered out
 	 */
 	public boolean filter(String fullTypeName) {
-		StringMatcherEx[] matchers= getStringMatchers();
+		StringMatcher[] matchers= getStringMatchers();
 		for (int i= 0; i < matchers.length; i++) {
-			StringMatcherEx curr= matchers[i];
+			StringMatcher curr= matchers[i];
 			if (curr.match(fullTypeName)) {
 				return true;
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SimilarElementsRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/SimilarElementsRequestor.java
@@ -14,7 +14,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.corrections;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.CompletionProposal;
@@ -180,6 +182,10 @@ public class SimilarElementsRequestor extends CompletionRequestor {
 
 	private SimilarElement[] process(ICompilationUnit cu, int pos) throws JavaModelException {
 		try {
+			List<String> importedElements = Arrays.stream(cu.getImports())
+						.map(t -> t.getElementName())
+						.toList();
+			TypeFilter.getDefault().removeFilterIfMatched(importedElements);
 			cu.codeComplete(pos, this);
 			processKeywords();
 			return fResult.toArray(new SimilarElement[fResult.size()]);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.Path;
@@ -1574,6 +1573,33 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 			.filter((action) -> action.getKind().equals((CodeActionKind.QuickFix)) && action.getTitle().equals(CorrectionMessages.UnresolvedElementsSubProcessor_add_allMissing_imports_description))
 			.collect(Collectors.toList());
 		assertEquals(1, addAllMissingImportsActions.size());
+	}
+
+	@Test
+	public void testIgnoreTypeFilter() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("public class E {\n");
+		buf.append("    void foo() {\n");
+		buf.append("        List v= new ArrayList();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		buf = new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.util.ArrayList;\n");
+		buf.append("import java.util.List;\n");
+		buf.append("public class E {\n");
+		buf.append("    void foo() {\n");
+		buf.append("        List v= new ArrayList();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		Expected e1 = new Expected("Import 'List' (java.util)", buf.toString());
+
+		assertCodeActions(cu, e1);
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/UnresolvedTypesQuickFixTest.java
@@ -1578,26 +1578,26 @@ public class UnresolvedTypesQuickFixTest extends AbstractQuickFixTest {
 	@Test
 	public void testIgnoreTypeFilter() throws Exception {
 		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
-		StringBuilder buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import java.util.ArrayList;\n");
-		buf.append("public class E {\n");
-		buf.append("    void foo() {\n");
-		buf.append("        List v= new ArrayList();\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu = pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String before = """
+package test1;
+import java.util.ArrayList;
+public class E {
+	void foo() {
+		List v= new ArrayList();
+	}
+}""";
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", before, false, null);
 
-		buf = new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import java.util.ArrayList;\n");
-		buf.append("import java.util.List;\n");
-		buf.append("public class E {\n");
-		buf.append("    void foo() {\n");
-		buf.append("        List v= new ArrayList();\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		Expected e1 = new Expected("Import 'List' (java.util)", buf.toString());
+		String after = """
+package test1;
+import java.util.ArrayList;
+import java.util.List;
+public class E {
+	void foo() {
+		List v= new ArrayList();
+	}
+}""";
+		Expected e1 = new Expected("Import 'List' (java.util)", after);
 
 		assertCodeActions(cu, e1);
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3166,7 +3166,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
-			+	"import java.util.List;"	
+			+	"import java.util.List;"
 			+	"public class Test {\n\n"
 			+	"	void test() {\n\n"
 			+	"		List\n"
@@ -3191,7 +3191,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
-			+	"import java.util.*;"	
+			+	"import java.util.*;"
 			+	"public class Test {\n\n"
 			+	"	void test() {\n\n"
 			+	"		List\n"
@@ -3216,7 +3216,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
-			+	"import static java.util.List.*;"	
+			+	"import static java.util.List.*;"
 			+	"public class Test {\n\n"
 			+	"	void test() {\n\n"
 			+	"		List\n"
@@ -3241,7 +3241,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
-			+	"import static java.util.List.DUMMY;"	
+			+	"import static java.util.List.DUMMY;"
 			+	"public class Test {\n\n"
 			+	"	void test() {\n\n"
 			+	"		List\n"
@@ -3256,6 +3256,27 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			CompletionList list = requestCompletions(unit, "		List");
 			assertNotNull(list);
 			assertTrue(list.getItems().stream().anyMatch(t -> "java.util.List".equals(t.getDetail())));
+		} finally {
+			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
+		}
+	}
+
+	@Test
+	public void testCompletion_IgnoreTypeFilterWhenImported5() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
+		//@formatter:off
+				"package org.sample;\n"
+			+	"import java.util.List;"
+			+	"public class Test {\n\n"
+			+	"}\n");
+		//@formatter:on
+		try {
+			List<String> filteredTypes = new ArrayList<>();
+			filteredTypes.add("java.util.*");
+			PreferenceManager.getPrefs(null).setFilteredTypes(filteredTypes);
+
+			CompletionList list = requestCompletions(unit, "java.util.");
+			assertNotNull(list);
 		} finally {
 			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3263,13 +3263,11 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_IgnoreTypeFilterWhenImported5() throws JavaModelException {
-		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
-		//@formatter:off
-				"package org.sample;\n"
-			+	"import java.util.List;"
-			+	"public class Test {\n\n"
-			+	"}\n");
-		//@formatter:on
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", """
+				package org.sample;
+				import java.util.List;
+				public class Test {
+				}""");
 		try {
 			List<String> filteredTypes = new ArrayList<>();
 			filteredTypes.add("java.util.*");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3076,7 +3076,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			CompletionList list = requestCompletions(unit, "java.util");
 			assertNotNull(list);
 			List<String> packages = list.getItems().stream().map(i -> i.getLabel()).collect(Collectors.toList());
-			assertEquals("java.util.* packages were not filtered: " + packages.toString(), 1, packages.size());
+			assertTrue(packages.size() > 1);
 			assertEquals("java.util", packages.get(0));
 		} finally {
 			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
@@ -3266,6 +3266,25 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", """
 				package org.sample;
 				import java.util.List;
+				public class Test {
+				}""");
+		try {
+			List<String> filteredTypes = new ArrayList<>();
+			filteredTypes.add("java.util.*");
+			PreferenceManager.getPrefs(null).setFilteredTypes(filteredTypes);
+
+			CompletionList list = requestCompletions(unit, "java.util.");
+			assertNotNull(list);
+		} finally {
+			PreferenceManager.getPrefs(null).setFilteredTypes(Collections.emptyList());
+		}
+	}
+
+	@Test
+	public void testCompletion_IgnoreTypeFilterWhenImported6() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", """
+				package org.sample;
+				import java.util.
 				public class Test {
 				}""");
 		try {


### PR DESCRIPTION
The idea comes from https://github.com/eclipse/eclipse.jdt.ls/pull/2467#issuecomment-1430924232.

This change has several benefits:
  1. Quick fixes for unresolved types will also contain the types that are already imported.
  2. If the package/type is used in one compilation unit, it is a hint that the package/type is used in other compilation units as well.

fix https://github.com/redhat-developer/vscode-java/issues/2943