### PR TITLE
Add syserr postfix completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplate.java
@@ -26,6 +26,7 @@ public enum PostfixTemplate {
 	NNULL(PostfixPreferences.NNULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NNULL_CONTENT, PostfixPreferences.NNULL_DESCRIPTION),
 	NULL(PostfixPreferences.NULL_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.NULL_CONTENT, PostfixPreferences.NULL_DESCRIPTION),
 	SYSOUT(PostfixPreferences.SYSOUT_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.SYSOUT_CONTENT, PostfixPreferences.SYSOUT_DESCRIPTION),
+	SYSERR(PostfixPreferences.SYSERR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.SYSERR_CONTENT, PostfixPreferences.SYSERR_DESCRIPTION),
 	THROW(PostfixPreferences.THROW_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.THROW_CONTENT, PostfixPreferences.THROW_DESCRIPTION),
 	VAR(PostfixPreferences.VAR_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.VAR_CONTENT, PostfixPreferences.VAR_DESCRIPTION),
 	WHILE(PostfixPreferences.WHILE_ID, JavaPostfixContextType.ID_ALL, PostfixPreferences.WHILE_CONTENT, PostfixPreferences.WHILE_DESCRIPTION);
@@ -63,6 +64,7 @@ class PostfixPreferences {
 	public static final String NNULL_ID = "org.eclipse.jdt.postfixcompletion.nnull";
 	public static final String NULL_ID = "org.eclipse.jdt.postfixcompletion.null";
 	public static final String SYSOUT_ID = "org.eclipse.jdt.postfixcompletion.sysout";
+	public static final String SYSERR_ID = "org.eclipse.jdt.postfixcompletion.syserr";
 	public static final String THROW_ID = "org.eclipse.jdt.postfixcompletion.throw";
 	public static final String VAR_ID = "org.eclipse.jdt.postfixcompletion.var";
 	public static final String WHILE_ID = "org.eclipse.jdt.postfixcompletion.while";
@@ -91,6 +93,7 @@ class PostfixPreferences {
 		"\t$${0}\n" +
 	"}";
 	public static final String SYSOUT_CONTENT = "System.out.println(${i:inner_expression(java.lang.Object)}${});$${0}";
+	public static final String SYSERR_CONTENT = "System.err.println(${i:inner_expression(java.lang.Object)}${});$${0}";
 	public static final String THROW_CONTENT = "throw ${true:inner_expression(java.lang.Throwable)};";
 	public static final String VAR_CONTENT = "${field:newType(inner_expression)} $${1:${var:newName(inner_expression)}} = ${inner_expression};$${0}";
 	public static final String WHILE_CONTENT = "while (${i:inner_expression(boolean)}) {\n" +
@@ -107,6 +110,7 @@ class PostfixPreferences {
 	public static final String NNULL_DESCRIPTION = "Creates an if statement and checks if the expression does not resolve to null";
 	public static final String NULL_DESCRIPTION = "Creates an if statement which checks if expression resolves to null";
 	public static final String SYSOUT_DESCRIPTION = "Sends the affected object to a System.out.println(..) call";
+	public static final String SYSERR_DESCRIPTION = "Sends the affected object to a System.err.println(..) call";
 	public static final String THROW_DESCRIPTION = "Throws the given Exception";
 	public static final String VAR_DESCRIPTION = "Creates a new variable";
 	public static final String WHILE_DESCRIPTION = "Creates a while loop";

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/PostfixCompletionTest.java
@@ -400,6 +400,33 @@ public class PostfixCompletionTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
+	public void test_syserr_object() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy(
+			"src/org/sample/Test.java",
+			"package org.sample;\n" +
+			"public class Test {\n" +
+			"	public void testMethod(String a) {\n" +
+			"		Boolean foo = true;\n" +
+			"		foo.syserr" +
+			"	}\n" +
+			"}"
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "foo.syserr");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.get(0);
+		assertEquals("syserr", item.getLabel());
+		assertEquals(item.getInsertText(), "System.err.println(foo);${0}");
+		assertEquals(item.getInsertTextFormat(), InsertTextFormat.Snippet);
+		Range range = item.getAdditionalTextEdits().get(0).getRange();
+		assertEquals(new Range(new Position(4, 2), new Position(4, 12)), range);
+	}
+
+	@Test
 	public void test_throw() throws JavaModelException {
 		//@formatter:off
 		ICompilationUnit unit = getWorkingCopy(


### PR DESCRIPTION
Add `.syserr` postfix, to complement the `.sysout` one
![Screenshot 2023-04-26 at 10 21 12](https://user-images.githubusercontent.com/148698/234515657-ffca2bac-a51c-4bba-9e2a-dc1ef3bd9417.png)

https://github.com/eclipse/eclipse.jdt.ls/issues/2288

Signed-off-by: Fred Bricon <fbricon@gmail.com>
