### PR TITLE
Revert "[lombok] No completions on field initializer"

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalRequestor.java
@@ -269,32 +269,6 @@ public final class CompletionProposalRequestor extends CompletionRequestor {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}
 		}
-		// see https://github.com/eclipse/eclipse.jdt.ls/issues/2669
-		Either<Range, InsertReplaceRange> editRange = itemDefaults.getEditRange();
-		if (editRange != null) {
-			Range range;
-			if (editRange.getLeft() != null) {
-				range = editRange.getLeft();
-			} else if (editRange.getRight() != null) {
-				range = editRange.getRight().getInsert() != null ? editRange.getRight().getInsert() : editRange.getRight().getReplace();
-			} else {
-				range = null;
-			}
-			int line = -1;
-			if (range != null) {
-				int offset = response.getOffset();
-				try {
-					Range offsetRange = JDTUtils.toRange(unit, offset, 0);
-					line = offsetRange.getStart().getLine();
-				} catch (JavaModelException e) {
-					// ignore
-				}
-			}
-			if (range != null && range.getStart().getLine() != line) {
-				itemDefaults.setEditRange(null);
-				itemDefaults.setInsertTextFormat(null);
-			}
-		}
 
 		if (proposals.size() > maxCompletions) {
 			//we keep receiving completions past our capacity so that makes the whole result incomplete

--- a/org.eclipse.jdt.ls.tests/pom.xml
+++ b/org.eclipse.jdt.ls.tests/pom.xml
@@ -41,7 +41,7 @@
 				</property>
 			</activation>
 			<properties>
-				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.28.jar</lombokArgs>
+				<lombokArgs>-javaagent:${basedir}/lib/lombok-1.18.24.jar</lombokArgs>
 			</properties>
 			<build>
 				<plugins>
@@ -53,7 +53,7 @@
 								<artifactItem>
 									<groupId>org.projectlombok</groupId>
 									<artifactId>lombok</artifactId>
-									<version>1.18.28</version>
+									<version>1.18.24</version>
 								</artifactItem>
 							</artifactItems>
 						</configuration>

--- a/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
+++ b/org.eclipse.jdt.ls.tests/projects/maven/mavenlombok/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>1.18.24</version>
         </dependency>
     </dependencies>
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -141,7 +141,7 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 		testClass("org.apache.commons.lang3.stringutils", 6579, 20);
 	}
 
-	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.28/lombok-1.18.28.jar)
+	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.24/lombok-1.18.24.jar)
 	// https://github.com/redhat-developer/vscode-java/issues/2805
 	@Test
 	public void testLombok() throws Exception {

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/RenameHandlerTest.java
@@ -574,7 +574,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 				);
 	}
 
-	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.28/lombok-1.18.28.jar)
+	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.20/lombok-1.18.20.jar)
 	// https://github.com/eclipse/eclipse.jdt.ls/issues/1775
 	@Test
 	public void testRenameTypeLombok() throws Exception {
@@ -593,7 +593,7 @@ public class RenameHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertEquals(expected, TextEditUtil.apply(source, edit.getChanges().get(JDTUtils.toURI(cu))));
 	}
 
-	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.28/lombok-1.18.28.jar)
+	// this test should pass when starting with -javaagent:<lombok_jar> (-javagent:~/.m2/repository/org/projectlombok/lombok/1.18.20/lombok-1.18.20.jar)
 	// https://github.com/redhat-developer/vscode-java/issues/2805
 	@Test
 	public void testRenameMethodLombok() throws Exception {


### PR DESCRIPTION
Reverts eclipse/eclipse.jdt.ls#2673

Looking at https://ci.eclipse.org/ls/job/jdt-ls-master/1699/, https://ci.eclipse.org/ls/job/jdt-ls-master/1700/ it seems to be failing so let's revert for now and merge after the release.