### PR TITLE
Add chain completions support

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -220,6 +220,7 @@ public class ChainCompletionProposalComputer {
 		final CompletionItem ci = new CompletionItem();
 		ci.setLabel(label);
 		ci.setInsertText(insert);
+		ci.setTextEditText(insert);
 		ci.setKind(CompletionItemKind.Method);
 
 		ChainElement root = chain.getElements().get(0);
@@ -234,6 +235,13 @@ public class ChainCompletionProposalComputer {
 		for (ChainType chainType : expectedTypes) {
 			if (chainType.getType() == null) {
 				continue;
+			}
+
+			if ("java.util.List".equals(chainType.getType().getFullyQualifiedName()) || "java.util.Set".equals(chainType.getType().getFullyQualifiedName()) || "java.util.Map".equals(chainType.getType().getFullyQualifiedName())) {
+				IType type = project.findType("java.util.Collections");
+				if (type != null) {
+					results.add(new ChainElement(type, false));
+				}
 			}
 
 			if (JavaModelUtil.is1d8OrHigher(project)) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.contentassist;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.JavaManipulation;
+import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.internal.ui.text.Chain;
+import org.eclipse.jdt.internal.ui.text.ChainElement;
+import org.eclipse.jdt.internal.ui.text.ChainElementAnalyzer;
+import org.eclipse.jdt.internal.ui.text.ChainFinder;
+import org.eclipse.jdt.internal.ui.text.ChainType;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+
+public class ChainCompletionProposalComputer {
+
+	private List<ChainElement> entrypoints;
+
+	private String[] excludedTypes;
+
+	private ICompilationUnit cu;
+
+	private CompletionProposalRequestor coll;
+
+	public ChainCompletionProposalComputer(ICompilationUnit cu, CompletionProposalRequestor coll) {
+		this.cu = cu;
+		this.coll = coll;
+	}
+
+	public List<CompletionItem> computeCompletionProposals() {
+		if (!shouldPerformCompletionOnExpectedType()) {
+			return Collections.emptyList();
+		}
+		return executeCallChainSearch();
+	}
+
+	private List<CompletionItem> executeCallChainSearch() {
+		final int maxChains = Integer.parseInt(JavaManipulation.getPreference("recommenders.chain.max_chains", cu.getJavaProject()));
+		final int minDepth = Integer.parseInt(JavaManipulation.getPreference("recommenders.chain.min_chain_length", cu.getJavaProject()));
+		final int maxDepth = Integer.parseInt(JavaManipulation.getPreference("recommenders.chain.max_chain_length", cu.getJavaProject()));
+
+		excludedTypes = JavaManipulation.getPreference("recommenders.chain.ignore_types", cu.getJavaProject()).split("\\|"); //$NON-NLS-1$
+		for (int i = 0; i < excludedTypes.length; ++i) {
+			excludedTypes[i] = "L" + excludedTypes[i].replace('.', '/'); //$NON-NLS-1$
+		}
+
+		final IType invocationType = cu.findPrimaryType();
+
+		final List<ChainType> expectedTypes = ChainElementAnalyzer.resolveBindingsForExpectedTypes(cu.getJavaProject(), coll.getContext());
+		final ChainFinder finder = new ChainFinder(expectedTypes, Arrays.asList(excludedTypes), invocationType);
+		final ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<?> future = executor.submit(() -> {
+				if (findEntrypoints()) {
+					finder.startChainSearch(entrypoints, maxChains, minDepth, maxDepth);
+				}
+			});
+			long timeout = Long.parseLong(JavaManipulation.getPreference("recommenders.chain.timeout", cu.getJavaProject()));
+			future.get(timeout, TimeUnit.SECONDS);
+		} catch (final Exception e) {
+			finder.cancel();
+			executor.shutdownNow();
+		}
+
+		return buildCompletionProposals(finder.getChains());
+	}
+
+	private List<CompletionItem> buildCompletionProposals(final List<Chain> chains) {
+		final List<CompletionItem> proposals = new LinkedList<>();
+		for (final Chain chain : chains) {
+			proposals.add(create(chain));
+		}
+		return proposals;
+	}
+
+	private boolean findEntrypoints() {
+		entrypoints = new LinkedList<>();
+		for (CompletionProposal prop : coll.getProposals()) {
+			IJavaElement javaElement = resolveJavaElement(prop, cu.getJavaProject());
+			if (javaElement != null) {
+				IJavaElement e = javaElement;
+				if (matchesExpectedPrefix(e) && !ChainFinder.isFromExcludedType(Arrays.asList(excludedTypes), e)) {
+					ChainElement ce = new ChainElement(e, false);
+					if (ce.getElementType() != null) {
+						entrypoints.add(ce);
+					}
+				}
+			} else {
+				IJavaElement[] visibleElements = coll.getContext().getVisibleElements(null);
+				for (IJavaElement ve : visibleElements) {
+					if (ve.getElementName().equals(new String(prop.getCompletion())) && matchesExpectedPrefix(ve) && !ChainFinder.isFromExcludedType(Arrays.asList(excludedTypes), ve)) {
+						ChainElement ce = new ChainElement(ve, false);
+						if (ce.getElementType() != null) {
+							entrypoints.add(ce);
+						}
+					}
+				}
+			}
+		}
+
+		return !entrypoints.isEmpty();
+	}
+
+	private IJavaElement resolveJavaElement(CompletionProposal prop, IJavaProject proj) {
+		try {
+			if (prop.getKind() == CompletionProposal.FIELD_REF) {
+				return JDTUtils.resolveField(prop, proj);
+			} else if (prop.getKind() == CompletionProposal.METHOD_REF || prop.getKind() == CompletionProposal.ANNOTATION_ATTRIBUTE_REF) {
+				return JDTUtils.resolveMethod(prop, proj);
+			}
+		} catch (JavaModelException e) {
+			// continue
+		}
+		return null;
+	}
+
+	private boolean shouldPerformCompletionOnExpectedType() {
+		AST ast;
+		CompilationUnit cuNode = SharedASTProviderCore.getAST(cu, SharedASTProviderCore.WAIT_NO, null);
+		if (cuNode == null) {
+			ASTParser p = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+			p.setSource(cu);
+			p.setResolveBindings(true);
+			p.setCompilerOptions(RefactoringASTParser.getCompilerOptions(cu));
+			cuNode = (CompilationUnit) p.createAST(null);
+		}
+		ast = cuNode.getAST();
+		return ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext())) != null || ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+	}
+
+	private boolean matchesExpectedPrefix(final IJavaElement element) {
+		String prefix = String.valueOf(coll.getContext().getToken());
+		return String.valueOf(element.getElementName()).startsWith(prefix);
+	}
+
+	private static CompletionItem create(final Chain chain) {
+		final String title = ChainElement.createChainCode(chain, true, 0);
+		final String body = ChainElement.createChainCode(chain, false, chain.getExpectedDimensions());
+		final CompletionItem ci = new CompletionItem();
+		ci.setLabel(title);
+		ci.setInsertText(title);
+		ci.setKind(CompletionItemKind.Method);
+		return ci;
+	}
+
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
@@ -173,7 +174,27 @@ public class ChainCompletionProposalComputer {
 	private boolean shouldPerformCompletionOnExpectedType() {
 		CompilationUnit cuNode = getASTRoot();
 		AST ast = cuNode.getAST();
-		return ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext())) != null || ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+		ITypeBinding binding = ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext()));
+		return (binding != null && !isPrimitiveOrBoxedPrimitive(binding) && !"java.lang.String".equals(binding.getQualifiedName()) && !"java.lang.Object".equals(binding.getQualifiedName()))
+				|| ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+	}
+
+	private boolean isPrimitiveOrBoxedPrimitive(ITypeBinding binding) {
+		if (binding.isPrimitive()) {
+			return true;
+		}
+
+		return switch (binding.getQualifiedName()) {
+			case "java.lang.Boolean" -> true;
+			case "java.lang.Byte" -> true;
+			case "java.lang.Character" -> true;
+			case "java.lang.Short" -> true;
+			case "java.lang.Double" -> true;
+			case "java.lang.Float" -> true;
+			case "java.lang.Integer" -> true;
+			case "java.lang.Long" -> true;
+			default -> false;
+		};
 	}
 
 	private CompilationUnit getASTRoot() {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -210,8 +210,18 @@ public class ChainCompletionProposalComputer {
 		CompilationUnit cuNode = getASTRoot();
 		AST ast = cuNode.getAST();
 		ITypeBinding binding = ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext()));
