### PR TITLE
No need to run didOpen/didClose/didChange with scheduling rule

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -302,14 +302,13 @@ public abstract class BaseDocumentLifeCycleHandler {
 
 	public void didClose(DidCloseTextDocumentParams params) {
 		documentVersions.remove(params.getTextDocument().getUri());
-		ISchedulingRule rule = JDTUtils.getRule(params.getTextDocument().getUri());
 		try {
 			ResourcesPlugin.getWorkspace().run(new IWorkspaceRunnable() {
 				@Override
 				public void run(IProgressMonitor monitor) throws CoreException {
 					handleClosed(params);
 				}
-			}, rule, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+			}, null, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Handle document close ", e);
 		}
@@ -317,14 +316,13 @@ public abstract class BaseDocumentLifeCycleHandler {
 
 	public void didOpen(DidOpenTextDocumentParams params) {
 		documentVersions.put(params.getTextDocument().getUri(), params.getTextDocument().getVersion());
-		ISchedulingRule rule = JDTUtils.getRule(params.getTextDocument().getUri());
 		try {
 			ResourcesPlugin.getWorkspace().run(new IWorkspaceRunnable() {
 				@Override
 				public void run(IProgressMonitor monitor) throws CoreException {
 					handleOpen(params);
 				}
-			}, rule, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+			}, null, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Handle document open ", e);
 		}
@@ -332,14 +330,13 @@ public abstract class BaseDocumentLifeCycleHandler {
 
 	public void didChange(DidChangeTextDocumentParams params) {
 		documentVersions.put(params.getTextDocument().getUri(), params.getTextDocument().getVersion());
-		ISchedulingRule rule = JDTUtils.getRule(params.getTextDocument().getUri());
 		try {
 			ResourcesPlugin.getWorkspace().run(new IWorkspaceRunnable() {
 				@Override
 				public void run(IProgressMonitor monitor) throws CoreException {
 					handleChanged(params);
 				}
-			}, rule, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+			}, null, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Handle document change ", e);
 		}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JsonRpcHelpers.java
@@ -84,7 +84,7 @@ final public class JsonRpcHelpers {
 			try {
 				return document.getLineOffset(line) + column;
 			} catch (BadLocationException e) {
-				JavaLanguageServerPlugin.logException(e.getMessage(), e);
+				JavaLanguageServerPlugin.debugTrace("toOffset: " + (e.getMessage() == null ? e.toString() : e.getMessage()));
 			}
 		}
 		return -1;
@@ -157,7 +157,7 @@ final public class JsonRpcHelpers {
 				int column = offset - document.getLineOffset(line);
 				return new int[] { line, column };
 			} catch (BadLocationException e) {
-				JavaLanguageServerPlugin.logException(e.getMessage(), e);
+				JavaLanguageServerPlugin.debugTrace("toLine: " + (e.getMessage() == null ? e.toString() : e.getMessage()));
 			}
 		}
 		return null;


### PR DESCRIPTION
As discussed in https://github.com/eclipse/eclipse.jdt.ls/issues/2518 and https://github.com/redhat-developer/vscode-java/issues/3077#issuecomment-1514418268, using scheduling rules in document lifecycle handlers can lead to deadlock and make the language server unresponsive during the build job. I propose to remove the scheduling rules from didOpen/didClose/didChange handlers for these reasons:
-  didOpen/didClose handlers are some trivial tasks, and used to open or discard a workingcopy. It should be fine not to run it with scheduling rule.
- didChange handler has two tasks: syncing the buffer with the text changes, and reconciling the Java Model with the buffer. The second reconcile/validation task was executed in a workspace job and already had a scheduling rule, so the question is whether the first one also needs one. According to the Eclipse implementation, it updates the document buffer without any scheduling rule when the user types code. You can debug the Eclipse behavior by adding a breakpoint on `org.eclipse.core.internal.filebuffers.SynchronizableDocument.replace()` and then typing code in Eclipse. So I think it should be ok for jdt.ls to follow the same approach on buffer synchronization of didChange handler.
- The original PR https://github.com/eclipse/eclipse.jdt.ls/pull/1479 that added the scheduling rules to didOpen/didClose/didChange was for performance improvement. That means the language server had no functional issues before the scheduling rules were introduced. Since they have more negative impact on performance, it’s worth trying to remove them.