### PR TITLE
No need to run completion handler in async thread pool

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -592,19 +592,12 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
 		logInfo(">> document/completion");
 		CompletionHandler handler = new CompletionHandler(preferenceManager);
-		final IProgressMonitor[] monitors = new IProgressMonitor[1];
-		CompletableFuture<Either<List<CompletionItem>, CompletionList>> result = computeAsync((monitor) -> {
-			monitors[0] = monitor;
-			if (Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION)) {
-				waitForLifecycleJobs(monitor);
-			}
-			return handler.completion(position, monitor);
-		});
-		result.join();
-		if (monitors[0].isCanceled()) {
-			result.cancel(true);
+		IProgressMonitor monitor = new NullProgressMonitor();
+		if (Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION)) {
+			waitForLifecycleJobs(monitor);
 		}
-		return result;
+		Either<List<CompletionItem>, CompletionList> result = handler.completion(position, monitor);
+		return CompletableFuture.completedFuture(result);
 	}
 
 	/* (non-Javadoc)
@@ -614,19 +607,12 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
 		logInfo(">> document/resolveCompletionItem");
 		CompletionResolveHandler handler = new CompletionResolveHandler(preferenceManager);
-		final IProgressMonitor[] monitors = new IProgressMonitor[1];
-		CompletableFuture<CompletionItem> result = computeAsync((monitor) -> {
-			monitors[0] = monitor;
-			if ((Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION))) {
-				waitForLifecycleJobs(monitor);
-			}
-			return handler.resolve(unresolved, monitor);
-		});
-		result.join();
-		if (monitors[0].isCanceled()) {
-			result.cancel(true);
+		IProgressMonitor monitor = new NullProgressMonitor();
+		if ((Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION))) {
+			waitForLifecycleJobs(monitor);
 		}
-		return result;
+		CompletionItem result = handler.resolve(unresolved, monitor);
+		return CompletableFuture.completedFuture(result);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -591,13 +591,17 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
 		logInfo(">> document/completion");
-		CompletionHandler handler = new CompletionHandler(preferenceManager);
-		IProgressMonitor monitor = new NullProgressMonitor();
-		if (Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION)) {
-			waitForLifecycleJobs(monitor);
+		try {
+			CompletionHandler handler = new CompletionHandler(preferenceManager);
+			IProgressMonitor monitor = new NullProgressMonitor();
+			if (Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION)) {
+				waitForLifecycleJobs(monitor);
+			}
+			Either<List<CompletionItem>, CompletionList> result = handler.completion(position, monitor);
+			return CompletableFuture.completedFuture(result);
+		} catch (Exception ex) {
+			return CompletableFuture.failedFuture(ex);
 		}
-		Either<List<CompletionItem>, CompletionList> result = handler.completion(position, monitor);
-		return CompletableFuture.completedFuture(result);
 	}
 
 	/* (non-Javadoc)
@@ -606,13 +610,17 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
 		logInfo(">> document/resolveCompletionItem");
-		CompletionResolveHandler handler = new CompletionResolveHandler(preferenceManager);
-		IProgressMonitor monitor = new NullProgressMonitor();
-		if ((Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION))) {
-			waitForLifecycleJobs(monitor);
+		try {
+			CompletionResolveHandler handler = new CompletionResolveHandler(preferenceManager);
+			IProgressMonitor monitor = new NullProgressMonitor();
+			if ((Boolean.getBoolean(JAVA_LSP_JOIN_ON_COMPLETION))) {
+				waitForLifecycleJobs(monitor);
+			}
+			CompletionItem result = handler.resolve(unresolved, monitor);
+			return CompletableFuture.completedFuture(result);
+		} catch (Exception ex) {
+			return CompletableFuture.failedFuture(ex);
 		}
-		CompletionItem result = handler.resolve(unresolved, monitor);
-		return CompletableFuture.completedFuture(result);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Currently we use `computeAsync` and `join` the async result to handle `completion` and `resolveCompletionItem` requests synchronously. This is not quite efficient. A better implementation is to run them directly in the main dispatcher thread, which can ensure the completion is handled immediately and without waiting for another async scheduler.