### PR TITLE
Fix IdentationError due to mix of spaces and tabs

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -70,7 +70,7 @@ def main(args):
 	jdtls_data_path = os.path.join(tempfile.gettempdir(), "jdtls-" + sha1(cwd_name.encode()).hexdigest())
 
 	parser = argparse.ArgumentParser()
-    parser.add_argument('--validate-java-version', action='store_true', default=True)
+	parser.add_argument('--validate-java-version', action='store_true', default=True)
 	parser.add_argument('--no-validate-java-version', dest='validate_java_version', action='store_false')
 	parser.add_argument("--jvm-arg",
 			default=[],


### PR DESCRIPTION
Fix `IdentationError` exception thrown by Python startup script due to inconsistent mix of spaces and tabs.