### PR TITLE
Avoid validating all opened workingcopies when didChange a document

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -48,7 +49,6 @@ import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IProblemRequestor;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -108,6 +108,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 	private Job validationTimer;
 	private Job publishDiagnosticsJob;
 	private Set<ICompilationUnit> toReconcile = new HashSet<>();
+	private Set<ICompilationUnit> toValidate = Collections.synchronizedSet(new HashSet<>());
 	private Map<String, Integer> documentVersions = new HashMap<>();
 	private MovingAverage movingAverageForValidation = new MovingAverage(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE);
 	private MovingAverage movingAverageForDiagnostics = new MovingAverage(PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE);
@@ -214,6 +215,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 					return Status.CANCEL_STATUS;
 				}
 				cu.makeConsistent(progress);
+				toValidate.add(cu);
 				//cu.reconcile(ICompilationUnit.NO_AST, false, null, progress.newChild(1));
 			}
 		}
@@ -239,27 +241,46 @@ public abstract class BaseDocumentLifeCycleHandler {
 		return Status.OK_STATUS;
 	}
 
+	public IStatus validateDocument(String uri, boolean debounce, IProgressMonitor monitor) throws JavaModelException {
+		ICompilationUnit unit = resolveCompilationUnit(uri);
+		if (unit == null || unit.getResource() == null || unit.getResource().isDerived()) {
+			return Status.OK_STATUS;
+		}
+
+		toValidate.add(unit);
+		if (debounce && publishDiagnosticsJob != null) {
+			publishDiagnosticsJob.cancel();
+			publishDiagnosticsJob.setRule(null);
+			if (monitor.isCanceled()) {
+				return Status.CANCEL_STATUS;
+			}
+			publishDiagnosticsJob.schedule(getPublishDiagnosticsDelay());
+			return Status.OK_STATUS;
+		}
+
+		return publishDiagnostics(monitor);
+	}
 	public IStatus publishDiagnostics(IProgressMonitor monitor) throws JavaModelException {
 		long start = System.currentTimeMillis();
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}
-		this.sharedASTProvider.disposeAST();
-		List<ICompilationUnit> toValidate = Arrays.asList(JavaCore.getWorkingCopies(null));
-		if (toValidate.isEmpty()) {
+		List<ICompilationUnit> validateCopy = new ArrayList<>(toValidate);
+		if (validateCopy.isEmpty()) {
 			return Status.OK_STATUS;
 		}
-		SubMonitor progress = SubMonitor.convert(monitor, toValidate.size() + 1);
+		SubMonitor progress = SubMonitor.convert(monitor, validateCopy.size() + 1);
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}
-		for (ICompilationUnit rootToValidate : toValidate) {
+		for (ICompilationUnit rootToValidate : validateCopy) {
 			if (monitor.isCanceled()) {
 				return Status.CANCEL_STATUS;
 			}
 			publishDiagnostics(rootToValidate, progress.newChild(1));
+			toValidate.remove(rootToValidate);
 		}
-		JavaLanguageServerPlugin.logInfo("Validated " + toValidate.size() + ". Took " + (System.currentTimeMillis() - start) + " ms");
+		JavaLanguageServerPlugin.logInfo("Validated " + validateCopy.size() + ". Took " + (System.currentTimeMillis() - start) + " ms");
 		return Status.OK_STATUS;
 	}
 
@@ -454,6 +475,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 			synchronized (toReconcile) {
 				toReconcile.remove(unit);
 			}
+			toValidate.remove(unit);
 			if (isSyntaxMode(unit) || !unit.exists() || unit.getResource().isDerived()) {
 				createDiagnosticsHandler(unit).clearDiagnostics();
 			} else if (hasUnsavedChanges(unit)) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -16,13 +16,13 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.internal.resources.Workspace;
 import org.eclipse.core.resources.IFile;
@@ -108,7 +108,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 	private Job validationTimer;
 	private Job publishDiagnosticsJob;
 	private Set<ICompilationUnit> toReconcile = new HashSet<>();
