### PR TITLE
Check additionalTextEdits & documentation resolve support via standard LSP

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -129,7 +129,9 @@ public class CompletionResolveHandler {
 				Range range = JDTUtils.toRange(unit, ctx.getOffset(), 0);
 				TextEdit textEdit = new TextEdit(range, content);
 				param.setTextEdit(Either.forLeft(textEdit));
-				param.setDocumentation(SnippetUtils.beautifyDocument(content));
+				if (manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
+					param.setDocumentation(SnippetUtils.beautifyDocument(content));
+				}
 				param.setData(null);
 			} catch (JavaModelException e) {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
@@ -148,6 +150,12 @@ public class CompletionResolveHandler {
 			);
 			proposalProvider.updateReplacement(completionResponse.getProposals().get(proposalId), param, '\0');
 		}
+
+		if (!manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
+			return param;
+		}
+
+		// below code is for resolving documentation
 		if (data.containsKey(DATA_FIELD_DECLARATION_SIGNATURE)) {
 			String typeName = stripSignatureToFQN(String.valueOf(data.get(DATA_FIELD_DECLARATION_SIGNATURE)));
 			try {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferences.java
@@ -275,10 +275,6 @@ public class ClientPreferences {
 		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("gradleChecksumWrapperPromptSupport", "false").toString());
 	}
 
-	public boolean isResolveAdditionalTextEditsSupport() {
-		return Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("resolveAdditionalTextEditsSupport", "false").toString());
-	}
-
 	/**
 	 * The command which will be triggered when the completion item is selected. Different clients can have different
 	 * command ids. The command id is set in the 'onCompletionItemSelectedCommand' field of the extended client capabilities.
@@ -416,6 +412,25 @@ public class ClientPreferences {
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem() != null
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getLabelDetailsSupport() != null
 			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getLabelDetailsSupport().booleanValue();
+	}
+
+	public boolean isResolveAdditionalTextEditsSupport() {
+		return isPropertySupportedForCompletionResolve("additionalTextEdits")
+			// TODO: the extended capability 'resolveAdditionalTextEditsSupport' should be deprecated.
+			|| Boolean.parseBoolean(extendedClientCapabilities.getOrDefault("resolveAdditionalTextEditsSupport", "false").toString());
+	}
+
+	public boolean isCompletionResolveDocumentSupport() {
+		return isPropertySupportedForCompletionResolve("documentation");
+	}
+
+	public boolean isPropertySupportedForCompletionResolve(String property) {
+		return (v3supported
+			&& capabilities.getTextDocument().getCompletion() != null
+			&& capabilities.getTextDocument().getCompletion().getCompletionItem() != null
+			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getResolveSupport() != null
+			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getResolveSupport().getProperties() != null
+			&& capabilities.getTextDocument().getCompletion().getCompletionItem().getResolveSupport().getProperties().contains(property));
 	}
 
 	public boolean isInlayHintRefreshSupported() {

--- a/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.ls.core.internal.handlers.CompletionResolveHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
 import org.eclipse.jdt.ls.core.internal.managers.ContentProviderManager;
 import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager;
+import org.eclipse.jdt.ls.core.internal.preferences.ClientPreferences;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
@@ -72,6 +73,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -384,6 +386,10 @@ public class SyntaxServerTest extends AbstractSyntaxProjectsManagerBasedTest {
 
 	@Test
 	public void testResolveCompletion() throws Exception {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
+
 		URI fileURI = openFile("maven/salut4", "src/main/java/java/Completion.java");
 		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(fileURI);
 		assertNotNull(cu);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -132,6 +132,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_javadoc() throws Exception {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		IJavaProject javaProject = JavaCore.create(project);
 		ICompilationUnit unit = (ICompilationUnit) javaProject.findElement(new Path("org/sample/TestJavadoc.java"));
 		unit.becomeWorkingCopy(null);
@@ -163,6 +166,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
 		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
 		Mockito.when(mockCapabilies.isSupportsCompletionDocumentationMarkdown()).thenReturn(true);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		ICompilationUnit unit = (ICompilationUnit) javaProject.findElement(new Path("org/sample/TestJavadoc.java"));
 		unit.becomeWorkingCopy(null);
 		String joinOnCompletion = System.getProperty(JDTLanguageServer.JAVA_LSP_JOIN_ON_COMPLETION);
@@ -2561,6 +2565,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_testMethodWithParams() throws Exception {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		ICompilationUnit unit = getWorkingCopy(
 		//@formatter:off
 		"src/org/sample/Test.java",
@@ -3030,6 +3037,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
 		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
 		Mockito.when(mockCapabilies.isSupportsCompletionDocumentationMarkdown()).thenReturn(true);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		Mockito.lenient().when(mockCapabilies.isClassFileContentSupported()).thenReturn(true);
 
 		//@formatter:off
@@ -3446,6 +3454,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 
 	@Test
 	public void testCompletion_ConstantDefaultValue() throws JavaModelException {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"
@@ -3486,6 +3497,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	// See https://github.com/redhat-developer/vscode-java/issues/1258
 	@Test
 	public void testCompletion_javadocOriginal() throws JavaModelException {
+		ClientPreferences mockCapabilies = Mockito.mock(ClientPreferences.class);
+		Mockito.when(preferenceManager.getClientPreferences()).thenReturn(mockCapabilies);
+		Mockito.when(mockCapabilies.isCompletionResolveDocumentSupport()).thenReturn(true);
 		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java",
 		//@formatter:off
 				"package org.sample;\n"

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/ClientPreferencesTest.java
@@ -16,10 +16,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeLensCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItemCapabilities;
+import org.eclipse.lsp4j.CompletionItemResolveSupportCapabilities;
 import org.eclipse.lsp4j.CompletionItemTagSupportCapabilities;
 import org.eclipse.lsp4j.DocumentSymbolCapabilities;
 import org.eclipse.lsp4j.FormattingCapabilities;
@@ -178,6 +181,20 @@ public class ClientPreferencesTest {
 		when(text.getCompletion()).thenReturn(capabilities);
 		itemCapabilities.setTagSupport(new CompletionItemTagSupportCapabilities());
 		assertTrue(prefs.isCompletionItemTagSupported());
+	}
+
+	@Test
+	public void testIsPropertySupportedForCompletionResolve() {
+		String property = "property";
+		assertFalse(prefs.isPropertySupportedForCompletionResolve(property));
+		CompletionItemCapabilities itemCapabilities = new CompletionItemCapabilities();
+		CompletionCapabilities capabilities = new CompletionCapabilities(itemCapabilities);
+		when(text.getCompletion()).thenReturn(capabilities);
+
+		CompletionItemResolveSupportCapabilities resolveCapabilities = new CompletionItemResolveSupportCapabilities();
+		resolveCapabilities.setProperties(Collections.singletonList(property));
+		itemCapabilities.setResolveSupport(resolveCapabilities);
+		assertTrue(prefs.isPropertySupportedForCompletionResolve(property));
 	}
 
 	@Test


### PR DESCRIPTION
Related with the issue: https://github.com/eclipse/eclipse.jdt.ls/issues/2584

Client side PR: https://github.com/redhat-developer/vscode-java/pull/3070

This PR first check the resolve support for `additionalTextEdits` & `documentation`

Check for `testEdit` will come next.