### PR TITLE
Use separate thread to handle didChangeWatchedFiles events

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -171,6 +171,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	private LanguageServerWorkingCopyOwner workingCopyOwner;
 	private PreferenceManager preferenceManager;
 	private DocumentLifeCycleHandler documentLifeCycleHandler;
+	private WorkspaceEventsHandler workspaceEventHandler;
 	private WorkspaceDiagnosticsHandler workspaceDiagnosticsHandler;
 	private ClasspathUpdateHandler classpathUpdateHandler;
 	private JVMConfigurator jvmConfigurator;
@@ -241,6 +242,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 		pm.setConnection(client);
 		WorkingCopyOwner.setPrimaryBufferProvider(this.workingCopyOwner);
 		this.documentLifeCycleHandler = new DocumentLifeCycleHandler(this.client, preferenceManager, pm, true);
+		this.workspaceEventHandler = new WorkspaceEventsHandler(pm, this.client, this.documentLifeCycleHandler);
 		this.telemetryManager.setLanguageClient(client);
 		this.telemetryManager.setPreferenceManager(preferenceManager);
 	}
@@ -573,8 +575,7 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
 		debugTrace(">> workspace/didChangeWatchedFiles ");
-		WorkspaceEventsHandler handler = new WorkspaceEventsHandler(pm, client, this.documentLifeCycleHandler);
-		handler.didChangeWatchedFiles(params);
+		this.workspaceEventHandler.didChangeWatchedFiles(params);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/syntaxserver/SyntaxLanguageServer.java
@@ -104,6 +104,7 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 	public static final String JAVA_LSP_JOIN_ON_COMPLETION = "java.lsp.joinOnCompletion";
 
 	private SyntaxDocumentLifeCycleHandler documentLifeCycleHandler;
+	private WorkspaceEventsHandler workspaceEventHandler;
 	private ContentProviderManager contentProviderManager;
 	private ProjectsManager projectsManager;
 	private PreferenceManager preferenceManager;
@@ -261,6 +262,7 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 	public void connectClient(JavaLanguageClient client) {
 		super.connectClient(client);
 		this.documentLifeCycleHandler.setClient(this.client);
+		this.workspaceEventHandler = new WorkspaceEventsHandler(this.projectsManager, this.client, this.documentLifeCycleHandler);
 	}
 
 	@Override
@@ -279,8 +281,7 @@ public class SyntaxLanguageServer extends BaseJDTLanguageServer implements Langu
 	@Override
 	public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
 		logInfo(">> workspace/didChangeWatchedFiles ");
-		WorkspaceEventsHandler handler = new WorkspaceEventsHandler(this.projectsManager, this.client, this.documentLifeCycleHandler);
-		handler.didChangeWatchedFiles(params);
+		this.workspaceEventHandler.didChangeWatchedFiles(params);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceEventHandlerTest.java
@@ -96,8 +96,7 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		File javaFile = new File(projectFile, "src/org/sample/Foo.java");
 		FileUtils.writeStringToFile(javaFile, source);
 		String uri = JDTUtils.toURI(unit);
-		DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(Arrays.asList(new FileEvent(uri, FileChangeType.Changed)));
-		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).didChangeWatchedFiles(params);
+		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).handleFileEvents(new FileEvent(uri, FileChangeType.Changed));
 		waitForBackgroundJobs();
 		assertTrue(classFile.lastModified() > lastModified);
 	}
@@ -124,12 +123,11 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		File newPack = new File(oldPack.getParent(), "mynewpack");
 		Files.move(oldPack, newPack);
 		assertTrue(unit.isWorkingCopy());
-		DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(Arrays.asList(
+		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).handleFileEvents(
 			new FileEvent(newUri, FileChangeType.Created),
 			new FileEvent(parentUri, FileChangeType.Changed),
 			new FileEvent(oldUri, FileChangeType.Deleted)
-		));
-		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).didChangeWatchedFiles(params);
+		);
 		assertFalse(unit.isWorkingCopy());
 	}
 
@@ -145,10 +143,7 @@ public class WorkspaceEventHandlerTest extends AbstractProjectsManagerBasedTest 
 		assertTrue(module2.exists());
 
 		clientRequests.clear();
-		DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(Arrays.asList(
-			new FileEvent(projectUri, FileChangeType.Deleted)
-		));
-		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).didChangeWatchedFiles(params);
+		new WorkspaceEventsHandler(projectsManager, javaClient, lifeCycleHandler).handleFileEvents(new FileEvent(projectUri, FileChangeType.Deleted));
 		waitForBackgroundJobs();
 		assertFalse(module2.exists());
 


### PR DESCRIPTION
See https://github.com/eclipse/eclipse.jdt.ls/issues/2518#issuecomment-1538440813, executing the file event handler in the default dispatch thread may block the jsonrpc reader. To avoid the deadlock, use a separate thread to handle didChangeWatchedFiles events.