### PR TITLE
WorkspaceEventHandlerTest.testDeleteProjectFolder fails

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
@@ -153,7 +153,7 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertFalse(module2.exists());
 
 		List<PublishDiagnosticsParams> diags = getClientRequests("publishDiagnostics");
-		assertEquals(9L, diags.size());
+		assertEquals(7, diags.size());
 		assertEndsWith(diags.get(0).getUri(), "/module2");
 		assertEndsWith(diags.get(1).getUri(), "/multimodule3");
 		assertEndsWith(diags.get(2).getUri(), "/multimodule3/pom.xml");
@@ -165,8 +165,6 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertEquals(0L, diags.get(5).getDiagnostics().size());
 		assertEndsWith(diags.get(6).getUri(), "/AppTest.java");
 		assertEquals(0L, diags.get(6).getDiagnostics().size());
-		assertEndsWith(diags.get(7).getUri(), "/multimodule3");
-		assertEndsWith(diags.get(8).getUri(), "/multimodule3/pom.xml");
 	}
 
 	private void assertEndsWith(String target, String suffix) {


### PR DESCRIPTION
Fixes #2506 