### PR TITLE
Avoid retrieving AST root during diagnostic publishing.

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -260,15 +260,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 			if (monitor.isCanceled()) {
 				return Status.CANCEL_STATUS;
 			}
-			CompilationUnit astRoot = this.sharedASTProvider.getAST(rootToValidate, CoreASTProvider.WAIT_YES, monitor);
-			if (monitor.isCanceled()) {
-				return Status.CANCEL_STATUS;
-			}
-			if (astRoot != null) {
-				// report errors, even if there are no problems in the file: The client need to know that they got fixed.
-				ICompilationUnit unit = (ICompilationUnit) astRoot.getTypeRoot();
-				publishDiagnostics(unit, progress.newChild(1));
-			}
+			publishDiagnostics(rootToValidate, progress.newChild(1));
 		}
 		JavaLanguageServerPlugin.logInfo("Validated " + toValidate.size() + ". Took " + (System.currentTimeMillis() - start) + " ms");
 		return Status.OK_STATUS;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -230,7 +230,8 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 0));
-		assertEquals(1, getCacheSize());
+		// https://github.com/eclipse/eclipse.jdt.ls/pull/2535
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		buf = new StringBuilder();
@@ -244,7 +245,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(true, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 1));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		saveDocument(cu1);
@@ -252,7 +253,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported();
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(0);
 
 		closeDocument(cu1);
@@ -284,7 +285,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 1));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		buf = new StringBuilder();
@@ -300,7 +301,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(true, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 0));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		closeDocument(cu1);
@@ -395,7 +396,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 0));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		buf = new StringBuilder();
@@ -407,7 +408,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(true, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 1));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		saveDocument(cu1);
@@ -415,7 +416,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported();
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(0);
 
 		closeDocument(cu1);
@@ -461,7 +462,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu2, 1));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		openDocument(cu1, cu1.getSource(), 1);
@@ -471,7 +472,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu2, 1), new ExpectedProblemReport(cu1, 0));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(2);
 
 		buf = new StringBuilder();
@@ -487,7 +488,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu2, 0), new ExpectedProblemReport(cu1, 0));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(2);
 
 		saveDocument(cu1);
@@ -497,7 +498,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
 		assertNewProblemReported();
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(0);
 
 		closeDocument(cu1);
@@ -800,7 +801,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.isWorkingCopy());
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertNewProblemReported(new ExpectedProblemReport(cu1, 1));
-		assertEquals(1, getCacheSize());
+		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(1);
 
 		StringBuilder buf2 = new StringBuilder();


### PR DESCRIPTION
A related issue - https://github.com/redhat-developer/vscode-java/issues/2982

Steps to reproduce

```
$ rm -rf jhisper-lite
$ git clone https://github.com/snjeza/jhipster-lite
$ cd jhipster-lite
$ code .
```
- enable lombok
- open AssertTest.java
```
private void test() {
    D d = new D| // try CA here
   // type
  Model56 model56 = new Model56();
  model56.getWeight()

  }
```
- check line `Validated X. Took XXX ms`

[Test vsix 1.17.3](https://github.com/snjeza/vscode-test/raw/master/java-1.17.3.vsix)