### PR TITLE
Store the uri of document into CompletionResponse

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -280,6 +280,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			response.setProposals(proposals);
 		}
 		response.setItems(completionItems);
+		response.setUri(this.uri);
 		CompletionResponses.store(response);
 
 		return completionItems;
@@ -339,7 +340,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		}
 		Map<String, String> data = new HashMap<>();
 		// append data field so that resolve request can use it.
-		data.put(CompletionResolveHandler.DATA_FIELD_URI, uri);
 		data.put(CompletionResolveHandler.DATA_FIELD_REQUEST_ID, String.valueOf(response.getId()));
 		data.put(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID, String.valueOf(index));
 		$.setData(data);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/JavadocCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/JavadocCompletionProposal.java
@@ -123,7 +123,6 @@ public class JavadocCompletionProposal {
 			}
 			ci.setDocumentation(documentation);
 			Map<String, String> data = new HashMap<>(3);
-			data.put(CompletionResolveHandler.DATA_FIELD_URI, JDTUtils.toURI(cu));
 			data.put(CompletionResolveHandler.DATA_FIELD_REQUEST_ID, "0");
 			data.put(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID, "0");
 			ci.setData(data);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -346,8 +346,7 @@ public class SnippetCompletionProposal extends CompletionProposal {
 				item.setLabelDetails(itemLabelDetails);
 			}
 
-			Map<String, String> data = new HashMap<>(3);
-			data.put(CompletionResolveHandler.DATA_FIELD_URI, uri);
+			Map<String, String> data = new HashMap<>(2);
 			data.put(CompletionResolveHandler.DATA_FIELD_REQUEST_ID, String.valueOf(response.getId()));
 			data.put(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID, String.valueOf(i));
 			item.setData(data);
@@ -358,6 +357,7 @@ public class SnippetCompletionProposal extends CompletionProposal {
 
 		response.setProposals(proposals);
 		response.setItems(res);
+		response.setUri(uri);
 		CompletionResponses.store(response);
 		return res;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -84,7 +84,6 @@ public class CompletionResolveHandler {
 		this.manager = manager;
 	}
 
-	public static final String DATA_FIELD_URI = "uri";
 	public static final String DATA_FIELD_DECLARATION_SIGNATURE = "decl_signature";
 	public static final String DATA_FIELD_SIGNATURE= "signature";
 	public static final String DATA_FIELD_NAME = "name";
@@ -99,7 +98,7 @@ public class CompletionResolveHandler {
 		Map<String, String> data = JSONUtility.toModel(param.getData(),Map.class);
 		// clean resolve data
 		param.setData(null);
-		if (!CompletionProposalRequestor.SUPPORTED_KINDS.contains(param.getKind()) || data == null || !data.containsKey(DATA_FIELD_URI) || !data.containsKey(DATA_FIELD_REQUEST_ID) || !data.containsKey(DATA_FIELD_PROPOSAL_ID)) {
+		if (!CompletionProposalRequestor.SUPPORTED_KINDS.contains(param.getKind()) || data == null || !data.containsKey(DATA_FIELD_REQUEST_ID) || !data.containsKey(DATA_FIELD_PROPOSAL_ID)) {
 			return param;
 		}
 		int proposalId = Integer.parseInt(data.get(DATA_FIELD_PROPOSAL_ID));
@@ -108,7 +107,8 @@ public class CompletionResolveHandler {
 		if (completionResponse == null || completionResponse.getProposals().size() <= proposalId) {
 			throw new IllegalStateException("Invalid completion proposal");
 		}
-		String uri = data.get(DATA_FIELD_URI);
+
+		String uri = completionResponse.getUri();
 		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(uri);
 		if (unit == null) {
 			throw new IllegalStateException(NLS.bind("Unable to match Compilation Unit from {0} ", uri));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
@@ -30,6 +30,7 @@ public class CompletionResponse {
 	private Long id;
 	private int offset;
 	private CompletionContext context;
+	private String uri;
 	private List<CompletionProposal> proposals;
 	private List<CompletionItem> items;
 
@@ -55,6 +56,18 @@ public class CompletionResponse {
 	 */
 	public void setContext(CompletionContext context) {
 		this.context = context;
+	}
+	/**
+	 * the uri of the document.
+	 */
+	public String getUri() {
+		return uri;
+	}
+	/**
+	 * @param uri the document uri to set.
+	 */
+	public void setUri(String uri) {
+		this.uri = uri;
 	}
 	/**
 	 * @return the proposals

--- a/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
+++ b/org.eclipse.jdt.ls.tests.syntaxserver/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxServerTest.java
@@ -316,7 +316,6 @@ public class SyntaxServerTest extends AbstractSyntaxProjectsManagerBasedTest {
 			@SuppressWarnings("unchecked")
 			Map<String,String> data = (Map<String, String>) item.getData();
 			assertNotNull(data);
-			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_URI)));
 			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID)));
 			assertTrue(StringUtils.isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID)));
 		}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -264,7 +264,6 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			@SuppressWarnings("unchecked")
 			Map<String,String> data = (Map<String, String>) item.getData();
 			assertNotNull(data);
-			assertTrue(isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_URI)));
 			assertTrue(isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID)));
 			assertTrue(isNotBlank(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID)));
 		}
@@ -283,15 +282,13 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		assertNotNull(list);
 		assertFalse("No proposals were found",list.getItems().isEmpty());
 
-		List<CompletionItem> items = new ArrayList<>(list.getItems());
-		for ( CompletionItem item : items) {
-			@SuppressWarnings("unchecked")
-			Map<String,String> data = (Map<String, String>) item.getData();
-			assertNotNull(data);
-			String uri = data.get(CompletionResolveHandler.DATA_FIELD_URI);
-			assertTrue(isNotBlank(uri));
-			assertTrue("unexpected URI prefix: " + uri, uri.matches("file://.*/src/java/Foo\\.java"));
-		}
+		Map<String,String> data = (Map<String, String>) list.getItems().get(0).getData();
+		long requestId = Long.parseLong(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID));
+		CompletionResponse completionResponse = CompletionResponses.get(requestId);
+		assertNotNull(completionResponse);
+		String uri = completionResponse.getUri();
+		assertNotNull(uri);
+		assertTrue("unexpected URI prefix: " + uri, uri.matches("file://.*/src/java/Foo\\.java"));
 	}
 
 


### PR DESCRIPTION
- instead of storing the uri into the data field of each completion item, now we store the uri into the CompletionResponse, and get it during resolving.
- Triggering completion via 'S' in Spring Petclinic project, the response (textDocument/completion) data size can be reduced from 3.05MB to 2.63MB. (Directly copy the trace to a text file)