### PR TITLE
Support 'off' mode when fill the argument during completion

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalDescriptionProvider.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionGuessMethodArgumentsMode;
 import org.eclipse.jdt.ls.core.internal.handlers.JsonRpcHelpers;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.CompletionItem;
@@ -696,6 +697,15 @@ public class CompletionProposalDescriptionProvider {
 	 * @param item
 	 */
 	public void updateDescription(CompletionProposal proposal, CompletionItem item) {
+		// change the proposal to required type proposal when the
+		// argument guessing is turned off and the proposal is a constructor.
+		if (JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode() ==
+				CompletionGuessMethodArgumentsMode.OFF) {
+			CompletionProposal requiredTypeProposal = CompletionProposalUtils.getRequiredTypeProposal(proposal);
+			if (requiredTypeProposal != null) {
+				proposal = requiredTypeProposal;
+			}
+		}
 		switch (proposal.getKind()) {
 			case CompletionProposal.METHOD_NAME_REFERENCE:
 			case CompletionProposal.METHOD_REF:

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalUtils.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jdt.ls.core.internal.contentassist;
 
+import java.util.Arrays;
+
 import org.eclipse.jdt.core.CompletionProposal;
 
 public class CompletionProposalUtils {
@@ -34,5 +36,30 @@ public class CompletionProposalUtils {
 		 * in static imports.
 		 */
 		return last == SEMICOLON || last == '.';
+	}
+
+	/**
+	 * Get required type completion proposal when the given proposal is a
+	 * constructor. <code>null</code> will returned if the given proposal is
+	 * not a constructor or no type completion proposal is available from the
+	 * required proposals.
+	 */
+	public static CompletionProposal getRequiredTypeProposal(CompletionProposal proposal) {
+		if (proposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION
+				&& proposal.getKind() != CompletionProposal.ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION
+				&& proposal.getKind() != CompletionProposal.ANONYMOUS_CLASS_DECLARATION) {
+			return null;
+		}
+
+		CompletionProposal requiredProposal = null;
+		CompletionProposal[] requiredProposals = proposal.getRequiredProposals();
+		if (requiredProposals != null) {
+			requiredProposal = Arrays.stream(requiredProposals)
+				.filter(p -> p.getKind() == CompletionProposal.TYPE_REF)
+				.findFirst()
+				.orElse(null);
+		}
+
+		return requiredProposal;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionGuessMethodArgumentsMode.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionGuessMethodArgumentsMode.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import com.google.common.base.CaseFormat;
+
+/**
+ * How the arguments fill during completion.
+ */
+public enum CompletionGuessMethodArgumentsMode {
+	/**
+	 * Do not insert argument names during completion.
+	 */
+	OFF,
+	/**
+	 * The parameter names will be inserted during completion.
+	 */
+	INSERT_PARAMETER_NAMES,
+	/**
+	 * The best guessed arguments will be inserted during completion according to the code context.
+	 */
+	INSERT_BEST_GUESSED_ARGUMENTS;
+
+	public static CompletionGuessMethodArgumentsMode fromString(String value, CompletionGuessMethodArgumentsMode defaultMode) {
+		if (value != null) {
+			String val = CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, value);
+			try {
+				return valueOf(val);
+			} catch(Exception e) {
+				// fall back to default severity
+			}
+		}
+		return defaultMode;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandler.java
@@ -89,6 +89,8 @@ public class CompletionHandler{
 
 	};
 
+	// TODO: we can consider to cache more detailed context so that the information can also
+	// be used by features like inlay hint.
 	public static CompletionProposal selectedProposal;
 
 	private PreferenceManager manager;
@@ -170,7 +172,16 @@ public class CompletionHandler{
 			throw ExceptionFactory.newException("Cannot get completion responses.");
 		}
 
-		selectedProposal = completionResponse.getProposals().get(pId);
+		CompletionProposal proposal = completionResponse.getProposals().get(pId);
+
+		// clear the cache if failed to get the selected proposal.
+		if (proposal == null) {
+			selectedProposal = null;
+		} else if (proposal.getKind() == CompletionProposal.METHOD_REF
+				|| proposal.getKind() == CompletionProposal.CONSTRUCTOR_INVOCATION
+				|| proposal.getKind() == CompletionProposal.METHOD_REF_WITH_CASTED_RECEIVER) {
+			selectedProposal = proposal;
+		}
 		CompletionItem item = completionResponse.getItems().get(pId);
 		if (item == null) {
 			throw ExceptionFactory.newException("Cannot get the completion item.");

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionResolveHandler.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalReplacementProvider;
 import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalRequestor;
+import org.eclipse.jdt.ls.core.internal.contentassist.CompletionProposalUtils;
 import org.eclipse.jdt.ls.core.internal.contentassist.SnippetCompletionProposal;
 import org.eclipse.jdt.ls.core.internal.contentassist.SnippetUtils;
 import org.eclipse.jdt.ls.core.internal.corext.template.java.JavaPostfixContext;
@@ -179,7 +180,15 @@ public class CompletionResolveHandler {
 			return param;
 		}
 
-		// below code is for resolving documentation
+		// resolving documentation
+		// 1. get the required type proposal when the argument guessing is
+		// turned off and the proposal is a constructor.
+		if (manager.getPreferences().getGuessMethodArgumentsMode() == CompletionGuessMethodArgumentsMode.OFF) {
+			CompletionProposal requiredTypeProposal = CompletionProposalUtils.getRequiredTypeProposal(proposal);
+			if (requiredTypeProposal != null) {
+				proposal = requiredTypeProposal;
+			}
+		}
 		IMember member = null;
 		if (proposal.getKind() == CompletionProposal.TYPE_REF) {
 			char[] signature = proposal.getSignature();

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/preferences/Preferences.java
@@ -63,6 +63,7 @@ import org.eclipse.jdt.ls.core.internal.RuntimeEnvironment;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand;
 import org.eclipse.jdt.ls.core.internal.commands.ProjectCommand.ClasspathResult;
 import org.eclipse.jdt.ls.core.internal.contentassist.TypeFilter;
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionGuessMethodArgumentsMode;
 import org.eclipse.jdt.ls.core.internal.handlers.CompletionMatchCaseMode;
 import org.eclipse.jdt.ls.core.internal.handlers.InlayHintsParameterMode;
 import org.eclipse.jdt.ls.core.internal.handlers.ProjectEncodingMode;
@@ -590,7 +591,7 @@ public class Preferences {
 	private boolean completionOverwrite;
 	private boolean foldingRangeEnabled;
 	private boolean selectionRangeEnabled;
-	private boolean guessMethodArguments;
+	private CompletionGuessMethodArgumentsMode guessMethodArguments;
 
 	private boolean javaFormatComments;
 	private boolean hashCodeEqualsTemplateUseJava7Objects;
@@ -842,7 +843,7 @@ public class Preferences {
 		completionOverwrite = true;
 		foldingRangeEnabled = true;
 		selectionRangeEnabled = true;
-		guessMethodArguments = false;
+		guessMethodArguments = CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES;
 		javaFormatComments = true;
 		hashCodeEqualsTemplateUseJava7Objects = false;
 		hashCodeEqualsTemplateUseInstanceof = false;
@@ -1030,8 +1031,15 @@ public class Preferences {
 		boolean selectionRangeEnabled = getBoolean(configuration, SELECTIONRANGE_ENABLED_KEY, true);
 		prefs.setSelectionRangeEnabled(selectionRangeEnabled);
 
-		boolean guessMethodArguments = getBoolean(configuration, JAVA_COMPLETION_GUESS_METHOD_ARGUMENTS_KEY, false);
-		prefs.setGuessMethodArguments(guessMethodArguments);
+		Object guessMethodArguments = getValue(configuration, JAVA_COMPLETION_GUESS_METHOD_ARGUMENTS_KEY);
+		if (guessMethodArguments instanceof Boolean b) {
+			prefs.setGuessMethodArgumentsMode(b ? CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS :
+					CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES);
+		} else {
+			String guessMethodArgumentsMode = getString(configuration, JAVA_COMPLETION_GUESS_METHOD_ARGUMENTS_KEY, null);
+			prefs.setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.fromString(guessMethodArgumentsMode,
+					CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES));
+		}
 
 		boolean hashCodeEqualsTemplateUseJava7Objects = getBoolean(configuration, JAVA_CODEGENERATION_HASHCODEEQUALS_USEJAVA7OBJECTS, false);
 		prefs.setHashCodeEqualsTemplateUseJava7Objects(hashCodeEqualsTemplateUseJava7Objects);
@@ -1471,7 +1479,7 @@ public class Preferences {
 		return this;
 	}
 
-	public Preferences setGuessMethodArguments(boolean guessMethodArguments) {
+	public Preferences setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode guessMethodArguments) {
 		this.guessMethodArguments = guessMethodArguments;
 		return this;
 	}
@@ -1790,7 +1798,7 @@ public class Preferences {
 		return selectionRangeEnabled;
 	}
 
-	public boolean isGuessMethodArguments() {
+	public CompletionGuessMethodArgumentsMode getGuessMethodArgumentsMode() {
 		return guessMethodArguments;
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CompletionHandlerTest.java
@@ -729,16 +729,16 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 	}
 
 	@Test
-	public void testCompletion_method_guessMethodArgumentsFalse() throws JavaModelException {
-		testCompletion_method_guessMethodArguments(false, "test(${1:name}, ${2:i});");
+	public void testCompletion_method_insertParameterNames() throws JavaModelException {
+		testCompletion_method_guessMethodArguments(CompletionGuessMethodArgumentsMode.INSERT_PARAMETER_NAMES, "test(${1:name}, ${2:i});");
 	}
 
 	@Test
-	public void testCompletion_method_guessMethodArgumentsTrue() throws JavaModelException {
-		testCompletion_method_guessMethodArguments(true, "test(${1:str}, ${2:x});");
+	public void testCompletion_method_insertBestGuessedArguments() throws JavaModelException {
+		testCompletion_method_guessMethodArguments(CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS, "test(${1:str}, ${2:x});");
 	}
 
-	private void testCompletion_method_guessMethodArguments(boolean guessMethodArguments, String expected) throws JavaModelException {
+	private void testCompletion_method_guessMethodArguments(CompletionGuessMethodArgumentsMode guessMethodArguments, String expected) throws JavaModelException {
 		ICompilationUnit unit = getWorkingCopy(
 		//@formatter:off
 				"src/java/Foo.java",
@@ -751,9 +751,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				"	}\n\n" +
 				"}\n");
 		//@formatter:on
-		boolean oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isGuessMethodArguments();
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
 		try {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(guessMethodArguments);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(guessMethodArguments);
 			CompletionList list = requestCompletions(unit, "tes");
 			assertNotNull(list);
 			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("test(String name, int i) : void")).findFirst().orElse(null);
@@ -765,7 +765,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci.getTextEdit().getLeft());
 			assertTextEdit(5, 2, 5, expected, ci.getTextEdit().getLeft());
 		} finally {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(oldGuessMethodArguments);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
 		}
 	}
 
@@ -782,9 +782,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				"	}\n\n" +
 				"}\n");
 		//@formatter:on
-		boolean oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isGuessMethodArguments();
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
 		try {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(true);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS);
 			CompletionList list = requestCompletions(unit, "tes");
 			assertNotNull(list);
 			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("test(String name, int i) : void")).findFirst().orElse(null);
@@ -796,7 +796,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci.getTextEdit().getLeft());
 			assertTextEdit(4, 2, 5, "test(${1:str}, ${2:0});", ci.getTextEdit().getLeft());
 		} finally {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(oldGuessMethodArguments);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
 		}
 	}
 
@@ -814,9 +814,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				"	}\n\n" +
 				"}\n");
 		//@formatter:on
-		boolean oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isGuessMethodArguments();
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
 		try {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(true);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS);
 			CompletionList list = requestCompletions(unit, "tes");
 			assertNotNull(list);
 			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("test(int i, int j) : void")).findFirst().orElse(null);
@@ -828,7 +828,7 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci.getTextEdit().getLeft());
 			assertTextEdit(5, 2, 5, "test(${1:one}, ${2:two});", ci.getTextEdit().getLeft());
 		} finally {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(oldGuessMethodArguments);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
 		}
 	}
 
@@ -845,9 +845,9 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 				"	private static class A { public A(String name){} }\n" +
 				"}\n");
 		//@formatter:on
-		boolean oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().isGuessMethodArguments();
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
 		try {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(true);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS);
 			CompletionList list = requestCompletions(unit, "new A");
 			assertNotNull(list);
 			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("A(String name)")).findFirst().orElse(null);
