### PR TITLE
Accept contributed settings from client side

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/MapFlattener.java
@@ -14,6 +14,7 @@ package org.eclipse.jdt.ls.core.internal.handlers;
 
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -85,6 +86,18 @@ public final class MapFlattener {
 			} catch (Exception e) {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}
+		}
+		return def;
+	}
+
+	public static Map<String, Object> getMap(Map<String, Object> configuration, String key) {
+		return getMap(configuration, key, Collections.emptyMap());
+	}
+
+	public static Map<String, Object> getMap(Map<String, Object> configuration, String key, Map<String, Object> def) {
+		Object val = getValue(configuration, key);
+		if (val instanceof Map) {
+			return (Map<String, Object>) val;
 		}
 		return def;
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.ls.core.internal.preferences;
 import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getBoolean;
 import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getInt;
 import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getList;
+import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getMap;
 import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getString;
 import static org.eclipse.jdt.ls.core.internal.handlers.MapFlattener.getValue;
 
@@ -651,6 +652,7 @@ public class Preferences {
 	private List<String> cleanUpActionsOnSave;
 	private boolean extractInterfaceReplaceEnabled;
 	private boolean telemetryEnabled;
+	private Map<String, Object> contributedSettings;
 
 	static {
 		JAVA_IMPORT_EXCLUSIONS_DEFAULT = new LinkedList<>();
@@ -881,6 +883,7 @@ public class Preferences {
 		cleanUpActionsOnSave = new ArrayList<>();
 		extractInterfaceReplaceEnabled = false;
 		telemetryEnabled = false;
+		contributedSettings = new HashMap<>();
 	}
 
 	private static void initializeNullAnalysisClasspathStorage() {
@@ -1240,6 +1243,9 @@ public class Preferences {
 		prefs.setExtractInterfaceReplaceEnabled(extractInterfaceReplaceEnabled);
 		boolean telemetryEnabled = getBoolean(configuration, JAVA_TELEMETRY_ENABLED_KEY, false);
 		prefs.setTelemetryEnabled(telemetryEnabled);
+
+		Map<String, Object> contributedSettings = getMap(configuration, "java._contribution_");
+		prefs.setContributedSettings(contributedSettings);
 		return prefs;
 	}
 
@@ -2383,4 +2389,11 @@ public class Preferences {
 		return telemetryEnabled;
 	}
 
+	public Map<String, Object> getContributedSettings() {
+		return contributedSettings;
+	}
+
+	public void setContributedSettings(Map<String, Object> contributedSettings) {
+		this.contributedSettings = contributedSettings;
+	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
@@ -15,7 +15,11 @@ package org.eclipse.jdt.ls.core.internal.preferences;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
+
 import org.junit.Test;
+
+import com.google.gson.internal.LinkedTreeMap;
 
 public class PreferencesTest {
 
@@ -47,5 +51,18 @@ public class PreferencesTest {
 		// Negative will fallback to default
 		preferences.setStaticImportOnDemandThreshold(-1);
 		assertEquals(Preferences.IMPORTS_STATIC_ONDEMANDTHRESHOLD_DEFAULT, preferences.getStaticImportOnDemandThreshold());
+	}
+
+	@Test
+	public void testContributedSettings() {
+		Map<String, Object> settings = new LinkedTreeMap<>();
+		Map<String, Object> contributedSettings = new LinkedTreeMap<>();
+		contributedSettings.put("foo", "bar");
+		contributedSettings.put("test", false);
+		settings.put("java._contribution_", contributedSettings);
+		Preferences preferences = Preferences.createFrom(settings);
+
+		assertEquals("bar", preferences.getContributedSettings().get("foo"));
+		assertEquals(false, preferences.getContributedSettings().get("test"));
 	}
 }


### PR DESCRIPTION
- The contributed settings will be stored in the preference as a map. Plugins of JDT.LS can use them when necessary.
requires https://github.com/redhat-developer/vscode-java/pull/3110