### PR TITLE
Support itemDefaults in CompletionList for snippets

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateBuffer;
 import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemDefaults;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Range;
@@ -64,8 +65,9 @@ public class PostfixTemplateEngine {
 	 * @param document The IDocument instance.
 	 * @param offset offset where the completion action happens.
 	 * @param compilationUnit the compilation unit.
+	 * @param completionItemDefaults the completion itemDefaults
 	 */
-	public List<CompletionItem> complete(IDocument document, int offset, ICompilationUnit compilationUnit) {
+	public List<CompletionItem> complete(IDocument document, int offset, ICompilationUnit compilationUnit, CompletionItemDefaults completionItemDefaults) {
 		List<CompletionItem> res = new ArrayList<>();
 		JavaPostfixContextType type = (JavaPostfixContextType) JavaLanguageServerPlugin.getInstance()
 				.getTemplateContextRegistry().getContextType(JavaPostfixContextType.ID_ALL);
@@ -102,6 +104,9 @@ public class PostfixTemplateEngine {
 			item.setLabel(template.getName());
 			item.setKind(CompletionItemKind.Snippet);
 			item.setInsertTextFormat(InsertTextFormat.Snippet);
+			if (completionItemDefaults.getInsertTextFormat() != null && completionItemDefaults.getInsertTextFormat() == InsertTextFormat.Snippet) {
+				item.setInsertTextFormat(null);
+			}
 			item.setDetail(template.getDescription());
 			item.setDocumentation(SnippetUtils.beautifyDocument(content));
 			// we hope postfix shows at the bottom of the completion list.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -223,7 +223,7 @@ public class CompletionHandler{
 					}
 					proposals.addAll(collector.getCompletionItems());
 					if (isSnippetStringSupported() && !UNSUPPORTED_RESOURCES.contains(unit.getResource().getName())) {
-						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector.getContext(), subMonitor));
+						proposals.addAll(SnippetCompletionProposal.getSnippets(unit, collector, subMonitor));
 					}
 					proposals.addAll(new JavadocCompletionProposal().getProposals(unit, offset, collector, subMonitor));
 				} catch (OperationCanceledException e) {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -310,7 +311,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void test_sysout_multiple_items() throws Exception {
+	public void test_sysout_itemDefaults_enabled() throws Exception {
 		//@formatter:off
 		ICompilationUnit unit = getWorkingCopy(
 				"src/org/sample/Test.java",
@@ -324,12 +325,16 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		CompletionList list = requestCompletions(unit, "new Test().syso");
 		//@formatter:on
 		assertNotNull(list);
+		assertNotNull(list.getItemDefaults().getEditRange());
+		assertEquals(InsertTextFormat.Snippet, list.getItemDefaults().getInsertTextFormat());
 
 		CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().startsWith("sysout")).findFirst().orElse(null);
 		assertNotNull(ci);
 
-		assertEquals("System.out.println(new Test());${0}", ci.getInsertText());
 		assertEquals("System.out.println(new Test());${0}", ci.getTextEditText());
+		//check that the fields covered by itemDefaults are set to null
+		assertNull(ci.getTextEdit());
+		assertNull(ci.getInsertTextFormat());
 		assertEquals(CompletionItemKind.Snippet, ci.getKind());
 	}
 
@@ -570,5 +575,7 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 		// Mock the preference manager to use LSP v3 support.
 		when(preferenceManager.getClientPreferences().isCompletionSnippetsSupported()).thenReturn(isSnippetSupported);
 		when(preferenceManager.getClientPreferences().isCompletionListItemDefaultsSupport()).thenReturn(isCompletionListItemDefaultsSupport);
+		when(preferenceManager.getClientPreferences().isCompletionListItemDefaultsEditRangeSupport()).thenReturn(isCompletionListItemDefaultsSupport);
+		when(preferenceManager.getClientPreferences().isCompletionListItemDefaultsInsertTextFormatSupport()).thenReturn(isCompletionListItemDefaultsSupport);
 	}
 }


### PR DESCRIPTION
* This PR also adds tests for completion with `itemDefaults` support enabled