@@ -859,7 +859,60 @@ public class CompletionHandlerTest extends AbstractCompilationUnitBasedTest {
 			assertNotNull(ci.getTextEdit().getLeft());
 			assertTextEdit(3, 6, 7, "A(${1:str})", ci.getTextEdit().getLeft());
 		} finally {
-			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArguments(oldGuessMethodArguments);
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
+		}
+	}
+
+	@Test
+	public void testCompletion_method_turnOffGuessMethodArguments() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"""
+				public class Foo {
+					static void test(int i, int j) {}
+					public static void main(String[] args) {
+						int one=1;
+						int two=2;
+						tes
+					}
+				}
+				"""
+		);
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
+		try {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.OFF);
+			CompletionList list = requestCompletions(unit, "tes");
+			assertNotNull(list);
+			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("test(int i, int j) : void")).findFirst().orElse(null);
+			assertNotNull(ci);
+			assertTextEdit(5, 2, 5, "test(${0});", ci.getTextEdit().getLeft());
+		} finally {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
+		}
+	}
+
+	@Test
+	public void testCompletion_constructor_turnOffGuessMethodArguments() throws JavaModelException {
+		ICompilationUnit unit = getWorkingCopy(
+				"src/java/Foo.java",
+				"""
+				public class Foo {
+					public static void main(String[] args) {
+						String s = new String
+					}
+				}
+				"""
+		);
+		CompletionGuessMethodArgumentsMode oldGuessMethodArguments = JavaLanguageServerPlugin.getPreferencesManager().getPreferences().getGuessMethodArgumentsMode();
+		try {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(CompletionGuessMethodArgumentsMode.OFF);
+			CompletionList list = requestCompletions(unit, "new String");
+			assertNotNull(list);
+			CompletionItem ci = list.getItems().stream().filter(item -> item.getLabel().equals("String - java.lang")).findFirst().orElse(null);
+			assertNotNull(ci);
+			assertEquals("String(${0})", ci.getTextEdit().getLeft().getNewText());
+		} finally {
+			JavaLanguageServerPlugin.getPreferencesManager().getPreferences().setGuessMethodArgumentsMode(oldGuessMethodArguments);
 		}
 	}
 

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/preferences/PreferencesTest.java
@@ -15,7 +15,12 @@ package org.eclipse.jdt.ls.core.internal.preferences;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
+
+import org.eclipse.jdt.ls.core.internal.handlers.CompletionGuessMethodArgumentsMode;
 import org.junit.Test;