-		return (binding != null && !isPrimitiveOrBoxedPrimitive(binding) && !"java.lang.String".equals(binding.getQualifiedName()) && !"java.lang.Object".equals(binding.getQualifiedName()))
-				|| ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+		IType type = ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext());
+		return hasValidExpectedTypeResolution(binding, type);
+	}
+
+	private boolean hasValidExpectedTypeResolution(ITypeBinding binding, IType type) {
+		if(binding != null) {
+			return !isPrimitiveOrBoxedPrimitive(binding) && !"java.lang.String".equals(binding.getQualifiedName()) && !"java.lang.Object".equals(binding.getQualifiedName());
+		} else if (type != null) {
+			return !"java.lang.String".equals(type.getFullyQualifiedName()) && !"java.lang.Object".equals(type.getFullyQualifiedName());
+		} else {
+			return false;
+		}
 	}
 
 	private boolean isPrimitiveOrBoxedPrimitive(ITypeBinding binding) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/ChainCompletionProposalComputer.java
@@ -12,36 +12,53 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.text.Chain;
 import org.eclipse.jdt.internal.ui.text.ChainElement;
+import org.eclipse.jdt.internal.ui.text.ChainElement.ElementType;
 import org.eclipse.jdt.internal.ui.text.ChainElementAnalyzer;
 import org.eclipse.jdt.internal.ui.text.ChainFinder;
 import org.eclipse.jdt.internal.ui.text.ChainType;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.TextEditConverter;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.TextEdit;
 
 public class ChainCompletionProposalComputer {
 
@@ -52,6 +69,8 @@ public class ChainCompletionProposalComputer {
 	private ICompilationUnit cu;
 
 	private CompletionProposalRequestor coll;
+
+	private Map<String, List<TextEdit>> additionalEdits = new HashMap<>();
 
 	public ChainCompletionProposalComputer(ICompilationUnit cu, CompletionProposalRequestor coll) {
 		this.cu = cu;
@@ -77,12 +96,12 @@ public class ChainCompletionProposalComputer {
 
 		final IType invocationType = cu.findPrimaryType();
 
-		final List<ChainType> expectedTypes = ChainElementAnalyzer.resolveBindingsForExpectedTypes(cu.getJavaProject(), coll.getContext());
+		final List<ChainType> expectedTypes = resolveBindingsForExpectedTypes(cu.getJavaProject(), coll.getContext());
 		final ChainFinder finder = new ChainFinder(expectedTypes, Arrays.asList(excludedTypes), invocationType);
 		final ExecutorService executor = Executors.newSingleThreadExecutor();
 		try {
 			Future<?> future = executor.submit(() -> {
-				if (findEntrypoints()) {
+				if (findEntrypoints(expectedTypes, cu.getJavaProject())) {
 					finder.startChainSearch(entrypoints, maxChains, minDepth, maxDepth);
 				}
 			});
@@ -98,13 +117,14 @@ public class ChainCompletionProposalComputer {
 
 	private List<CompletionItem> buildCompletionProposals(final List<Chain> chains) {
 		final List<CompletionItem> proposals = new LinkedList<>();
+
 		for (final Chain chain : chains) {
 			proposals.add(create(chain));
 		}
 		return proposals;
 	}
 
-	private boolean findEntrypoints() {
+	private boolean findEntrypoints(List<ChainType> expectedTypes, IJavaProject project) {
 		entrypoints = new LinkedList<>();
 		for (CompletionProposal prop : coll.getProposals()) {
 			IJavaElement javaElement = resolveJavaElement(prop, cu.getJavaProject());
@@ -119,7 +139,7 @@ public class ChainCompletionProposalComputer {
 			} else {
 				IJavaElement[] visibleElements = coll.getContext().getVisibleElements(null);
 				for (IJavaElement ve : visibleElements) {
-					if (ve.getElementName().equals(new String(prop.getCompletion())) && matchesExpectedPrefix(ve) && !ChainFinder.isFromExcludedType(Arrays.asList(excludedTypes), ve)) {
+					if (matchesExpectedPrefix(ve) && !ChainFinder.isFromExcludedType(Arrays.asList(excludedTypes), ve)) {
 						ChainElement ce = new ChainElement(ve, false);
 						if (ce.getElementType() != null) {
 							entrypoints.add(ce);
@@ -127,6 +147,11 @@ public class ChainCompletionProposalComputer {
 					}
 				}
 			}
+		}
+		try {
+			entrypoints.addAll(computeContextEntrypoints(expectedTypes, project));
+		} catch (JavaModelException e) {
+			// continue
 		}
 
 		return !entrypoints.isEmpty();
@@ -146,7 +171,12 @@ public class ChainCompletionProposalComputer {
 	}
 
 	private boolean shouldPerformCompletionOnExpectedType() {
-		AST ast;
+		CompilationUnit cuNode = getASTRoot();
+		AST ast = cuNode.getAST();
+		return ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext())) != null || ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+	}
+
+	private CompilationUnit getASTRoot() {
 		CompilationUnit cuNode = SharedASTProviderCore.getAST(cu, SharedASTProviderCore.WAIT_NO, null);
 		if (cuNode == null) {
 			ASTParser p = ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
@@ -155,8 +185,7 @@ public class ChainCompletionProposalComputer {
 			p.setCompilerOptions(RefactoringASTParser.getCompilerOptions(cu));
 			cuNode = (CompilationUnit) p.createAST(null);
 		}
-		ast = cuNode.getAST();
-		return ast.resolveWellKnownType(ChainElementAnalyzer.getExpectedFullyQualifiedTypeName(coll.getContext())) != null || ChainElementAnalyzer.getExpectedType(cu.getJavaProject(), coll.getContext()) != null;
+		return cuNode;
 	}
 
 	private boolean matchesExpectedPrefix(final IJavaElement element) {
@@ -164,14 +193,134 @@ public class ChainCompletionProposalComputer {
 		return String.valueOf(element.getElementName()).startsWith(prefix);
 	}
 
-	private static CompletionItem create(final Chain chain) {
-		final String title = ChainElement.createChainCode(chain, true, 0);
-		final String body = ChainElement.createChainCode(chain, false, chain.getExpectedDimensions());
+	private CompletionItem create(final Chain chain) {
+		final String label = ChainElement.createChainCode(chain, true, 0);
+		final String insert = ChainElement.createChainCode(chain, false, chain.getExpectedDimensions());
 		final CompletionItem ci = new CompletionItem();
-		ci.setLabel(title);
-		ci.setInsertText(title);
+		ci.setLabel(label);
+		ci.setInsertText(insert);
 		ci.setKind(CompletionItemKind.Method);
+
+		ChainElement root = chain.getElements().get(0);
+		if (root.getElementType() == ElementType.TYPE) {
+			ci.setAdditionalTextEdits(addImport(((IType) root.getElement()).getFullyQualifiedName()));
+		}
 		return ci;
+	}
+
+	private List<ChainElement> computeContextEntrypoints(List<ChainType> expectedTypes, IJavaProject project) throws JavaModelException {
+		final List<ChainElement> results = new ArrayList<>();
+		for (ChainType chainType : expectedTypes) {
+			if (chainType.getType() == null) {
+				continue;
+			}
+
+			if (JavaModelUtil.is1d8OrHigher(project)) {
+				if ("java.util.stream.Collector".equals(chainType.getType().getFullyQualifiedName())) {
+					IType type = project.findType("java.util.stream.Collectors");
+					if (type != null) {
+						results.add(new ChainElement(type, false));
+					}
+				}
+			}
+		}
+		return results;
+	}
+
+	private List<TextEdit> addImport(String type) {
+		if (additionalEdits.containsKey(type)) {
+			return additionalEdits.get(type);
+		}
+
+		try {
+			boolean qualified = type.indexOf('.') != -1;
+			if (!qualified) {
+				return Collections.emptyList();
+			}
+
+			CompilationUnit root = getASTRoot();
+			ImportRewrite importRewrite;
+			if (root == null) {
+				importRewrite = StubUtility.createImportRewrite(cu, true);
+			} else {
+				importRewrite = StubUtility.createImportRewrite(root, true);
+			}
+
+			ImportRewriteContext context;
+			if (root == null) {
+				context = null;
+			} else {
+				context = new ContextSensitiveImportRewriteContext(root, coll.getContext().getOffset(), importRewrite);
+			}
+
+			importRewrite.addImport(type, context);
+			List<TextEdit> edits = this.additionalEdits.getOrDefault(type, new ArrayList<>());
+			TextEditConverter converter = new TextEditConverter(cu, importRewrite.rewriteImports(new NullProgressMonitor()));
+			edits.addAll(converter.convert());
+			this.additionalEdits.put(type, edits);
+			return edits;
+		} catch (CoreException e) {
+			JavaLanguageServerPlugin.log(e);
+			return Collections.emptyList();
+		}
+	}
+
+	// The following needs to move to jdt ui core manipulation
+	public static List<ChainType> resolveBindingsForExpectedTypes(final IJavaProject proj, final CompletionContext ctx) {
+		final List<ChainType> types = new LinkedList<>();
+		final IType[] expectedTypeSigs = getExpectedType(proj, ctx);
+		if (expectedTypeSigs == null) {
+			final char[][] expectedTypes = ctx.getExpectedTypesSignatures();
+			for (int i = 0; i < expectedTypes.length; i++) {
+				String typeSig = new String(expectedTypes[i]);
+				int dim = getArrayDimension(expectedTypes[i]);
+				ChainType type = new ChainType(typeSig, dim);
+				types.add(type);
+			}
+		} else {
+			for (int i = 0; i < expectedTypeSigs.length; i++) {
+				ChainType type = new ChainType(expectedTypeSigs[i]);
+				types.add(type);
+			}
+		}
+		return types;
+	}
+
+	private static int getArrayDimension(final char[] expectedTypesSignatures) {
+		if (expectedTypesSignatures != null && expectedTypesSignatures.length > 0) {
+			return Signature.getArrayCount(new String(expectedTypesSignatures));
+		}
+
+		return 0;
+	}
+
+	public static IType[] getExpectedType(final IJavaProject proj, final CompletionContext ctx) {
+		IType[] expected = null;
+		String[] fqExpectedTypes = getExpectedFullyQualifiedTypeNames(ctx);
+		if (fqExpectedTypes != null && fqExpectedTypes.length > 0) {
+			expected = new IType[fqExpectedTypes.length];
+			for (int i = 0; i < fqExpectedTypes.length; i++) {
+				try {
+					expected[i] = proj.findType(fqExpectedTypes[i]);
+				} catch (JavaModelException e) {
+					// do nothing
+				}
+
+			}
+		}
+		return expected;
+	}
+
+	public static String[] getExpectedFullyQualifiedTypeNames(final CompletionContext ctx) {
+		String[] fqExpectedTypes = null;
+		final char[][] expectedTypes = ctx.getExpectedTypesSignatures();
+		if (expectedTypes != null && expectedTypes.length > 0) {
+			fqExpectedTypes = new String[expectedTypes.length];
+			for (int i = 0; i < expectedTypes.length; i++) {
+				fqExpectedTypes[i] = SignatureUtil.stripSignatureToFQN(new String(expectedTypes[i]));
+			}
+		}
+		return fqExpectedTypes;
 	}
 
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -282,7 +282,7 @@ public class CompletionHandler{
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
 					if (manager.getPreferences().isChainCompletionEnabled() && params.getContext().getTriggerKind() != CompletionTriggerKind.TriggerCharacter) {
-						ChainCompletionProposalComputer chain = new ChainCompletionProposalComputer(unit, collector);
+						ChainCompletionProposalComputer chain = new ChainCompletionProposalComputer(unit, collector, this.isSnippetStringSupported());
 						proposals.addAll(chain.computeCompletionProposals());
 					}
 				} catch (OperationCanceledException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.ls.core.internal.ExceptionFactory;
 import org.eclipse.jdt.ls.core.internal.JDTEnvironmentUtils;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.contentassist.ChainCompletionProposalComputer;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalRequestor;
 import org.eclipse.jdt.ls.core.internal.contentassist.JavadocCompletionProposal;
 import org.eclipse.jdt.ls.core.internal.contentassist.SnippetCompletionProposal;
@@ -279,6 +280,8 @@ public class CompletionHandler{
 						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector, subMonitor));
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
+					ChainCompletionProposalComputer chain = new ChainCompletionProposalComputer(unit, collector);
+					proposals.addAll(chain.computeCompletionProposals());
 				} catch (OperationCanceledException e) {
 					monitor.setCanceled(true);
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -56,6 +56,7 @@ import org.eclipse.lsp4j.CompletionItemOptions;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.CompletionTriggerKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -280,8 +281,10 @@ public class CompletionHandler{
 						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector, subMonitor));
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
-					ChainCompletionProposalComputer chain = new ChainCompletionProposalComputer(unit, collector);
-					proposals.addAll(chain.computeCompletionProposals());
+					if (manager.getPreferences().isChainCompletionEnabled() && params.getContext().getTriggerKind() != CompletionTriggerKind.TriggerCharacter) {
+						ChainCompletionProposalComputer chain = new ChainCompletionProposalComputer(unit, collector);
+						proposals.addAll(chain.computeCompletionProposals());
+					}
 				} catch (OperationCanceledException e) {
 					monitor.setCanceled(true);
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -101,6 +101,12 @@ public class PreferenceManager {
 		defEclipsePrefs.put(StubUtility.CODEGEN_EXCEPTION_VAR_NAME, "e"); //$NON-NLS-1$
 		defEclipsePrefs.put(StubUtility.CODEGEN_ADD_COMMENTS, Boolean.FALSE.toString());
 
+		defEclipsePrefs.put("recommenders.chain.min_chain_length", "2");
+		defEclipsePrefs.put("recommenders.chain.max_chain_length", "4");
+		defEclipsePrefs.put("recommenders.chain.max_chains", "20");
+		defEclipsePrefs.put("recommenders.chain.timeout", "1");
+		defEclipsePrefs.put("recommenders.chain.ignore_types", "java.lang.Object"); //$NON-NLS-1$
+
 		ContextTypeRegistry registry = new ContextTypeRegistry();
 		// Register standard context types from JDT
 		CodeTemplateContextType.registerContextTypes(registry);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/PreferenceManager.java
@@ -102,10 +102,10 @@ public class PreferenceManager {
 		defEclipsePrefs.put(StubUtility.CODEGEN_ADD_COMMENTS, Boolean.FALSE.toString());
 
 		defEclipsePrefs.put("recommenders.chain.min_chain_length", "2");
-		defEclipsePrefs.put("recommenders.chain.max_chain_length", "4");
+		defEclipsePrefs.put("recommenders.chain.max_chain_length", "3");
 		defEclipsePrefs.put("recommenders.chain.max_chains", "20");
 		defEclipsePrefs.put("recommenders.chain.timeout", "1");
-		defEclipsePrefs.put("recommenders.chain.ignore_types", "java.lang.Object"); //$NON-NLS-1$
+		defEclipsePrefs.put("recommenders.chain.ignore_types", ""); //$NON-NLS-1$
 
 		ContextTypeRegistry registry = new ContextTypeRegistry();
 		// Register standard context types from JDT

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -502,6 +502,11 @@ public class Preferences {
 
 	public static final String JAVA_REFACTORING_EXTRACT_INTERFACE_REPLACE = "java.refactoring.extract.interface.replace";
 
+	/**
+	 * Preference key to enable/disable chain completion.
+	 */
+	public static final String CHAIN_COMPLETION_KEY = "java.completion.chain.enabled";
+
 	public static final String TEXT_DOCUMENT_FORMATTING = "textDocument/formatting";
 	public static final String TEXT_DOCUMENT_RANGE_FORMATTING = "textDocument/rangeFormatting";
 	public static final String TEXT_DOCUMENT_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting";
@@ -656,6 +661,7 @@ public class Preferences {
 	private boolean extractInterfaceReplaceEnabled;
 	private boolean telemetryEnabled;
 	private boolean validateAllOpenBuffersOnChanges;
+	private boolean chainCompletionEnabled;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -1255,6 +1261,8 @@ public class Preferences {
 		prefs.setTelemetryEnabled(telemetryEnabled);
 		boolean validateAllOpenBuffers = getBoolean(configuration, JAVA_EDIT_VALIDATE_ALL_OPEN_BUFFERS_ON_CHANGES, true);
 		prefs.setValidateAllOpenBuffersOnChanges(validateAllOpenBuffers);
+		boolean chainCompletionEnabled = getBoolean(configuration, CHAIN_COMPLETION_KEY, false);
+		prefs.setChainCompletionEnabled(chainCompletionEnabled);
 		return prefs;
 	}
 
@@ -2211,6 +2219,14 @@ public class Preferences {
 
 	public boolean getExtractInterfaceReplaceEnabled() {
 		return this.extractInterfaceReplaceEnabled;
+	}
+
+	public void setChainCompletionEnabled(boolean chainCompletionEnabled) {
+		this.chainCompletionEnabled = chainCompletionEnabled;
+	}
+
+	public boolean isChainCompletionEnabled() {
+		return this.chainCompletionEnabled;
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
@@ -115,6 +115,7 @@ public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest
 		assertEquals("Additional edits count", 1, completionItem.getAdditionalTextEdits().size());
 		assertNotNull(completionItem.getAdditionalTextEdits().get(0));
 		assertEquals("Import", "import java.util.stream.Collectors;\n", completionItem.getAdditionalTextEdits().get(0).getNewText());
+		assertEquals("Completion Label", "toList()", completionItem.getLabel());
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
@@ -180,4 +180,86 @@ public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest
 		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("emptyList() <T>")).collect(Collectors.toList());
 		assertEquals("emptyList completion count", 0, completionItems.size());
 	}
+
+	@Test
+	public void testChainCompletionsOnPrimitiveVariableExpectNoCompletions() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						public class Foo {
+						    public static boo(IntChain chain) {
+								Integer variable = ;
+						    }
+
+							static class IntChain {
+								public Integer newInt() {
+									return 1;
+								}
+							}
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "variable = ");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("newInt")).collect(Collectors.toList());
+		assertEquals("emptyList completion count", 0, completionItems.size());
+	}
+
+	@Test
+	public void testChainCompletionsOnStringVariableExpectNoCompletions() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						public class Foo {
+						    public static boo(StringChain chain) {
+								String variable = //
+								"variable".concat("");
+						    }
+
+							static class StringChain {
+								public String newString() {
+									return "";
+								}
+							}
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "variable = ");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("newString")).collect(Collectors.toList());
+		assertEquals("emptyList completion count [binding]", 0, completionItems.size());
+
+		list = requestCompletions(unit, "\"variable\".concat(");
+		completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("newString")).collect(Collectors.toList());
+		assertEquals("emptyList completion count [type]", 0, completionItems.size());
+	}
+
+	@Test
+	public void testChainCompletionsOnObjectVariableExpectNoCompletions() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						public class Foo {
+						    public static boo(ObjectChain chain) {
+								Object variable = //
+								chain.equals(variable);
+						    }
+
+							static class ObjectChain {
+								public Object newObject() {
+									return new Object();
+								}
+							}
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "variable = ");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("newObject")).collect(Collectors.toList());
+		assertEquals("emptyList completion count", 0, completionItems.size());
+
+		list = requestCompletions(unit, "chain.equals(");
+		completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("newObject")).collect(Collectors.toList());
+		assertEquals("emptyList completion count [type]", 0, completionItems.size());
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
@@ -102,13 +102,15 @@ public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest
 						""");
 		//@formatter:on
 		CompletionList list = requestCompletions(unit, "collect(");
-		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("toList() <T>")).collect(Collectors.toList());
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("toList")).collect(Collectors.toList());
 		assertEquals("toList completion count", 1, completionItems.size());
 
 		CompletionItem completionItem = completionItems.get(0);
 		assertNotNull(completionItem);
 		assertEquals("Completion getTextEditText", "Collectors.toList()", completionItem.getTextEditText());
-
+		assertNotNull(completionItem.getLabelDetails());
+		assertEquals("Completion detail.description", "java.util.stream.Collector<T,?,java.util.List<T>>", completionItem.getLabelDetails().getDescription());
+		assertEquals("Completion detail.detail", " - Collectors.toList()", completionItem.getLabelDetails().getDetail());
 		assertNotNull(completionItem.getAdditionalTextEdits());
 		assertEquals("Additional edits count", 1, completionItem.getAdditionalTextEdits().size());
 		assertNotNull(completionItem.getAdditionalTextEdits().get(0));
@@ -130,7 +132,7 @@ public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest
 						""");
 		//@formatter:on
 		CompletionList list = requestCompletions(unit, "names =");
-		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("emptyList() <T>")).collect(Collectors.toList());
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().contains("emptyList")).collect(Collectors.toList());
 		assertEquals("emptyList completion count", 1, completionItems.size());
 
 		CompletionItem completionItem = completionItems.get(0);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerChainTest.java
@@ -1,0 +1,183 @@
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompletionHandlerChainTest extends AbstractCompilationUnitBasedTest {
+	private DocumentLifeCycleHandler lifeCycleHandler;
+	private JavaClientConnection javaClient;
+
+	private static String COMPLETION_TEMPLATE = """
+			{
+			    "id": "1",
+			    "method": "textDocument/completion",
+			    "params": {
+			        "textDocument": {
+			            "uri": "${file}"
+			        },
+			        "position": {
+			            "line": ${line},
+			            "character": ${char}
+			        },
+					"context": {
+						"triggerKind": 1
+					}
+			    },
+			    "jsonrpc": "2.0"
+			}""";
+
+	@Before
+	public void setUp() {
+		mockLSP3Client();
+		CoreASTProvider sharedASTProvider = CoreASTProvider.getInstance();
+		sharedASTProvider.disposeAST();
+		javaClient = new JavaClientConnection(client);
+		lifeCycleHandler = new DocumentLifeCycleHandler(javaClient, preferenceManager, projectsManager, true);
+		preferences.setPostfixCompletionEnabled(false);
+		preferences.setChainCompletionEnabled(true);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		javaClient.disconnect();
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
+		return requestCompletions(unit, completeBehind, 0);
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
+		int[] loc = findCompletionLocation(unit, completeBehind, fromIndex);
+		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+	}
+
+	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {
+		return COMPLETION_TEMPLATE.replace("${file}", JDTUtils.toURI(unit)).replace("${line}", String.valueOf(line)).replace("${char}", String.valueOf(kar));
+	}
+
+	private void mockLSP3Client() {
+		mockLSPClient(true, true);
+	}
+
+	private void mockLSP2Client() {
+		mockLSPClient(false, false);
+	}
+
+	private void mockLSPClient(boolean isSnippetSupported, boolean isSignatureHelpSuported) {
+		// Mock the preference manager to use LSP v3 support.
+		when(preferenceManager.getClientPreferences().isCompletionSnippetsSupported()).thenReturn(isSnippetSupported);
+	}
+
+	@Test
+	public void testChainCompletionsOnParameter() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						import java.util.stream.Stream;
+						public class Foo {
+						    public static void main(String[] args) {
+								Stream.of("1").collect()
+						    }
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "collect(");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("toList() <T>")).collect(Collectors.toList());
+		assertEquals("toList completion count", 1, completionItems.size());
+
+		CompletionItem completionItem = completionItems.get(0);
+		assertNotNull(completionItem);
+		assertEquals("Completion getTextEditText", "Collectors.toList()", completionItem.getTextEditText());
+
+		assertNotNull(completionItem.getAdditionalTextEdits());
+		assertEquals("Additional edits count", 1, completionItem.getAdditionalTextEdits().size());
+		assertNotNull(completionItem.getAdditionalTextEdits().get(0));
+		assertEquals("Import", "import java.util.stream.Collectors;\n", completionItem.getAdditionalTextEdits().get(0).getNewText());
+	}
+
+	@Test
+	public void testChainCompletionsOnVariable() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						import java.util.List;
+						public class Foo {
+						    public static void main(String[] args) {
+								List<String> names =
+						    }
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "names =");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("emptyList() <T>")).collect(Collectors.toList());
+		assertEquals("emptyList completion count", 1, completionItems.size());
+
+		CompletionItem completionItem = completionItems.get(0);
+		assertNotNull(completionItem);
+		assertEquals("Completion getTextEditText", "Collections.emptyList()", completionItem.getTextEditText());
+
+		assertNotNull(completionItem.getAdditionalTextEdits());
+		assertEquals("Additional edits count", 1, completionItem.getAdditionalTextEdits().size());
+		assertNotNull(completionItem.getAdditionalTextEdits().get(0));
+		assertEquals("Import", "import java.util.Collections;\n", completionItem.getAdditionalTextEdits().get(0).getNewText());
+	}
+
+	@Test
+	public void testChainCompletionsOnVariableWithNewKeywordExpectNoChains() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						import java.util.List;
+						public class Foo {
+						    public static void main(String[] args) {
+								List<String> names = new
+						    }
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "names = new");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("emptyList() <T>")).collect(Collectors.toList());
+		assertEquals("emptyList completion count", 0, completionItems.size());
+	}
+
+	@Test
+	public void testChainCompletionsOnVariableCompletingConstructorExpectNoChains() throws Exception {
+		//@formatter:off
+			ICompilationUnit unit = getWorkingCopy(
+					"src/java/Foo.java",
+					"""
+						import java.util.List;
+						public class Foo {
+						    public static void main(String[] args) {
+								List<String> names = new Arr
+						    }
+						}
+						""");
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "names = new Arr");
+		List<CompletionItem> completionItems = list.getItems().stream().filter(i -> i.getLabel().endsWith("emptyList() <T>")).collect(Collectors.toList());
+		assertEquals("emptyList completion count", 0, completionItems.size());
+	}
+}


### PR DESCRIPTION
Bring chain completions support to JDT.LS which was started by @rgrunber. I clean it up a little bit and add 
- Support for overloaded methods where expected type signatures in the context is more than one.
- Some support suggesting chain completions using static methods in classes like `Collectors` as a POC. The idea is to improve the this to read from a simple model file where either Microsoft IntelliCore (cc: @jdneo @testforstephen) can provide or any other interested extension provider. We need to discuss the best way to provide this as a extension point for providing model information (cc: @rgrunber @mickaelistria @fbricon )


