### PR TITLE
Update org.eclipse.jdt.ls.tp.target to use m2e snapshot

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -18,7 +18,7 @@
             <unit id="org.eclipse.m2e.maven.runtime" version="0.0.0"/>
             <unit id="org.eclipse.m2e.workspace.cli" version="0.0.0"/>
             <unit id="ch.qos.logback.classic" version="0.0.0"/>
-	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
+	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/2.3.0/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -18,7 +18,7 @@
             <unit id="org.eclipse.m2e.maven.runtime" version="0.0.0"/>
             <unit id="org.eclipse.m2e.workspace.cli" version="0.0.0"/>
             <unit id="ch.qos.logback.classic" version="0.0.0"/>
-	        <repository location="https://download.eclipse.org/technology/m2e/releases/2.2.1/"/>
+	        <repository location="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Maven 3.9.1 is embedded in latest m2e snapshot build, which enables jdtls to resolve dependencies in parallel.
