### PR TITLE
Remove -noverify option from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ java \
 	-Dosgi.bundles.defaultStartLevel=4 \
 	-Declipse.product=org.eclipse.jdt.ls.core.product \
 	-Dlog.level=ALL \
-	-noverify \
 	-Xmx1G \
 	--add-modules=ALL-SYSTEM \
 	--add-opens java.base/java.util=ALL-UNNAMED \


### PR DESCRIPTION
- Option was deprecated in JDK 13 (see https://github.com/eclipse/eclipse.jdt.ls/commit/e7235f90d6a1e85aa22c7621858a54529b811188)