### PR TITLE
Lazily resolve completion text edit according to the preference

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -314,7 +314,10 @@ public class SnippetCompletionProposal extends CompletionProposal {
 			item.setLabel(template.getName());
 			item.setKind(CompletionItemKind.Snippet);
 
-			if (completionItemDefaults.getInsertTextFormat() != null && completionItemDefaults.getInsertTextFormat() == InsertTextFormat.Snippet){
+			if (isCompletionListItemDefaultsSupport() &&
+				completionItemDefaults.getInsertTextFormat() != null &&
+				completionItemDefaults.getInsertTextFormat() == InsertTextFormat.Snippet
+			) {
 				item.setInsertTextFormat(null);
 			} else {
 				item.setInsertTextFormat(InsertTextFormat.Snippet);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -125,13 +125,14 @@ public class CompletionResolveHandler {
 				CompletionProposal proposal = completionResponse.getProposals().get(proposalId);
 				Template template = ((SnippetCompletionProposal) proposal).getTemplate();
 				String content = SnippetCompletionProposal.evaluateGenericTemplate(unit, ctx, template);
-
-				Range range = JDTUtils.toRange(unit, ctx.getOffset(), 0);
-				TextEdit textEdit = new TextEdit(range, content);
-				param.setTextEdit(Either.forLeft(textEdit));
 				if (manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
 					param.setDocumentation(SnippetUtils.beautifyDocument(content));
 				}
+
+				if (manager.getPreferences().isCompletionLazyResolveTextEditEnabled()) {
+					SnippetCompletionProposal.setTextEdit(ctx, unit, param, content);
+				}
+
 				param.setData(null);
 			} catch (JavaModelException e) {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -325,6 +325,11 @@ public class Preferences {
 	public static final String COMPLETION_MATCH_CASE_MODE_KEY = "java.completion.matchCase";
 
 	/**
+	 * Preference key to specify whether text edit of completion item can be lazily resolved.
+	 */
+	public static final String COMPLETION_LAZY_RESOLVE_TEXT_EDIT_ENABLED_KEY = "java.completion.lazyResolveTextEdit.enabled";
+
+	/**
 	 * Preference key to enable/disable the 'foldingRange'.
 	 */
 	public static final String FOLDINGRANGE_ENABLED_KEY = "java.foldingRange.enabled";
@@ -580,6 +585,7 @@ public class Preferences {
 	private boolean completionEnabled;
 	private boolean postfixCompletionEnabled;
 	private CompletionMatchCaseMode completionMatchCaseMode;
+	private boolean completionLazyResolveTextEditEnabled;
 	private boolean completionOverwrite;
 	private boolean foldingRangeEnabled;
 	private boolean selectionRangeEnabled;
@@ -830,6 +836,7 @@ public class Preferences {
 		completionEnabled = true;
 		postfixCompletionEnabled = true;
 		completionMatchCaseMode = CompletionMatchCaseMode.OFF;
+		completionLazyResolveTextEditEnabled = false;
 		completionOverwrite = true;
 		foldingRangeEnabled = true;
 		selectionRangeEnabled = true;
@@ -1007,6 +1014,9 @@ public class Preferences {
 
 		String completionMatchCaseMode = getString(configuration, COMPLETION_MATCH_CASE_MODE_KEY, null);
 		prefs.setCompletionMatchCaseMode(CompletionMatchCaseMode.fromString(completionMatchCaseMode, CompletionMatchCaseMode.OFF));
+
+		boolean completionLazyResolveTextEditEnabled = getBoolean(configuration, COMPLETION_LAZY_RESOLVE_TEXT_EDIT_ENABLED_KEY, false);
+		prefs.setCompletionLazyResolveTextEditEnabled(completionLazyResolveTextEditEnabled);
 
 		boolean completionOverwrite = getBoolean(configuration, JAVA_COMPLETION_OVERWRITE_KEY, true);
 		prefs.setCompletionOverwrite(completionOverwrite);
@@ -1431,6 +1441,14 @@ public class Preferences {
 
 	public void setCompletionMatchCaseMode(CompletionMatchCaseMode completionMatchCaseMode) {
 		this.completionMatchCaseMode = completionMatchCaseMode;
+	}
+
+	public boolean isCompletionLazyResolveTextEditEnabled() {
+		return completionLazyResolveTextEditEnabled;
+	}
+
+	public void setCompletionLazyResolveTextEditEnabled(boolean completionLazyResolveTextEditEnabled) {
+		this.completionLazyResolveTextEditEnabled = completionLazyResolveTextEditEnabled;
 	}
 
 	public Preferences setCompletionOverwrite(boolean completionOverwrite) {


### PR DESCRIPTION
- JDT.LS will only resolve the text edit for the snippets only when
  the preference 'java.completion.lazyResolveTextEdit.enabled' is set
  to true.
- If not, the 'textEdit' of the snippets will be set during
  'textDocument/completion'.

requires https://github.com/redhat-developer/vscode-java/pull/3072

fix https://github.com/eclipse/eclipse.jdt.ls/issues/2584