-	private Set<ICompilationUnit> toValidate = Collections.synchronizedSet(new HashSet<>());
+	private Set<ICompilationUnit> toValidate = ConcurrentHashMap.newKeySet();
 	private Map<String, Integer> documentVersions = new HashMap<>();
 	private MovingAverage movingAverageForValidation = new MovingAverage(DOCUMENT_LIFECYCLE_MAX_DEBOUNCE);
 	private MovingAverage movingAverageForDiagnostics = new MovingAverage(PUBLISH_DIAGNOSTICS_MIN_DEBOUNCE);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -267,7 +267,7 @@ public abstract class BaseDocumentLifeCycleHandler {
 			return Status.CANCEL_STATUS;
 		}
 		List<ICompilationUnit> validateCopy =
-			preferenceManager.getClientPreferences().validateAllOpenBuffersOnDidChange()
+			preferenceManager.getPreferences().isValidateAllOpenBuffersOnChanges()
 				? Arrays.asList(JavaCore.getWorkingCopies(null)) : new ArrayList<>(toValidate);
 		if (validateCopy.isEmpty()) {
 			return Status.OK_STATUS;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IProblemRequestor;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -265,7 +266,9 @@ public abstract class BaseDocumentLifeCycleHandler {
 		if (monitor.isCanceled()) {
 			return Status.CANCEL_STATUS;
 		}
-		List<ICompilationUnit> validateCopy = new ArrayList<>(toValidate);
+		List<ICompilationUnit> validateCopy =
+			preferenceManager.getClientPreferences().validateAllOpenBuffersOnDidChange()
+				? Arrays.asList(JavaCore.getWorkingCopies(null)) : new ArrayList<>(toValidate);
 		if (validateCopy.isEmpty()) {
 			return Status.OK_STATUS;
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -36,6 +36,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.BaseJDTLanguageServer;
@@ -74,6 +75,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.AddOverr
 import org.eclipse.jdt.ls.core.internal.handlers.OverrideMethodsHandler.OverridableMethodsResponse;
 import org.eclipse.jdt.ls.core.internal.handlers.WorkspaceSymbolHandler.SearchSymbolParams;
 import org.eclipse.jdt.ls.core.internal.lsp.JavaProtocolExtensions;
+import org.eclipse.jdt.ls.core.internal.lsp.ValidateDocumentParams;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
 import org.eclipse.jdt.ls.core.internal.managers.TelemetryManager;
@@ -858,6 +860,20 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public void didClose(DidCloseTextDocumentParams params) {
 		debugTrace(">> document/didClose");
 		documentLifeCycleHandler.didClose(params);
+	}
+
+	
+	@Override
+	public void validateDocument(ValidateDocumentParams params) {
+		logInfo(">> java/validateDocument");
+		computeAsync((monitor) -> {
+			try {
+				documentLifeCycleHandler.validateDocument(params.getTextDocument().getUri(), true, monitor);
+			} catch (JavaModelException e) {
+				// ignore
+			}
+			return null;
+		});
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/JavaProtocolExtensions.java
@@ -143,4 +143,7 @@ public interface JavaProtocolExtensions {
 
 	@JsonRequest
 	CompletableFuture<CheckExtractInterfaceResponse> checkExtractInterfaceStatus(CodeActionParams params);
+
+	@JsonNotification
+	void validateDocument(ValidateDocumentParams params);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ValidateDocumentParams.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/lsp/ValidateDocumentParams.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.lsp;
+
+import java.util.Objects;
+
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+public class ValidateDocumentParams {
+	TextDocumentIdentifier textDocument;
+
+	public ValidateDocumentParams() {
+	}
+
+	public ValidateDocumentParams(TextDocumentIdentifier textDocument) {
+		this.textDocument = textDocument;
+	}
+
+	public TextDocumentIdentifier getTextDocument() {
+		return textDocument;
+	}
+
+	public void setTextDocument(TextDocumentIdentifier textDocument) {
+		this.textDocument = textDocument;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(textDocument);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ValidateDocumentParams other = (ValidateDocumentParams) obj;
+		return Objects.equals(textDocument, other.textDocument);
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -471,4 +471,7 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("skipTextEventPropagation", "false").toString());
 	}
 
+	public boolean validateAllOpenBuffersOnDidChange() {
+		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("validateAllOpenBuffersOnDidChange", "true").toString());
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -470,8 +470,4 @@ public class ClientPreferences {
 	public boolean skipTextEventPropagation() {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("skipTextEventPropagation", "false").toString());
 	}
-
-	public boolean validateAllOpenBuffersOnDidChange() {
-		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("validateAllOpenBuffersOnDidChange", "true").toString());
-	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -465,6 +465,7 @@ public class Preferences {
 
 	public static final String JAVA_TELEMETRY_ENABLED_KEY = "java.telemetry.enabled";
 
+	public static final String JAVA_EDIT_VALIDATE_ALL_OPEN_BUFFERS_ON_CHANGES = "java.edit.validateAllOpenBuffersOnChanges";
 	/**
 	 * The preferences for generating toString method.
 	 */
@@ -651,6 +652,7 @@ public class Preferences {
 	private List<String> cleanUpActionsOnSave;
 	private boolean extractInterfaceReplaceEnabled;
 	private boolean telemetryEnabled;
+	private boolean validateAllOpenBuffersOnChanges;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -881,6 +883,7 @@ public class Preferences {
 		cleanUpActionsOnSave = new ArrayList<>();
 		extractInterfaceReplaceEnabled = false;
 		telemetryEnabled = false;
+		validateAllOpenBuffersOnChanges = true;
 	}
 
 	private static void initializeNullAnalysisClasspathStorage() {
@@ -1240,6 +1243,8 @@ public class Preferences {
 		prefs.setExtractInterfaceReplaceEnabled(extractInterfaceReplaceEnabled);
 		boolean telemetryEnabled = getBoolean(configuration, JAVA_TELEMETRY_ENABLED_KEY, false);
 		prefs.setTelemetryEnabled(telemetryEnabled);
+		boolean validateAllOpenBuffers = getBoolean(configuration, JAVA_EDIT_VALIDATE_ALL_OPEN_BUFFERS_ON_CHANGES, true);
+		prefs.setValidateAllOpenBuffersOnChanges(validateAllOpenBuffers);
 		return prefs;
 	}
 
@@ -2383,4 +2388,11 @@ public class Preferences {
 		return telemetryEnabled;
 	}
 
+	public boolean isValidateAllOpenBuffersOnChanges() {
+		return validateAllOpenBuffersOnChanges;
+	}
+
+	public void setValidateAllOpenBuffersOnChanges(boolean validateAllOpenBuffersOnChanges) {
+		this.validateAllOpenBuffersOnChanges = validateAllOpenBuffersOnChanges;
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/DocumentLifeCycleHandlerTest.java
@@ -471,7 +471,7 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(false, cu1.hasUnsavedChanges());
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
-		assertNewProblemReported(new ExpectedProblemReport(cu2, 1), new ExpectedProblemReport(cu1, 0));
+		assertNewProblemReported(new ExpectedProblemReport(cu1, 0));
 		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(2);
 
@@ -487,9 +487,13 @@ public class DocumentLifeCycleHandlerTest extends AbstractProjectsManagerBasedTe
 		assertEquals(true, cu1.hasUnsavedChanges());
 		assertEquals(true, cu2.isWorkingCopy());
 		assertEquals(false, cu2.hasUnsavedChanges());
-		assertNewProblemReported(new ExpectedProblemReport(cu2, 0), new ExpectedProblemReport(cu1, 0));
+		assertNewProblemReported(new ExpectedProblemReport(cu1, 0));
 		assertEquals(0, getCacheSize());
 		assertNewASTsCreated(2);
+
+		closeDocument(cu2);
+		openDocument(cu2, cu2.getSource(), 1);
+		assertNewProblemReported(new ExpectedProblemReport(cu2, 0));
 
 		saveDocument(cu1);
 


### PR DESCRIPTION
This PR introduces a workspace setting `java.edit.validateAllOpenBuffersOnChanges` that allows users to choose the diagnostics strategy for unsaved changes when editing a Java file.

 - **Strategy 1**: Validate all open Java files (workingcopies) in the editor for errors when you're typing in a Java file. The advantage of this strategy is that it can detect errors quickly if the current changes affect other open Java files. The drawback is that it can be costly to validate all open buffers on every change.
- **Strategy 2**: Validate only the current Java file for errors when you're typing. This strategy can use less CPU resources and respond faster if the changes introduce errors. However, it may not report potential errors in other Java files right away. If the client prefers strategy 2, we recommend that the client supports resending a request to validate the document when users switch their focus to a Java file. The format of the validate document notification is as follows:
```
languageClient.sendNotification('java/validateDocument', {
	textDocument: {
		uri: '<java file uri string>',
	},
});
```