### PR TITLE
Add quickfix to convert lambda block to expression

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpRegistry.java
@@ -50,6 +50,7 @@ public class CleanUpRegistry {
 		cleanUpsList.add(new InstanceofPatternMatch());
 		cleanUpsList.add(new LambdaExpressionCleanup());
 		cleanUpsList.add(new TryWithResourceCleanUp());
+		cleanUpsList.add(new LambdaExpressionAndMethodRefCleanUp());
 
 		// Store in a Map so that they can be accessed by ID quickly
 		cleanUps = new HashMap<>();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionAndMethodRefCleanUp.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionAndMethodRefCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Red Hat Inc. and others.
+ * Copyright (c) 2023 Red Hat Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -19,19 +19,19 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.manipulation.CleanUpContextCore;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
-import org.eclipse.jdt.internal.corext.fix.LambdaExpressionsFixCore;
+import org.eclipse.jdt.internal.corext.fix.LambdaExpressionAndMethodRefFixCore;
 
 /**
- * Represents a cleanup that converts an anonymous class creation to a lambda expression
+ * Represents a cleanup that does several actions to clean up lambda expression
  */
-public class LambdaExpressionCleanup implements ISimpleCleanUp {
+public class LambdaExpressionAndMethodRefCleanUp implements ISimpleCleanUp {
 
 	/* (non-Javadoc)
 	 * @see org.eclipse.jdt.ls.core.internal.cleanup.ISimpleCleanUp#getIdentifier()
 	 */
 	@Override
 	public String getIdentifier() {
-		return "lambdaExpressionFromAnonymousClass";
+		return "lambdaExpression";
 	}
 
 	/* (non-Javadoc)
@@ -43,7 +43,7 @@ public class LambdaExpressionCleanup implements ISimpleCleanUp {
 		if (unit == null) {
 			return null;
 		}
-		return LambdaExpressionsFixCore.createCleanUp(unit, true, false);
+		return LambdaExpressionAndMethodRefFixCore.createCleanUp(unit);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/corrections/proposals/IProposalRelevance.java
@@ -285,6 +285,7 @@ public interface IProposalRelevance {
 	public static final int INSERT_INFERRED_TYPE_ARGUMENTS_ERROR= 1;
 	public static final int RETURN_ALLOCATED_OBJECT_VOID= 1;
 	public static final int CONVERT_TO_IF_RETURN= 1;
+	public static final int LAMBDA_EXPRESSION_AND_METHOD_REF_CLEANUP = 1;
 
 	public static final int CONVERT_TO_MESSAGE_FORMAT= 0;
 	public static final int COPY_ANNOTATION_JAR= 0;

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/cleanup/CleanUpsTest.java
@@ -446,7 +446,7 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 
 		ICompilationUnit unit = pack1.createCompilationUnit("LambdaExpression.java", contents, false, monitor);
 		String uri = unit.getUnderlyingResource().getLocationURI().toString();
-		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("lambdaExpression"), monitor);
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("lambdaExpressionFromAnonymousClass"), monitor);
 		String actual = TextEditUtil.apply(unit, textEdits);
 		String expected = "package test1;\n" //
 				+ "\n" //
@@ -493,7 +493,8 @@ public class CleanUpsTest extends AbstractMavenBasedTest {
 
 		ICompilationUnit unit = pack1.createCompilationUnit("MultiCleanup.java", contents, false, monitor);
 		String uri = unit.getUnderlyingResource().getLocationURI().toString();
-		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("lambdaExpression", "instanceofPatternMatch", "stringConcatToTextBlock", "addFinalModifier"), monitor);
+		List<TextEdit> textEdits = registry.getEditsForAllActiveCleanUps(new TextDocumentIdentifier(uri), Arrays.asList("lambdaExpressionFromAnonymousClass", "instanceofPatternMatch", "stringConcatToTextBlock", "addFinalModifier"),
+				monitor);
 		String actual = TextEditUtil.apply(unit, textEdits);
 		String expected = "package test1;\n"
 				+ "\n"

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambdaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/ConvertMethodReferenceToLambdaTest.java
@@ -34,7 +34,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ConvertMethodReferenceToLambaTest extends AbstractQuickFixTest {
+public class ConvertMethodReferenceToLambdaTest extends AbstractQuickFixTest {
 	private IJavaProject fJProject;
 	private IPackageFragmentRoot fSourceFolder;
 
@@ -73,7 +73,7 @@ public class ConvertMethodReferenceToLambaTest extends AbstractQuickFixTest {
 		assertEquals(2, codeActions.size());
 		Either<Command, CodeAction> codeAction = codeActions.get(0);
 		CodeAction action = codeAction.getRight();
-		assertEquals(CodeActionKind.QuickFix, action.getKind());
+		assertEquals(JavaCodeActionKind.QUICK_ASSIST, action.getKind());
 		assertEquals("Convert to lambda expression", action.getTitle());
 		Command c = action.getCommand();
 		assertEquals("java.apply.workspaceEdit", c.getCommand());
@@ -98,14 +98,14 @@ public class ConvertMethodReferenceToLambaTest extends AbstractQuickFixTest {
 		Range range = new Range(new Position(4, 39), new Position(4, 39));
 		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
 		assertEquals(2, codeActions.size());
-		Either<Command, CodeAction> codeAction = codeActions.get(0);
+		Either<Command, CodeAction> codeAction = codeActions.get(1);
 		CodeAction action = codeAction.getRight();
-		assertEquals(CodeActionKind.QuickFix, action.getKind());
-		assertEquals("Convert to method reference", action.getTitle());
+		assertEquals(JavaCodeActionKind.QUICK_ASSIST, action.getKind());
+		assertEquals("Clean up lambda expression", action.getTitle());
 		Command c = action.getCommand();
 		assertEquals("java.apply.workspaceEdit", c.getCommand());
 		assertNotNull(c.getArguments());
-		assertEquals("Convert to method reference", c.getTitle());
+		assertEquals("Clean up lambda expression", c.getTitle());
 	}
 
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LambdaQuickFixTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/correction/LambdaQuickFixTest.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.correction;
+
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LambdaQuickFixTest extends AbstractSelectionTest {
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setup() throws Exception {
+		fJProject1 = newEmptyProject();
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		fJProject1.setOptions(options);
+		fSourceFolder = fJProject1.getPackageFragmentRoot(fJProject1.getProject().getFolder("src"));
+		setOnly(CodeActionKind.Refactor, CodeActionKind.QuickFix);
+	}
+
+	@Test
+	public void testCleanUpLambdaConvertLambdaBlockToExpression() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		setOnly(JavaCodeActionKind.QUICK_ASSIST);
+		//@formatter:off
+		String contents = "package test1;\r\n"
+				+ "interface F1 {\r\n"
+				+ "    int foo1(int a);\r\n"
+				+ "}\r\n"
+				+ "public class E {\r\n"
+				+ "    public void foo(int a) {\r\n"
+				+ "        F1 k = (e) -> {\r\n"
+				+ "            return a;\r\n"
+				+ "        };\r\n"
+				+ "        k.foo1(5);\r\n"
+				+ "    }\r\n"
+				+ "}";
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", contents, false, null);
+		//@formatter:off
+		String expected = "package test1;\r\n"
+				+ "interface F1 {\r\n"
+				+ "    int foo1(int a);\r\n"
+				+ "}\r\n"
+				+ "public class E {\r\n"
+				+ "    public void foo(int a) {\r\n"
+				+ "        F1 k = e -> a;\r\n"
+				+ "        k.foo1(5);\r\n"
+				+ "    }\r\n"
+				+ "}";
+		//@formatter:on
+		Range range = new Range(new Position(7, 16), new Position(7, 16));
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
+		Expected e1 = new Expected("Clean up lambda expression", expected, JavaCodeActionKind.QUICK_ASSIST);
+		assertCodeActions(codeActions, e1);
+	}
+
+	@Test
+	public void testCleanUpLambdaConvertLambdaBlockToExpressionAddParenthesis() throws Exception {
+		IPackageFragment pack1 = fSourceFolder.createPackageFragment("test1", false, null);
+		setOnly(JavaCodeActionKind.QUICK_ASSIST);
+		//@formatter:off
+		String contents = "package test1;\r\n"
+				+ "interface F1 {\r\n"
+				+ "    int foo1(int a);\r\n"
+				+ "}\r\n"
+				+ "public class E {\r\n"
+				+ "    public void foo(int a) {\r\n"
+				+ "        F1 k = (e) -> {\r\n"
+				+ "            return a + 1;\r\n"
+				+ "        };\r\n"
+				+ "        k.foo1(5);\r\n"
+				+ "    }\r\n"
+				+ "}";
+		//@formatter:on
+		ICompilationUnit cu = pack1.createCompilationUnit("E.java", contents, false, null);
+		//@formatter:off
+		String expected = "package test1;\r\n"
+				+ "interface F1 {\r\n"
+				+ "    int foo1(int a);\r\n"
+				+ "}\r\n"
+				+ "public class E {\r\n"
+				+ "    public void foo(int a) {\r\n"
+				+ "        F1 k = e -> (a + 1);\r\n"
+				+ "        k.foo1(5);\r\n"
+				+ "    }\r\n"
+				+ "}";
+		//@formatter:on
+		Range range = new Range(new Position(7, 16), new Position(7, 16));
+		List<Either<Command, CodeAction>> codeActions = evaluateCodeActions(cu, range);
+		Expected e1 = new Expected("Clean up lambda expression", expected, JavaCodeActionKind.QUICK_ASSIST);
+		assertCodeActions(codeActions, e1);
+	}
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandlerTest.java
@@ -635,7 +635,7 @@ public class CodeActionHandlerTest extends AbstractCompilationUnitBasedTest {
 		List<Either<Command, CodeAction>> codeActions = getCodeActions(params);
 
 		Assert.assertNotNull(codeActions);
-		CodeAction action = codeActions.get(1).getRight();
+		CodeAction action = codeActions.get(0).getRight();
 		Assert.assertEquals("Add missing method 'action' to class 'Foo'", action.getTitle());
 	}
 


### PR DESCRIPTION
Fixes #2489
* adds quick fix to convert lambda block to expression when there is exactly one statement within the block

![lambda_block_to_expression_quickfix](https://github.com/eclipse/eclipse.jdt.ls/assets/73968480/682df166-4831-4bdd-8cf6-b14830350591)
