### PR TITLE
Remove unnecessary completion item data field

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -15,7 +15,6 @@
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
 import java.lang.reflect.Field;
-import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.CompletionContext;
@@ -26,7 +25,6 @@ import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
-import org.eclipse.jdt.ls.core.internal.handlers.CompletionResolveHandler;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.CompletionItem;
@@ -360,9 +358,6 @@ public class CompletionProposalDescriptionProvider {
 		detail.append(description);
 		item.setDetail(detail.toString());
 
-		setSignature(item, String.valueOf(methodProposal.getSignature()));
-		setDeclarationSignature(item, String.valueOf(methodProposal.getDeclarationSignature()));
-		setName(item, String.valueOf(methodProposal.getName()));
 		if (fUnit != null && methodProposal.isConstructor() && typeInfo.length() > 0 && item.getData() != null && methodProposal.getRequiredProposals() != null && methodProposal.getRequiredProposals().length > 0) {
 			CompletionProposal requiredProposal = methodProposal.getRequiredProposals()[0];
 			try {
@@ -434,10 +429,6 @@ public class CompletionProposalDescriptionProvider {
 		declaringType= Signature.getSimpleName(declaringType);
 		typeBuffer.append(String.format("Override method in '%s'", declaringType));
 		item.setDetail(typeBuffer.toString());
-
-		setSignature(item, String.valueOf(methodProposal.getSignature()));
-		setDeclarationSignature(item, String.valueOf(methodProposal.getDeclarationSignature()));
-		setName(item, String.valueOf(methodProposal.getName()));
 	}
 
 	/**
@@ -483,7 +474,6 @@ public class CompletionProposalDescriptionProvider {
 		}
 		char[] fullName= Signature.toCharArray(signature);
 		createTypeProposalLabel(fullName, item);
-		setDeclarationSignature(item, String.valueOf(signature));
 	}
 
 	private void createJavadocTypeProposalLabel(CompletionProposal typeProposal, CompletionItem item) {
@@ -606,7 +596,6 @@ public class CompletionProposalDescriptionProvider {
 		char[] declaration= proposal.getDeclarationSignature();
 		StringBuilder detailBuf = new StringBuilder();
 		if (declaration != null) {
-			setDeclarationSignature(item, String.valueOf(declaration));
 			declaration= Signature.getSignatureSimpleName(declaration);
 			if (declaration.length > 0) {
 				if (proposal.getRequiredProposals() != null) {
@@ -625,7 +614,6 @@ public class CompletionProposalDescriptionProvider {
 		}
 		detailBuf.append(buf);
 		item.setDetail(detailBuf.toString());
-		setName(item,String.valueOf(name));
 	}
 
 	private void createPackageProposalLabel(CompletionProposal proposal, CompletionItem item) {
@@ -675,7 +663,6 @@ public class CompletionProposalDescriptionProvider {
 				item.setDetail(String.valueOf(signatureQualifier) + "." + name);
 			}
 		}
-		setDeclarationSignature(item, String.valueOf(declaringTypeSignature));
 	}
 
 	private void createLabelWithLambdaExpression(CompletionProposal proposal, CompletionItem item) {
@@ -692,35 +679,6 @@ public class CompletionProposalDescriptionProvider {
 			label.append(returnType);
 			item.setLabel(label.toString());
 		}
-	}
-
-	/**
-	 * Sets the signature for use on the resolve call.
-	 * @param item
-	 * @param signature
-	 */
-	@SuppressWarnings("unchecked")
-	private void setSignature(CompletionItem item, String signature){
-		((Map<String, String>)item.getData()).put(CompletionResolveHandler.DATA_FIELD_SIGNATURE,String.valueOf(signature));
-	}
-	/**
-	 * Sets the declaration signature to data that is used on the resolve call.
-	 * @param item
-	 * @param signature
-	 */
-	@SuppressWarnings("unchecked")
-	private void setDeclarationSignature(CompletionItem item, String signature){
-		((Map<String, String>)item.getData()).put(CompletionResolveHandler.DATA_FIELD_DECLARATION_SIGNATURE,String.valueOf(signature));
-	}
-
-	/**
-	 * Sets the name to data that is used on the resolve call.
-	 * @param item
-	 * @param name
-	 */
-	@SuppressWarnings("unchecked")
-	private void setName(CompletionItem item, String name){
-		((Map<String, String>)item.getData()).put(CompletionResolveHandler.DATA_FIELD_NAME,String.valueOf(name));
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2021 Red Hat Inc. and others.
+ * Copyright (c) 2016-2023 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -67,13 +67,12 @@ import org.eclipse.osgi.util.NLS;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
+
 /**
  * Adds the completion string and documentation.
  * It checks the client capabilities.
  * If a client supports both SnippetStrings and SignatureHelp
  * SnippetStrings are prioritized for handling parameters.
- *
- *
  */
 @SuppressWarnings("restriction")
 public class CompletionResolveHandler {
@@ -88,9 +87,6 @@ public class CompletionResolveHandler {
 	}
 
 	public static final String DATA_FIELD_URI = "uri";
-	public static final String DATA_FIELD_DECLARATION_SIGNATURE = "decl_signature";
-	public static final String DATA_FIELD_SIGNATURE= "signature";
-	public static final String DATA_FIELD_NAME = "name";
 	public static final String DATA_FIELD_REQUEST_ID = "rid";
 	public static final String DATA_FIELD_PROPOSAL_ID = "pid";
 
@@ -120,11 +116,11 @@ public class CompletionResolveHandler {
 			return param;
 		}
 
+		CompletionProposal proposal = completionResponse.getProposals().get(proposalId);
 		// generic snippets
 		if (param.getKind() == CompletionItemKind.Snippet) {
 			try {
 				CompletionContext ctx = completionResponse.getContext();
-				CompletionProposal proposal = completionResponse.getProposals().get(proposalId);
 				if (proposal instanceof SnippetCompletionProposal) {
 					Template template = ((SnippetCompletionProposal) proposal).getTemplate();
 					String content = SnippetCompletionProposal.evaluateGenericTemplate(unit, ctx, template);
@@ -176,7 +172,7 @@ public class CompletionResolveHandler {
 				manager.getClientPreferences(),
 				true
 			);
-			proposalProvider.updateReplacement(completionResponse.getProposals().get(proposalId), param, '\0');
+			proposalProvider.updateReplacement(proposal, param, '\0');
 		}
 
 		if (!manager.getClientPreferences().isCompletionResolveDocumentSupport()) {
@@ -184,17 +180,29 @@ public class CompletionResolveHandler {
 		}
 
 		// below code is for resolving documentation
-		if (data.containsKey(DATA_FIELD_DECLARATION_SIGNATURE)) {
-			String typeName = stripSignatureToFQN(String.valueOf(data.get(DATA_FIELD_DECLARATION_SIGNATURE)));
-			try {
-				IMember member = null;
-				IType type = unit.getJavaProject().findType(typeName);
-
-				CompletionProposal proposal = completionResponse.getProposals().get(proposalId);
-				if (type!=null && data.containsKey(DATA_FIELD_NAME)) {
-					String name = data.get(DATA_FIELD_NAME);
-					String[] paramSigs = CharOperation.NO_STRINGS;
-					if(data.containsKey( DATA_FIELD_SIGNATURE)){
+		IMember member = null;
+		if (proposal.getKind() == CompletionProposal.TYPE_REF) {
+			char[] signature = proposal.getSignature();
+			if (signature != null) {
+				String typeName = stripSignatureToFQN(String.valueOf(signature));
+				try {
+					IType type = unit.getJavaProject().findType(typeName);
+					if (type != null) {
+						member = type;
+					}
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.logException(e.getMessage(), e);
+					return param;
+				}
+			}
+		} else {
+			char[] declarationSignature = proposal.getDeclarationSignature();
+			if (declarationSignature != null) {
+				String typeName = stripSignatureToFQN(String.valueOf(declarationSignature));
+				try {
+					IType type = unit.getJavaProject().findType(typeName);
+					if (type != null && proposal.getName() != null) {
+						String[] paramSigs = CharOperation.NO_STRINGS;
 						if (proposal instanceof InternalCompletionProposal internalProposal) {
 							Binding binding = internalProposal.getBinding();
 							if (binding instanceof MethodBinding methodBinding) {
@@ -212,114 +220,112 @@ public class CompletionResolveHandler {
 								paramSigs = parameters;
 							}
 						}
-					}
-					IMethod method = type.getMethod(name, paramSigs);
-					IMethod[] methods = type.findMethods(method);
-					if (methods != null && methods.length > 0) {
-						method = methods[0];
-					}
-					if (method.exists()) {
-						member = method;
-					} else {
-						IField field = type.getField(name);
-						if (field.exists()) {
-							member = field;
+						String name = String.valueOf(proposal.getName());
+						IMethod method = type.getMethod(name, paramSigs);
+						IMethod[] methods = type.findMethods(method);
+						if (methods != null && methods.length > 0) {
+							method = methods[0];
+						}
+						if (method.exists()) {
+							member = method;
+						} else {
+							IField field = type.getField(name);
+							if (field.exists()) {
+								member = field;
+							}
 						}
 					}
-				} else {
-					member = type;
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.logException(e.getMessage(), e);
+					return param;
 				}
-
-				if (member != null && member.exists() && !monitor.isCanceled()) {
-					String javadoc = null;
-					try {
-						final IMember curMember = member;
-						javadoc = SimpleTimeLimiter.create(JavaLanguageServerPlugin.getExecutorService()).callWithTimeout(() -> {
-							Reader reader;
-							if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
-								reader = JavadocContentAccess2.getMarkdownContentReader(curMember);
-							} else {
-								reader = JavadocContentAccess.getPlainTextContentReader(curMember);
-							}
-							return reader == null? null:CharStreams.toString(reader);
-						}, 500, TimeUnit.MILLISECONDS);
-					} catch (UncheckedTimeoutException | TimeoutException tooSlow) {
-						//Ignore error for now as it's spamming clients on content assist.
-						//TODO cache javadoc resolution results?
-						//JavaLanguageServerPlugin.logError("Unable to get documentation under 500ms");
-						monitor.setCanceled(true);
-					} catch (Exception e) {
-						JavaLanguageServerPlugin.logException("Unable to read documentation", e);
-						monitor.setCanceled(true);
-					}
-
-					String constantValue = null;
-					if (proposal.getKind() == CompletionProposal.FIELD_REF) {
-						try {
-							IField field = JDTUtils.resolveField(proposal, unit.getJavaProject());
-							Region nameRegion = null;
-							if (field != null) {
-								ITypeRoot typeRoot = field.getTypeRoot();
-								ISourceRange nameRange = ((ISourceReference) field).getNameRange();
-								if (SourceRange.isAvailable(nameRange)) {
-									nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
-								}
-								constantValue = JDTUtils.getConstantValue(field, typeRoot, nameRegion);
-							}
-						} catch (JavaModelException e) {
-							JavaLanguageServerPlugin.log(e);
-						}
-					}
-					if (constantValue != null) {
-						if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
-							javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + "\n\n" + VALUE + constantValue;
-						} else {
-							javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + VALUE + constantValue;
-						}
-					}
-
-					String defaultValue = null;
-					if (proposal.getKind() == CompletionProposal.METHOD_REF || proposal.getKind() == CompletionProposal.ANNOTATION_ATTRIBUTE_REF) {
-						try {
-							IMethod method = JDTUtils.resolveMethod(proposal, unit.getJavaProject());
-							Region nameRegion = null;
-							if (method != null) {
-								ITypeRoot typeRoot = method.getTypeRoot();
-								ISourceRange nameRange = ((ISourceReference) method).getNameRange();
-								if (SourceRange.isAvailable(nameRange)) {
-									nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
-								}
-								defaultValue = JDTUtils.getAnnotationMemberDefaultValue(method, typeRoot, nameRegion);
-							}
-						} catch (JavaModelException e) {
-							JavaLanguageServerPlugin.log(e);
-						}
-					}
-					if (defaultValue != null) {
-						if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
-							javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + "\n\n" + DEFAULT + defaultValue;
-						} else {
-							javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + DEFAULT + defaultValue;
-						}
-					}
-					if (javadoc != null) {
-						if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
-							MarkupContent markupContent = new MarkupContent();
-							markupContent.setKind(MarkupKind.MARKDOWN);
-							markupContent.setValue(javadoc);
-							param.setDocumentation(markupContent);
-						} else {
-							param.setDocumentation(javadoc);
-						}
-					}
-				}
-			} catch (JavaModelException e) {
-				JavaLanguageServerPlugin.logException("Unable to resolve compilation", e);
-				monitor.setCanceled(true);
 			}
 		}
-		if (monitor.isCanceled()) {
-			param.setData(null);
+
+		if (member != null && member.exists() && !monitor.isCanceled()) {
+			String javadoc = null;
+			try {
+				final IMember curMember = member;
+				javadoc = SimpleTimeLimiter.create(JavaLanguageServerPlugin.getExecutorService()).callWithTimeout(() -> {
+					Reader reader;
+					if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
+						reader = JavadocContentAccess2.getMarkdownContentReader(curMember);
+					} else {
+						reader = JavadocContentAccess.getPlainTextContentReader(curMember);
+					}
+					return reader == null? null:CharStreams.toString(reader);
+				}, 500, TimeUnit.MILLISECONDS);
+			} catch (UncheckedTimeoutException | TimeoutException tooSlow) {
+				//Ignore error for now as it's spamming clients on content assist.
+				//TODO cache javadoc resolution results?
+				//JavaLanguageServerPlugin.logError("Unable to get documentation under 500ms");
+				return param;
+			} catch (Exception e) {
+				JavaLanguageServerPlugin.logException("Unable to read documentation", e);
+				return param;
+			}
+
+			String constantValue = null;
+			if (proposal.getKind() == CompletionProposal.FIELD_REF) {
+				try {
+					IField field = JDTUtils.resolveField(proposal, unit.getJavaProject());
+					Region nameRegion = null;
+					if (field != null) {
+						ITypeRoot typeRoot = field.getTypeRoot();
+						ISourceRange nameRange = ((ISourceReference) field).getNameRange();
+						if (SourceRange.isAvailable(nameRange)) {
+							nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
+						}
+						constantValue = JDTUtils.getConstantValue(field, typeRoot, nameRegion);
+					}
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.log(e);
+					return param;
+				}
+			}
+			if (constantValue != null) {
+				if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
+					javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + "\n\n" + VALUE + constantValue;
+				} else {
+					javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + VALUE + constantValue;
+				}
+			}
+
+			String defaultValue = null;
+			if (proposal.getKind() == CompletionProposal.METHOD_REF || proposal.getKind() == CompletionProposal.ANNOTATION_ATTRIBUTE_REF) {
+				try {
+					IMethod method = JDTUtils.resolveMethod(proposal, unit.getJavaProject());
+					Region nameRegion = null;
+					if (method != null) {
+						ITypeRoot typeRoot = method.getTypeRoot();
+						ISourceRange nameRange = ((ISourceReference) method).getNameRange();
+						if (SourceRange.isAvailable(nameRange)) {
+							nameRegion = new Region(nameRange.getOffset(), nameRange.getLength());
+						}
+						defaultValue = JDTUtils.getAnnotationMemberDefaultValue(method, typeRoot, nameRegion);
+					}
+				} catch (JavaModelException e) {
+					JavaLanguageServerPlugin.log(e);
+					return param;
+				}
+			}
+			if (defaultValue != null) {
+				if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
+					javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + "\n\n" + DEFAULT + defaultValue;
+				} else {
+					javadoc = (javadoc == null ? EMPTY_STRING : javadoc) + DEFAULT + defaultValue;
+				}
+			}
+			if (javadoc != null) {
+				if (manager.getClientPreferences().isSupportsCompletionDocumentationMarkdown()) {
+					MarkupContent markupContent = new MarkupContent();
+					markupContent.setKind(MarkupKind.MARKDOWN);
+					markupContent.setValue(javadoc);
+					param.setDocumentation(markupContent);
+				} else {
+					param.setDocumentation(javadoc);
+				}
+			}
 		}
 		return param;
 	}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandlerTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.manipulation.CoreASTProvider;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompletionResolveHandlerTest extends AbstractCompilationUnitBasedTest {
+
+	private JavaClientConnection javaClient;
+	private static String COMPLETION_TEMPLATE =
+			"{\n" +
+					"    \"id\": \"1\",\n" +
+					"    \"method\": \"textDocument/completion\",\n" +
+					"    \"params\": {\n" +
+					"        \"textDocument\": {\n" +
+					"            \"uri\": \"${file}\"\n" +
+					"        },\n" +
+					"        \"position\": {\n" +
+					"            \"line\": ${line},\n" +
+					"            \"character\": ${char}\n" +
+					"        }\n" +
+					"    },\n" +
+					"    \"jsonrpc\": \"2.0\"\n" +
+					"}";
+
+	@Before
+	public void setUp() {
+		CoreASTProvider sharedASTProvider = CoreASTProvider.getInstance();
+		sharedASTProvider.disposeAST();
+		javaClient = new JavaClientConnection(client);
+		preferences.setPostfixCompletionEnabled(false);
+		when(preferenceManager.getClientPreferences().isCompletionResolveDocumentSupport()).thenReturn(true);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		javaClient.disconnect();
+	}
+
+	@Test
+	public void testSnippet_while_itemDefaults_enabled_generic_snippets() throws JavaModelException {
+		//@formatter:off
+		ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", """
+				package org.sample;
+				public class Test {
+					/**
+					 * This is a test.
+					 */
+					private int a;
+					public void test(int a) {
+						a
+					}
+				}"""
+		);
+		//@formatter:on
+		CompletionList list = requestCompletions(unit, "\ta");
+
+		assertNotNull(list);
+
+		List<CompletionItem> items = new ArrayList<>(list.getItems());
+		CompletionItem item = items.stream().filter(i -> "this.a".equals(i.getInsertText())).findFirst().get();
+
+		CompletionItem resolved = server.resolveCompletionItem(item).join();
+		assertEquals("This is a test.", resolved.getDocumentation().getLeft().trim());
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
+		return requestCompletions(unit, completeBehind, 0);
+	}
+
+	private CompletionList requestCompletions(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
+		int[] loc = findCompletionLocation(unit, completeBehind, fromIndex);
+		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+	}
+
+	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {
+		return COMPLETION_TEMPLATE.replace("${file}", JDTUtils.toURI(unit))
+				.replace("${line}", String.valueOf(line))
+				.replace("${char}", String.valueOf(kar));
+	}
+
+}


### PR DESCRIPTION
- The signature information is not needed to store in the completion item data field. It can be retrieved from the proposal that stored in the completion response cache.

fix #2645 
fix #2638 

Complete after a string variable. the response data can be reduced from **83.7KB** to **70.4KB**