### PR TITLE
Add support for external completion providers. Fix #2379

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/ICompletionContributionService.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/ICompletionContributionService.java
@@ -29,4 +29,14 @@ public interface ICompletionContributionService {
 	 * Unregister a completion ranking provider.
 	 */
 	void unregisterRankingProvider(ICompletionRankingProvider provider);
+
+	/**
+	 * Register a completion proposal provider.
+	 */
+	void registerProposalProvider(ICompletionProposalProvider provider);
+
+	/**
+	 * Unregister a completion proposal provider.
+	 */
+	void unregisterProposalProvider(ICompletionProposalProvider provider);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/ICompletionProposalProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/contentassist/ICompletionProposalProvider.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gayan Perera and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.contentassist;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.ICompilationUnit;
+
+public interface ICompletionProposalProvider {
+	List<CompletionProposal> compute(int offset, ICompilationUnit unit, CompletionContext context, IProgressMonitor monitor);
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionContributionService.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionContributionService.java
@@ -15,20 +15,23 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.eclipse.jdt.ls.core.contentassist.ICompletionRankingProvider;
 import org.eclipse.jdt.ls.core.contentassist.ICompletionContributionService;
+import org.eclipse.jdt.ls.core.contentassist.ICompletionProposalProvider;
+import org.eclipse.jdt.ls.core.contentassist.ICompletionRankingProvider;
 
 public class CompletionContributionService implements ICompletionContributionService {
 
-	private List<ICompletionRankingProvider> providers;
+	private List<ICompletionRankingProvider> rankingProviders;
 
+	private List<ICompletionProposalProvider> proposalProviders;
 
 	public CompletionContributionService() {
-		this.providers = new LinkedList<>();
+		this.rankingProviders = new LinkedList<>();
+		this.proposalProviders = new LinkedList<>();
 	}
 
 	public List<ICompletionRankingProvider> getRankingProviders() {
-		return this.providers;
+		return this.rankingProviders;
 	}
 
 	@Override
@@ -36,12 +39,12 @@ public class CompletionContributionService implements ICompletionContributionSer
 		if (provider == null) {
 			return;
 		}
-		for (ICompletionRankingProvider p : this.providers) {
+		for (ICompletionRankingProvider p : this.rankingProviders) {
 			if (p.equals(provider)) {
 				return;
 			}
 		}
-		this.providers.add(provider);
+		this.rankingProviders.add(provider);
 	}
 
 	@Override
@@ -49,6 +52,31 @@ public class CompletionContributionService implements ICompletionContributionSer
 		if (provider == null) {
 			return;
 		}
-		this.providers.removeIf(p -> p.equals(provider));
+		this.rankingProviders.removeIf(p -> p.equals(provider));
+	}
+
+	public List<ICompletionProposalProvider> getProposalProviders() {
+		return proposalProviders;
+	}
+
+	@Override
+	public void registerProposalProvider(ICompletionProposalProvider provider) {
+		if (provider == null) {
+			return;
+		}
+		for (ICompletionProposalProvider p : this.proposalProviders) {
+			if (p.equals(provider)) {
+				return;
+			}
+		}
+		this.proposalProviders.add(provider);
+	}
+
+	@Override
+	public void unregisterProposalProvider(ICompletionProposalProvider provider) {
+		if (provider == null) {
+			return;
+		}
+		this.proposalProviders.removeIf(p -> p.equals(provider));
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
 import org.eclipse.jdt.ls.core.contentassist.CompletionRanking;
+import org.eclipse.jdt.ls.core.contentassist.ICompletionProposalProvider;
 import org.eclipse.jdt.ls.core.contentassist.ICompletionRankingProvider;
 import org.eclipse.jdt.ls.core.internal.ExceptionFactory;
 import org.eclipse.jdt.ls.core.internal.JDTEnvironmentUtils;
@@ -228,6 +229,9 @@ public class CompletionHandler{
 				try {
 					if (isIndexEngineEnabled()) {
 						unit.codeComplete(offset, collector, subMonitor);
+						if (!subMonitor.isCanceled()) {
+							collectFromRegisteredProviders(offset, unit, collector, subMonitor);
+						}
 					} else {
 						ModelBasedCompletionEngine.codeComplete(unit, offset, collector, DefaultWorkingCopyOwner.PRIMARY, subMonitor);
 					}
@@ -248,6 +252,13 @@ public class CompletionHandler{
 			list.setItemDefaults(collector.getCompletionItemDefaults());
 		}
 		return list;
+	}
+
+	private void collectFromRegisteredProviders(int offset, ICompilationUnit unit, CompletionProposalRequestor collector, IProgressMonitor monitor) {
+		List<ICompletionProposalProvider> providers = ((CompletionContributionService) JavaLanguageServerPlugin.getCompletionContributionService()).getProposalProviders();
+		providers.forEach(provider -> {
+			provider.compute(offset, unit, collector.getContext(), monitor).forEach(collector::accept);
+		});
 	}
 
 	private String[] getFavoriteStaticMembers() {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionProposalProviderTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionProposalProviderTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gayan Perera and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.IAnnotatable;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.contentassist.ICompletionProposalProvider;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.JsonMessageHelper;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CompletionProposalProviderTest extends AbstractCompilationUnitBasedTest {
+
+	private static String COMPLETION_TEMPLATE = "{\n" + "    \"id\": \"1\",\n" + "    \"method\": \"textDocument/completion\",\n" + "    \"params\": {\n" + "        \"textDocument\": {\n" + "            \"uri\": \"${file}\"\n"
+			+ "        },\n" + "        \"position\": {\n" + "            \"line\": ${line},\n" + "            \"character\": ${char}\n" + "        }\n" + "    },\n" + "    \"jsonrpc\": \"2.0\"\n" + "}";
+
+	private TestProposalProvider provider;
+
+	@Before
+	public void setUp() {
+		provider = new TestProposalProvider();
+		JavaLanguageServerPlugin.getCompletionContributionService().registerProposalProvider(provider);
+	}
+
+	@After
+	public void tearDown() {
+		JavaLanguageServerPlugin.getCompletionContributionService().unregisterProposalProvider(provider);
+		provider = null;
+	}
+
+	@Test
+	public void testCompletionsFromExternalCompletionProvider() throws Exception {
+		ICompilationUnit unit = getWorkingCopy("src/java/Foo.java", """
+				public class Foo {
+					@SuppressWarnings()
+					void foo() {
+					}
+				}
+				""");
+
+		CompletionList list = requestCompletions(unit, "@SuppressWarnings(");
+		assertNotNull(list);
+		assertFalse("No proposals were found", list.getItems().isEmpty());
+
+		Optional<CompletionItem> item = list.getItems().stream().filter(i -> "rawtypes".equals(i.getLabel())).findFirst();
+		assertTrue("No expected completion item from provider", item.isPresent());
+	}
+
+	class TestProposalProvider implements ICompletionProposalProvider {
+		@Override
+		public List<CompletionProposal> compute(int offset, ICompilationUnit unit, CompletionContext context, IProgressMonitor monitor) {
+			try {
+				if (unit.getElementAt(offset) instanceof IAnnotatable ann && ann.getAnnotation("SuppressWarnings") != null) {
+					CompletionProposal completion = CompletionProposal.create(CompletionProposal.KEYWORD, offset);
+					completion.setCompletion("rawtypes".toCharArray());
+					return List.of(completion);
+				}
+			} catch (JavaModelException e) {
+			}
+			return Collections.emptyList();
+		}
+	}
+
+	protected CompletionList requestCompletions(ICompilationUnit unit, String completeBehind) throws JavaModelException {
+		return requestCompletions(unit, completeBehind, 0);
+	}
+
+	protected CompletionList requestCompletions(ICompilationUnit unit, String completeBehind, int fromIndex) throws JavaModelException {
+		int[] loc = findCompletionLocation(unit, completeBehind, fromIndex);
+		return server.completion(JsonMessageHelper.getParams(createCompletionRequest(unit, loc[0], loc[1]))).join().getRight();
+	}
+
+	private String createCompletionRequest(ICompilationUnit unit, int line, int kar) {
+		return COMPLETION_TEMPLATE.replace("${file}", JDTUtils.toURI(unit)).replace("${line}", String.valueOf(line)).replace("${char}", String.valueOf(kar));
+	}
+}


### PR DESCRIPTION
This PR introduce new extension point ICompletionProposalProvider which can be implemented to provide external CompletionProposals into jdt.ls which can be registered through ICompletionContributionService from any jdt.ls extension implementation.