### PR TITLE
Cache and re-use type bindings for a completion invocation

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -97,6 +97,8 @@ public class CompletionProposalReplacementProvider {
 	 */
 	private boolean isResolvingRequest;
 
+	final Map<String, IBinding> bindings = new HashMap<>();
+
 	public CompletionProposalReplacementProvider(ICompilationUnit compilationUnit, CompletionContext context, int offset,
 			Preferences preferences, ClientPreferences clientPrefs, boolean isResolvingRequest) {
 		super();
@@ -937,13 +939,16 @@ public class CompletionProposalReplacementProvider {
 		for (int i= 0; i < keys.length; i++) {
 			keys[i]= String.valueOf(chKeys[0]);
 		}
+		// https://github.com/eclipse/eclipse.jdt.ls/pull/2535
+		if (bindings.size() > 0) {
+			return (ITypeBinding) bindings.get(keys[0]);
+		}
 
 		final ASTParser parser = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setProject(compilationUnit.getJavaProject());
 		parser.setResolveBindings(true);
 		parser.setStatementsRecovery(true);
 
-		final Map<String, IBinding> bindings= new HashMap<>();
 		ASTRequestor requestor= new ASTRequestor() {
 			@Override
 			public void acceptBinding(String bindingKey, IBinding binding) {


### PR DESCRIPTION
A related issue - https://github.com/redhat-developer/vscode-java/issues/2982

Steps to reproduce

```
$ git clone https://github.com/snjeza/jhipster-lite
$ cd jhipster-lite
$ code .
```
- enable lombok
- open AssertTest.java
- 
```
private void test() {
    D d = new D| // try CA here
  }

```

See https://github.com/redhat-developer/vscode-java/issues/2982#issuecomment-1493402938