+
+import com.google.gson.internal.LinkedTreeMap;
 
 public class PreferencesTest {
 
@@ -48,4 +53,18 @@ public class PreferencesTest {
 		preferences.setStaticImportOnDemandThreshold(-1);
 		assertEquals(Preferences.IMPORTS_STATIC_ONDEMANDTHRESHOLD_DEFAULT, preferences.getStaticImportOnDemandThreshold());
 	}
+
+	@Test
+	public void testLegacyCompletionGuessMethodArguments() {
+		Map<String, Object> config = new LinkedTreeMap<>();
+		Map<String, Object> inJava = new LinkedTreeMap<>();
+		config.put("java", inJava);
+		Map<String, Object> inCompletion = new LinkedTreeMap<>();
+		inJava.put("completion", inCompletion);
+		inCompletion.put("guessMethodArguments", Boolean.TRUE);
+
+		Preferences preferences = Preferences.createFrom(config);
+		assertEquals(CompletionGuessMethodArgumentsMode.INSERT_BEST_GUESSED_ARGUMENTS, preferences.getGuessMethodArgumentsMode());
+	}
+
 }


### PR DESCRIPTION
- Change the option of 'java.completion.guessMethodArguments' from boolean to three options: "off", "insertParameterNames" and "insertBestGuessedArguments".
- When it's "off", no arguments will be inserted during completion. Moreover, the constructors will be collapsed into one item in the completion list.

