### PR TITLE
Update tp to 4.28-I-builds I20230416-0550

### DIFF
--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -29,7 +29,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.28-I-builds/I20230405-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.28-I-builds/I20230416-0550/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>


### PR DESCRIPTION
See https://github.com/eclipse/eclipse.jdt.ls/pull/2586#issuecomment-1510358912, the Java debugger was broken in the I20230405-1800 build, but fixed in the latest I20230416-0550 build.