### PR TITLE
Get rid of the duplicated COMPLETION_EXECUTION_TIME in completion items

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -280,7 +280,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			response.setProposals(proposals);
 		}
 		response.setItems(completionItems);
-		response.setUri(this.uri);
+		response.setCommonData(CompletionResolveHandler.DATA_FIELD_URI, uri);
 		CompletionResponses.store(response);
 
 		return completionItems;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SnippetCompletionProposal.java
@@ -357,7 +357,7 @@ public class SnippetCompletionProposal extends CompletionProposal {
 
 		response.setProposals(proposals);
 		response.setItems(res);
-		response.setUri(uri);
+		response.setCommonData(CompletionResolveHandler.DATA_FIELD_URI, uri);
 		CompletionResponses.store(response);
 		return res;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corext/template/java/PostfixTemplateEngine.java
@@ -145,7 +145,7 @@ public class PostfixTemplateEngine {
 
 		response.setProposals(proposals);
 		response.setItems(res);
-		response.setUri(JDTUtils.toURI(compilationUnit));
+		response.setCommonData(CompletionResolveHandler.DATA_FIELD_URI, JDTUtils.toURI(compilationUnit));
 		CompletionResponses.store(response);
 		return res;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -121,6 +122,7 @@ public class CompletionHandler{
 			JavaLanguageServerPlugin.logInfo("Completion request completed");
 		}
 		long executionTime = System.currentTimeMillis() - startTime;
+		String lastRequestId = null;
 		for (CompletionItem item : $.getItems()) {
 			String requestId = "";
 			String proposalId = "";
@@ -128,12 +130,27 @@ public class CompletionHandler{
 			if (data != null) {
 				requestId = data.getOrDefault(CompletionResolveHandler.DATA_FIELD_REQUEST_ID, "");
 				proposalId = data.getOrDefault(CompletionResolveHandler.DATA_FIELD_PROPOSAL_ID, "");
-				data.put(CompletionRanking.COMPLETION_EXECUTION_TIME, String.valueOf(executionTime));
+			}
+			if (requestId.isEmpty() || proposalId.isEmpty()) {
+				continue;
 			}
 			item.setCommand(new Command("", "java.completion.onDidSelect", Arrays.asList(
 					requestId,
 					proposalId
 			)));
+
+			if (Objects.equals(requestId, lastRequestId)) {
+				continue;
+			}
+			lastRequestId = requestId;
+			int pId = Integer.parseInt(proposalId);
+			long rId = Long.parseLong(requestId);
+			CompletionResponse completionResponse = CompletionResponses.get(rId);
+			if (completionResponse == null || completionResponse.getProposals().size() <= pId) {
+				JavaLanguageServerPlugin.logError("Failed to save common data for completion items.");
+				continue;
+			}
+			completionResponse.setCommonData(CompletionRanking.COMPLETION_EXECUTION_TIME, String.valueOf(executionTime));
 		}
 		return Either.forRight($);
 	}
@@ -154,6 +171,10 @@ public class CompletionHandler{
 		if (item == null) {
 			throw ExceptionFactory.newException("Cannot get the completion item.");
 		}
+
+		// get the cached completion execution time and set it to the selected item in case that providers need it.
+		String executionTime = completionResponse.getCommonData(CompletionRanking.COMPLETION_EXECUTION_TIME);
+		((Map<String, String>)item.getData()).put(CompletionRanking.COMPLETION_EXECUTION_TIME, executionTime);
 
 		List<ICompletionRankingProvider> providers =
 				((CompletionContributionService) JavaLanguageServerPlugin.getCompletionContributionService()).getRankingProviders();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -174,7 +174,9 @@ public class CompletionHandler{
 
 		// get the cached completion execution time and set it to the selected item in case that providers need it.
 		String executionTime = completionResponse.getCommonData(CompletionRanking.COMPLETION_EXECUTION_TIME);
-		((Map<String, String>)item.getData()).put(CompletionRanking.COMPLETION_EXECUTION_TIME, executionTime);
+		if (executionTime != null) {
+			((Map<String, String>)item.getData()).put(CompletionRanking.COMPLETION_EXECUTION_TIME, executionTime);
+		}
 
 		List<ICompletionRankingProvider> providers =
 				((CompletionContributionService) JavaLanguageServerPlugin.getCompletionContributionService()).getRankingProviders();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -87,6 +87,7 @@ public class CompletionResolveHandler {
 		this.manager = manager;
 	}
 
+	public static final String DATA_FIELD_URI = "uri";
 	public static final String DATA_FIELD_DECLARATION_SIGNATURE = "decl_signature";
 	public static final String DATA_FIELD_SIGNATURE= "signature";
 	public static final String DATA_FIELD_NAME = "name";
@@ -111,7 +112,7 @@ public class CompletionResolveHandler {
 			throw new IllegalStateException("Invalid completion proposal");
 		}
 
-		String uri = completionResponse.getUri();
+		String uri = completionResponse.getCommonData(DATA_FIELD_URI);
 		ICompilationUnit unit = JDTUtils.resolveCompilationUnit(uri);
 		if (unit == null) {
 			throw new IllegalStateException(NLS.bind("Unable to match Compilation Unit from {0} ", uri));

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
@@ -12,7 +12,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.jdt.core.CompletionContext;
@@ -30,7 +32,10 @@ public class CompletionResponse {
 	private Long id;
 	private int offset;
 	private CompletionContext context;
-	private String uri;
+	/**
+	 * Stores the data that are common among the completion items.
+	 */
+	private Map<String, String> commonData = new HashMap<>();
 	private List<CompletionProposal> proposals;
 	private List<CompletionItem> items;
 
@@ -57,18 +62,15 @@ public class CompletionResponse {
 	public void setContext(CompletionContext context) {
 		this.context = context;
 	}
-	/**
-	 * the uri of the document.
-	 */
-	public String getUri() {
-		return uri;
+
+	public String getCommonData(String key) {
+		return this.commonData.get(key);
 	}
-	/**
-	 * @param uri the document uri to set.
-	 */
-	public void setUri(String uri) {
-		this.uri = uri;
+
+	public void setCommonData(String key, String value) {
+		this.commonData.put(key, value);
 	}
+
 	/**
 	 * @return the proposals
 	 */

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.manipulation.CoreASTProvider;
 import org.eclipse.jdt.internal.codeassist.impl.AssistOptions;
+import org.eclipse.jdt.ls.core.contentassist.CompletionRanking;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
@@ -287,9 +288,30 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		long requestId = Long.parseLong(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID));
 		CompletionResponse completionResponse = CompletionResponses.get(requestId);
 		assertNotNull(completionResponse);
-		String uri = completionResponse.getUri();
+		String uri = completionResponse.getCommonData(CompletionResolveHandler.DATA_FIELD_URI);
 		assertNotNull(uri);
 		assertTrue("unexpected URI prefix: " + uri, uri.matches("file://.*/src/java/Foo\\.java"));
+	}
+
+	@Test
+	public void testCompletion_dataFieldExecutionTime() throws Exception {
+		ICompilationUnit unit = getWorkingCopy(
+			"src/java/Foo.java",
+			"public class Foo {\n"+
+				"	void foo() {\n"+
+				"		Objec\n"+
+				"	}\n"+
+				"}\n");
+		CompletionList list = requestCompletions(unit, "Objec");
+		assertNotNull(list);
+		assertFalse("No proposals were found",list.getItems().isEmpty());
+
+		Map<String,String> data = (Map<String, String>) list.getItems().get(0).getData();
+		long requestId = Long.parseLong(data.get(CompletionResolveHandler.DATA_FIELD_REQUEST_ID));
+		CompletionResponse completionResponse = CompletionResponses.get(requestId);
+		assertNotNull(completionResponse);
+		String time = completionResponse.getCommonData(CompletionRanking.COMPLETION_EXECUTION_TIME);
+		assertNotNull(time);
 	}
 
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionRankingProviderTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionRankingProviderTest.java
@@ -87,14 +87,15 @@ public class CompletionRankingProviderTest extends AbstractCompilationUnitBasedT
 		assertTrue(recommended.getLabel().startsWith("★"));
 		assertTrue(((Map)recommended.getData()).containsKey("foo"));
 		assertEquals(recommended.getFilterText(), recommended.getInsertText());
-		assertTrue(((Map)recommended.getData()).containsKey(CompletionRanking.COMPLETION_EXECUTION_TIME));
 	}
 
 	@Test
 	public void testOnDidCompletionItemSelect() throws Exception {
 		CompletionHandler handler = new CompletionHandler(JavaLanguageServerPlugin.getPreferencesManager());
 		CompletionResponse response = new CompletionResponse();
-		response.setItems(Arrays.asList(new CompletionItem()));
+		CompletionItem completionItem = new CompletionItem();
+		completionItem.setData(new HashMap<>());
+		response.setItems(Arrays.asList(completionItem));
 		CompletionResponses.store(response);
 		handler.onDidCompletionItemSelect(String.valueOf(response.getId()), "0");
 


### PR DESCRIPTION
- Now, the server will cache the COMPLETION_EXECUTION_TIME and only set it into the data field when the item is selected in the callback function.

fix #2621 

##### Data size change

Triggering completion via 'S' in Spring Petclinic project, the response (textDocument/completion) data size can be reduced from 2.67MB to 2.54MB. (Directly copy the trace to a text file)