requires https://github.com/redhat-developer/vscode-java/pull/3143

fix https://github.com/eclipse/eclipse.jdt.ls/issues/2512

Some pref data about completion with different mode, the completion happens with `List<String> l = new A|`:

##### When lazy-resolve turns **on**:

  | off | insert parameter names | insert guessed arguments
-- | -- | -- | --
#1 | 3291 | 3922 | 3739
#2 | 1174 | 1158 | 1221
#3 | 880 | 1201 | 1097
#4 | 888 | 1095 | 1038
#5 | 806 | 986 | 1010
#6 | 801 | 1025 | 996
#7 | 791 | 1029 | 993
#8 | 843 | 1062 | 1015
#9 | 789 | 1003 | 987
#10 | 787 | 1014 | 989
Avg | 1105 | 1349.5 | 1308.5


##### When lazy-resolve turns **off**:

  | off | parameter name | guess argument
-- | -- | -- | --
#1 | 3400 | 3676 | 4207
#2 | 1504 | 1212 | 1318
#3 | 940 | 1146 | 1242
#4 | 889 | 1015 | 1094
#5 | 823 | 1032 | 1070
#6 | 797 | 1030 | 1051
#7 | 797 | 988 | 1069
#8 | 784 | 1005 | 1051
#9 | 788 | 984 | 1031
#10 | 782 | 974 | 1022
Avg | 1150.4 | 1306.2 | 1415.5
