### PR TITLE
Prevent sending shutdown job progress report

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -450,6 +450,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public CompletableFuture<Object> shutdown() {
 		logInfo(">> shutdown");
 		return computeAsync((monitor) -> {
+			shutdownJob.setSystem(true);
 			shutdownJob.schedule();
 			shutdownReceived = true;
 			if (preferenceManager.getClientPreferences().shouldLanguageServerExitOnShutdown()) {
@@ -473,6 +474,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 			}, 1, TimeUnit.MINUTES);
 		}
 		if (!shutdownReceived) {
+			shutdownJob.setSystem(true);
 			shutdownJob.schedule();
 		}
 		try {


### PR DESCRIPTION
Relating to https://github.com/redhat-developer/vscode-java/pull/2586, the status icon could continue spinning after restarting the language server since the shutdown job is never completed. 

This change ensures that the progress report for the shutdown job is never sent to avoid this issue.