### PR TITLE
Reduce the target platform size by eliminating unnecessary bundles.

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -12,8 +12,11 @@
             <repository location="https://download.eclipse.org/buildship/updates/e423/snapshots/3.x/3.1.7.v20221108-1729-s/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-            <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
-            <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.jdt" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.apt.core" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.core" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.maven.runtime" version="0.0.0"/>
+            <unit id="org.eclipse.m2e.workspace.cli" version="0.0.0"/>
             <unit id="ch.qos.logback.classic" version="0.0.0"/>
 	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
         </location>
@@ -34,7 +37,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
            <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.20.0/"/>
-           <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+           <unit id="org.eclipse.lsp4j" version="0.0.0"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>


### PR DESCRIPTION
- Only include org.eclipse.lsp4j and not bundles in the lsp4j feature
- Only include required subset of the m2e.feature.group

The real motivation for this change is I suspect some bundles being included through the m2e feature group, are severely slowing down the test runtime in Eclipse. I don't think it affects Maven. It's only Eclipse that will run a test by default, by including all bundles within the target platform.

The target platform is installed to `~/${your-jdt-ls-workspace}/.metadata/.plugins/org.eclipse.pde.core/.bundle_pool/plugins/` . To test the difference I deleted the folder between changes.

**Before this change**
783 bundles - 342MB
2.5min to run CleanUpsTest

**With this change**
685 bundles - 314MB
25s to run CleanUpsTest