### PR TITLE
Support java.lang.Object for sysout postfix completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
@@ -90,7 +90,7 @@ class PostfixPreferences {
 	public static final String NULL_CONTENT = "if (${i:inner_expression(java.lang.Object,array)} == null) {\n" +
 		"\t$${0}\n" +
 	"}";
-	public static final String SYSOUT_CONTENT = "System.out.println(${i:inner_expression(java.lang.String)}${});$${0}";
+	public static final String SYSOUT_CONTENT = "System.out.println(${i:inner_expression(java.lang.Object)}${});$${0}";
 	public static final String THROW_CONTENT = "throw ${true:inner_expression(java.lang.Throwable)};";
 	public static final String VAR_CONTENT = "${field:newType(inner_expression)} $${1:${var:newName(inner_expression)}} = ${inner_expression};$${0}";
 	public static final String WHILE_CONTENT = "while (${i:inner_expression(boolean)}) {\n" +
@@ -106,7 +106,7 @@ class PostfixPreferences {
 	public static final String IF_DESCRIPTION = "Creates a if statement";
 	public static final String NNULL_DESCRIPTION = "Creates an if statement and checks if the expression does not resolve to null";
 	public static final String NULL_DESCRIPTION = "Creates an if statement which checks if expression resolves to null";
-	public static final String SYSOUT_DESCRIPTION = "Sends the affected string to a System.out.println(..) call";
+	public static final String SYSOUT_DESCRIPTION = "Sends the affected object to a System.out.println(..) call";
 	public static final String THROW_DESCRIPTION = "Throws the given Exception";
 	public static final String VAR_DESCRIPTION = "Creates a new variable";
 	public static final String WHILE_DESCRIPTION = "Creates a while loop";

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -130,7 +130,9 @@ public class CompletionHandler{
 
 	public void onDidCompletionItemSelect(String requestId, String proposalId) throws CoreException {
 		triggerSignatureHelp();
-
+		if (proposalId.isEmpty() || requestId.isEmpty()) {
+			return;
+		}
 		int pId = Integer.parseInt(proposalId);
 		long rId = Long.parseLong(requestId);
 		CompletionResponse completionResponse = CompletionResponses.get(rId);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -310,6 +310,33 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void test_sysout_object() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		Boolean foo = true;\n" +
+			"		foo.sysout" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "foo.sysout");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("sysout", item.getLabel());
+		assertEquals(item.getInsertText(), "System.out.println(foo);${0}");
+		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
+		Range range = item.getAdditionalTextEdits().get(0).getRange();
+		assertEquals(new Range(new Position(4, 2), new Position(4, 12)), range);
+	}
+
+	@Test
 	public void test_throw() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = getWorkingCopy(


### PR DESCRIPTION
This change allows the `sysout` postfix completion to be used on Objects in addition to Strings.

This PR should close https://github.com/eclipse/eclipse.jdt.ls/pull/1468 as it covers a similar use case.