### PR TITLE
Check inlayHint refresh capability before sending refresh

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/InlayHintsPreferenceChangeListener.java
@@ -16,17 +16,23 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.util.Objects;
 
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.jdt.ls.core.internal.preferences.IPreferencesChangeListener;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 
 public class InlayHintsPreferenceChangeListener implements IPreferencesChangeListener {
 
     @Override
     public void preferencesChange(Preferences oldPreferences, Preferences newPreferences) {
+        PreferenceManager preferencesManager = JavaLanguageServerPlugin.getPreferencesManager();
+        ClientPreferences clientPreferences = preferencesManager.getClientPreferences();
+        if (!clientPreferences.isRefreshInlayHintsSupported()) {
+            return;
+        }
         if (!Objects.equals(oldPreferences.getInlayHintsParameterMode(), newPreferences.getInlayHintsParameterMode())) {
             JavaLanguageServerPlugin.getInstance().getClientConnection().refreshInlayHints();
         }
-
         if (!Objects.equals(oldPreferences.getInlayHintsExclusionList(), newPreferences.getInlayHintsExclusionList())) {
             InlayHintFilterManager.instance().reset();
             JavaLanguageServerPlugin.getInstance().getClientConnection().refreshInlayHints();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -24,6 +24,7 @@ import org.eclipse.lsp4j.DiagnosticsTagSupport;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.ResourceOperationKind;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
@@ -381,4 +382,11 @@ public class ClientPreferences {
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getInsertReplaceSupport().booleanValue();
 	}
 
+	public boolean isRefreshInlayHintsSupported() {
+		WorkspaceClientCapabilities workspace = capabilities.getWorkspace();
+		return v3supported
+			&& workspace.getInlayHint() != null
+			&& workspace.getInlayHint().getRefreshSupport() != null
+			&& workspace.getInlayHint().getRefreshSupport().booleanValue();
+	}
 }


### PR DESCRIPTION
Support for `workspace/inlayHint/refresh` is optional and clients could
log warnings or even show errors if the server calls the handler despite
the capability missing.
