### PR TITLE
Make Start Up Script compatible with older Python

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -70,9 +70,8 @@ def main(args):
 	jdtls_data_path = os.path.join(tempfile.gettempdir(), "jdtls-" + sha1(cwd_name.encode()).hexdigest())
 
 	parser = argparse.ArgumentParser()
-	parser.add_argument('--validate-java-version', action='store_true')
-	parser.add_argument('--no-validate-java-version', dest='validate-java-version', action='store_false')
-	parser.set_defaults(feature=True)
+    parser.add_argument('--validate-java-version', action='store_true', default=True)
+	parser.add_argument('--no-validate-java-version', dest='validate_java_version', action='store_false')
 	parser.add_argument("--jvm-arg",
 			default=[],
 			action="append",

--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -70,7 +70,9 @@ def main(args):
 	jdtls_data_path = os.path.join(tempfile.gettempdir(), "jdtls-" + sha1(cwd_name.encode()).hexdigest())
 
 	parser = argparse.ArgumentParser()
-	parser.add_argument("--validate-java-version", default=True, action=argparse.BooleanOptionalAction)
+	parser.add_argument('--validate-java-version', action='store_true')
+	parser.add_argument('--no-validate-java-version', dest='validate-java-version', action='store_false')
+	parser.set_defaults(feature=True)
 	parser.add_argument("--jvm-arg",
 			default=[],
 			action="append",


### PR DESCRIPTION
Previously the start up script created to be friendly to package managers used the `BooleanOptionalAction` in its argument parser. This feature is only available in Python 3.9 and later. Since the script shebang in [jdtls](https://github.com/eclipse/eclipse.jdt.ls/blob/master/org.eclipse.jdt.ls.product/scripts/jdtls#L1) indicates only Python3, this change updates the script to conform with expected compatibility.

This fix was suggested by @tmmvn in [issue 2153](https://github.com/eclipse/eclipse.jdt.ls/issues/2153). This change implements that fix.