### PR TITLE
Make WorkspaceSymbolHandlerTest.testProjectSearch more consistent.

### DIFF
--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceSymbolHandlerTest.java
@@ -114,9 +114,10 @@ public class WorkspaceSymbolHandlerTest extends AbstractProjectsManagerBasedTest
 		List<SymbolInformation> results = WorkspaceSymbolHandler.search(query, monitor);
 		assertNotNull(results);
 		assertEquals("Found " + results.size() + " results", 2, results.size());
+		assertTrue(results.stream().anyMatch(s -> "org.sample".equals(s.getContainerName())));
+		assertTrue(results.stream().anyMatch(s -> "java".equals(s.getContainerName())));
 		SymbolInformation symbol = results.get(0);
 		assertEquals(SymbolKind.Interface, symbol.getKind());
-		assertEquals("java", symbol.getContainerName());
 		assertEquals(query, symbol.getName());
 		Location location = symbol.getLocation();
 		assertNotEquals("Range should not equal the default range", JDTUtils.newRange(), location.getRange());


### PR DESCRIPTION
- testcase should not make assumptions about result order

Seems to have started failing more frequently due to https://github.com/eclipse/eclipse.jdt.ls/pull/2547