### PR TITLE
Increase relevance of "create enum"

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/UnresolvedElementsSubProcessor.java
@@ -842,7 +842,7 @@ public class UnresolvedElementsSubProcessor {
 						proposals.add(new NewCUProposal(cu, node, NewCUProposal.K_INTERFACE, enclosing, rel + 2));
 					}
 					if ((kind & TypeKinds.ENUMS) != 0) {
-						proposals.add(new NewCUProposal(cu, node, NewCUProposal.K_ENUM, enclosing, rel));
+						proposals.add(new NewCUProposal(cu, node, NewCUProposal.K_ENUM, enclosing, rel + 1));
 					}
 					if ((kind & TypeKinds.ANNOTATIONS) != 0) {
 						proposals.add(new NewCUProposal(cu, node, NewCUProposal.K_ANNOTATION, enclosing, rel + 1));


### PR DESCRIPTION
fix https://github.com/redhat-developer/vscode-java/issues/2940

let's make "create" quick fixes in the same position. Since `rel` will make "create enum ..." at the button of "Change to ..." due to character "r" and "h". 

demo:
![image](https://user-images.githubusercontent.com/45906942/226845092-ea31f229-58cd-4c7c-8da9-2a0fd531574c.png)
