### PR TITLE
Fix the constructor completion not working when match case turned on

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -612,6 +612,19 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			return true;
 		}
 
+		if (proposal.getKind() == CompletionProposal.CONSTRUCTOR_INVOCATION
+				|| proposal.getKind() == CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION
+				|| proposal.getKind() == CompletionProposal.ANONYMOUS_CLASS_DECLARATION) {
+			CompletionProposal[] requiredProposals = proposal.getRequiredProposals();
+			if (requiredProposals != null) {
+				for (CompletionProposal requiredProposal : requiredProposals) {
+					if (requiredProposal.getKind() == CompletionProposal.TYPE_REF) {
+						proposal = requiredProposal;
+					}
+				}
+			}
+		}
+
 		char firstCharOfCompletion;
 		if (proposal.getKind() == CompletionProposal.TYPE_REF) {
 			String simpleTypeName = SignatureUtil.getSimpleTypeName(proposal);
@@ -620,10 +633,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 			firstCharOfCompletion = proposal.getCompletion()[0];
 		}
 
-		if (this.context.getToken()[0] != firstCharOfCompletion) {
-			return false;
-		}
-
-		return true;
+		return this.context.getToken()[0] == firstCharOfCompletion;
 	}
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -3518,6 +3518,30 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 		}
 	}
 
+	@Test
+	public void testCompletion_MatchCaseFirstLetterForConstructor() throws Exception {
+		try {
+			preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.FIRSTLETTER);
+			ICompilationUnit unit = getWorkingCopy("src/org/sample/Test.java", String.join("\n",
+			//@formatter:off
+					"package org.sample",
+					"public class Test {",
+					"	public static void main(String[] args) {",
+					"		String a = new S",
+					"	}",
+					"}"));
+					//@formatter:on
+			CompletionList list = requestCompletions(unit, "new S");
+			assertFalse(list.getItems().isEmpty());
+			assertTrue(list.getItems().stream()
+				.allMatch(t -> Character.isUpperCase(t.getLabel().charAt(0))));
+			assertTrue(list.getItems().stream()
+				.anyMatch(t -> t.getLabel().startsWith("String")));
+		} finally {
+			preferenceManager.getPreferences().setCompletionMatchCaseMode(CompletionMatchCaseMode.OFF);
+		}
+	}
+
 	// https://github.com/eclipse/eclipse.jdt.ls/issues/2376
 	@Test
 	public void testCompletion_selectSnippetItem() throws Exception {


### PR DESCRIPTION
- When the completion is a constructor, we need to get the first char
  from the required proposal instead of the main proposal.

fix https://github.com/redhat-developer/vscode-java/issues/3118

Signed-off-by: Sheng Chen <sheche@microsoft.com>