### PR TITLE
Only append data on completion item selected

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/CompletionRanking.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/CompletionRanking.java
@@ -105,7 +105,10 @@ public class CompletionRanking {
 	/**
 	 * A map data structure that will be appended to completion item's data field. When a completion
 	 * item is selected, the selected item will be passed to the provider. Providers can use the stored
-	 * data to do post process on demand.
+	 * data to do post process on demand. Please note that the data will only be appended when item
+	 * selected event happens. The data will not exist during textDocument/completion and completionItem/resolve
+	 * phases.
+	 *
 	 * <p>
 	 * The key <code>"COMPLETION_EXECUTION_TIME"</code> is preserved to store the time calculating all the
 	 * completion items at the server side in millisecond.

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -244,6 +245,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		if (!proposals.isEmpty()){
 			initializeCompletionListItemDefaults(proposals.get(0));
 		}
+
+		List<Map<String, String>> contributedData = new LinkedList<>();
 		//Let's compute replacement texts for the most relevant results only
 		for (int i = 0; i < limit; i++) {
 			CompletionProposal proposal = proposals.get(i);
@@ -260,11 +263,8 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 							item.setFilterText(item.getInsertText());
 						}
 					}
-					Map<String, String> itemData = (Map<String, String>) item.getData();
 					Map<String, String> rankingData = rankingResult.getData();
-					for (String key : rankingData.keySet()) {
-						itemData.put(key, rankingData.get(key));
-					}
+					contributedData.add(rankingData);
 				}
 				completionItems.add(item);
 			} catch (Exception e) {
@@ -281,6 +281,7 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 		}
 		response.setItems(completionItems);
 		response.setCommonData(CompletionResolveHandler.DATA_FIELD_URI, uri);
+		response.setCompletionItemData(contributedData);
 		CompletionResponses.store(response);
 
 		return completionItems;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -178,6 +178,11 @@ public class CompletionHandler{
 			((Map<String, String>)item.getData()).put(CompletionRanking.COMPLETION_EXECUTION_TIME, executionTime);
 		}
 
+		Map<String, String> contributedData = completionResponse.getCompletionItemData(pId);
+		if (contributedData != null) {
+			((Map<String, String>)item.getData()).putAll(contributedData);
+		}
+
 		List<ICompletionRankingProvider> providers =
 				((CompletionContributionService) JavaLanguageServerPlugin.getCompletionContributionService()).getRankingProviders();
 		for (ICompletionRankingProvider provider : providers) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -93,8 +93,6 @@ public class CompletionResolveHandler {
 	public static final String DATA_FIELD_NAME = "name";
 	public static final String DATA_FIELD_REQUEST_ID = "rid";
 	public static final String DATA_FIELD_PROPOSAL_ID = "pid";
-	public static final String DATA_FIELD_CONSTANT_VALUE = "constant_value";
-	public static final String DATA_METHOD_DEFAULT_VALUE = "default_value";
 
 	public CompletionItem resolve(CompletionItem param, IProgressMonitor monitor) {
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResponse.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ls.core.internal.handlers;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,11 @@ public class CompletionResponse {
 	private Map<String, String> commonData = new HashMap<>();
 	private List<CompletionProposal> proposals;
 	private List<CompletionItem> items;
+	/**
+	 * Stores the data that are specific to each completion item.
+	 * Those data are contributed by the ranking providers.
+	 */
+	private List<Map<String, String>> completionItemData;
 
 	public CompletionResponse() {
 		id = idSeed.getAndIncrement();
@@ -108,5 +114,16 @@ public class CompletionResponse {
 	 */
 	public void setItems(List<CompletionItem> items) {
 		this.items = items;
+	}
+
+	public Map<String, String> getCompletionItemData(int index) {
+		if (completionItemData == null || index >= completionItemData.size()) {
+			return Collections.emptyMap();
+		}
+		return completionItemData.get(index);
+	}
+
+	public void setCompletionItemData(List<Map<String, String>> completionItemData) {
+		this.completionItemData = completionItemData;
 	}
 }


### PR DESCRIPTION
- Instead of adding data to the completion items directly, now we only append those data when 'onDidSelect' happens. Because those data are only used by the registered ranking providers. Both server and client do not care about it actually.