### PR TITLE
Use subprocess.run in jdtls script on Windows

### DIFF
--- a/org.eclipse.jdt.ls.product/scripts/jdtls.py
+++ b/org.eclipse.jdt.ls.product/scripts/jdtls.py
@@ -85,19 +85,24 @@ def main(args):
 	shared_config_path = get_shared_config_path(jdtls_base_path)
 	jar_path = find_equinox_launcher(jdtls_base_path)
 
-	os.execvp(java_executable,
-		["-Declipse.application=org.eclipse.jdt.ls.core.id1",
-		"-Dosgi.bundles.defaultStartLevel=4",
-		"-Declipse.product=org.eclipse.jdt.ls.core.product",
-		"-Dosgi.checkConfiguration=true",
-		"-Dosgi.sharedConfiguration.area=" + str(shared_config_path),
-		"-Dosgi.sharedConfiguration.area.readOnly=true",
-		"-Dosgi.configuration.cascaded=true",
-		"-Xms1G",
-		"--add-modules=ALL-SYSTEM",
-		"--add-opens", "java.base/java.util=ALL-UNNAMED",
-		"--add-opens", "java.base/java.lang=ALL-UNNAMED"]
-		+ known_args.jvm_arg
-		+ ["-jar", jar_path,
-		"-data", known_args.data]
-		+ args)
+	system = platform.system()
+	exec_args = ["-Declipse.application=org.eclipse.jdt.ls.core.id1",
+			"-Dosgi.bundles.defaultStartLevel=4",
+			"-Declipse.product=org.eclipse.jdt.ls.core.product",
+			"-Dosgi.checkConfiguration=true",
+			"-Dosgi.sharedConfiguration.area=" + str(shared_config_path),
+			"-Dosgi.sharedConfiguration.area.readOnly=true",
+			"-Dosgi.configuration.cascaded=true",
+			"-Xms1G",
+			"--add-modules=ALL-SYSTEM",
+			"--add-opens", "java.base/java.util=ALL-UNNAMED",
+			"--add-opens", "java.base/java.lang=ALL-UNNAMED"] \
+			+ known_args.jvm_arg \
+			+ ["-jar", jar_path,
+			"-data", known_args.data] \
+			+ args
+
+	if system == 'Windows':
+		subprocess.run([java_executable] + exec_args)
+	else:
+		os.execvp(java_executable, exec_args)


### PR DESCRIPTION
Fixes #2615 

* `subprocess.run` is used in the case when the OS is windows to ensure that the parent process (python script) is alive after starting up the language server