### PR TITLE
Measure elapsed time for project initialization checkpoints.

### DIFF
--- a/USAGE_DATA.md
+++ b/USAGE_DATA.md
@@ -9,6 +9,6 @@ When telemetry events are enabled, the following information is emitted :
  * The total number of Java projects within the workspace
  * The lowest and highest Java compiler source level used (eg. 11 & 17)
  * Whether the project(s) are being imported for the first time (eg. true)
- * The current time (in milliseconds) at which the language server started, initialized the workspace project(s), and completed building the project(s)
+ * The elapsed time (in milliseconds) at which the language server initialized the workspace project(s), declared as ready for requests, and completed building the project(s)
  * The number of libraries that were indexed after project initialization
  * The total size (in bytes) of libraries that were indexed after project initialization

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -94,14 +94,18 @@ public class TelemetryManager {
 			}
 		}
 
+		long projectInitElapsedTime, serviceReadyElapsedTime, buildFinishedElapsedTime;
+		projectInitElapsedTime = this.projectsInitializedTime - this.languageServerStartTime;
+		serviceReadyElapsedTime = this.serviceReadyTime - this.languageServerStartTime;
+		buildFinishedElapsedTime = buildFinishedTime - this.languageServerStartTime;
+
 		properties.add("buildToolNames", buildToolNamesList);
 		properties.addProperty("javaProjectCount", javaProjectCount);
 		properties.addProperty("compiler.source.min", Float.toString(sourceLevelMin));
 		properties.addProperty("compiler.source.max", Float.toString(sourceLevelMax));
-		properties.addProperty("timestamp.languageserverstart", Long.toString(this.languageServerStartTime));
-		properties.addProperty("timestamp.projectsinitialized", Long.toString(this.projectsInitializedTime));
-		properties.addProperty("timestamp.serviceready", Long.toString(this.serviceReadyTime));
-		properties.addProperty("timestamp.buildFinished", Long.toString(buildFinishedTime));
+		properties.addProperty("time.projectsinitialized", Long.toString(projectInitElapsedTime));
+		properties.addProperty("time.serviceready", Long.toString(serviceReadyElapsedTime));
+		properties.addProperty("time.buildFinished", Long.toString(buildFinishedElapsedTime));
 		properties.addProperty("initialization.first", Boolean.toString(this.firstTimeInitialization));
 
 		IndexManager manager = JavaModelManager.getIndexManager();


### PR DESCRIPTION
- Fixes #2564 

- An accurate view of the total time would be something like (service ready elapsed time + build finished elapsed time), since project initialization is a subset of the service ready time.