### PR TITLE
Implement method hierarchy through existing type hierarchy logic.

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>type-hierarchy</groupId>
+	<artifactId>type-hierarchy</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Five.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Five.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Five extends Two {
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Four.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Four.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Four extends One {
+    @Override
+    public void foo() {
+        super.foo();
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/One.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/One.java
@@ -1,0 +1,7 @@
+package org.example;
+
+public class One extends Zero {
+    @Override
+    public void foo() {
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Six.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Six.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public class Six extends Two {
+    @Override
+    public void foo() {
+        super.foo();
+    }
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Three.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Three.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Three extends One {
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Two.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Two.java
@@ -1,0 +1,4 @@
+package org.example;
+
+public class Two extends Zero {
+}

--- a/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Zero.java
+++ b/org.eclipse.jdt.ls.tests/projects/maven/type-hierarchy/src/main/java/org/example/Zero.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public class Zero {
+    public void foo() {
+    }
+}


### PR DESCRIPTION
- The method hierarchy for a given method of some type is a subset of the type hierarchy where methods not implemented are filtered out

![method-hierarchy](https://user-images.githubusercontent.com/1417342/224093367-ee44b7b7-e62d-46db-8cf5-4307ae269de1.gif)

- I should add some test cases for this