### PR TITLE
Use fernflower as the default decompiler

### DIFF
--- a/org.eclipse.jdt.ls.core/.classpath
+++ b/org.eclipse.jdt.ls.core/.classpath
@@ -4,6 +4,7 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.14.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/remark-1.2.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/java-decompiler-engine-231.9011.34.jar"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ls.core/META-INF/MANIFEST.MF
@@ -47,6 +47,7 @@ Export-Package: org.eclipse.jdt.ls.core.contentassist;x-friends:="org.eclipse.jd
  org.eclipse.jdt.ls.core.internal.corext.util;x-internal:=true,
  org.eclipse.jdt.ls.core.internal.corrections;x-internal:=true,
  org.eclipse.jdt.ls.core.internal.corrections.proposals;x-internal:=true,
+ org.eclipse.jdt.ls.core.internal.decompiler;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.framework.protobuf;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.handlers;x-friends:="org.eclipse.jdt.ls.tests",
  org.eclipse.jdt.ls.core.internal.hover;x-friends:="org.eclipse.jdt.ls.tests",
@@ -62,6 +63,7 @@ Export-Package: org.eclipse.jdt.ls.core.contentassist;x-friends:="org.eclipse.jd
  org.eclipse.lsp4j.legacy.typeHierarchy;x-friends:="org.eclipse.jdt.ls.tests"
 Bundle-ClassPath: lib/jsoup-1.14.2.jar,
  lib/remark-1.2.0.jar,
+ lib/java-decompiler-engine-231.9011.34.jar,
  .
 Bundle-Vendor: %Bundle-Vendor
 Automatic-Module-Name: org.eclipse.jdt.ls.core

--- a/org.eclipse.jdt.ls.core/build.properties
+++ b/org.eclipse.jdt.ls.core/build.properties
@@ -5,6 +5,7 @@ bin.includes = META-INF/,\
                plugin.xml,\
                lib/jsoup-1.14.2.jar,\
                lib/remark-1.2.0.jar,\
+               lib/java-decompiler-engine-231.9011.34.jar,\
                lifecycle-mapping-metadata.xml,\
                plugin.properties,\
                gradle/checksums/checksums.json,\

--- a/org.eclipse.jdt.ls.core/plugin.xml
+++ b/org.eclipse.jdt.ls.core/plugin.xml
@@ -43,8 +43,8 @@
    <extension
          point="org.eclipse.jdt.ls.core.contentProvider">
       <contentProvider
-            class="org.eclipse.jdt.ls.core.internal.DisassemblerContentProvider"
-            id="disassemblerContentProvider"
+            class="org.eclipse.jdt.ls.core.internal.decompiler.FernFlowerDecompiler"
+            id="fernflowerContentProvider"
             priority="2147483647"
             uriPattern=".+\.class.*">
       </contentProvider>

--- a/org.eclipse.jdt.ls.core/pom.xml
+++ b/org.eclipse.jdt.ls.core/pom.xml
@@ -27,6 +27,11 @@
 							<artifactId>jsoup</artifactId>
 							<version>1.14.2</version>
 						</artifactItem>
+						<artifactItem>
+							<groupId>com.jetbrains.intellij.java</groupId>
+							<artifactId>java-decompiler-engine</artifactId>
+							<version>231.9011.34</version>
+						</artifactItem>
 					</artifactItems>
 				</configuration>
 			</plugin>
@@ -87,4 +92,10 @@
 			</plugin>
 		</plugins>
 	</build>
+	<repositories>
+		<repository>
+			<id>jetbrains-intellij</id>
+			<url>https://www.jetbrains.com/intellij-repository/releases/</url>
+		</repository>
+	</repositories>
 </project>

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DecompilerResult.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/DecompilerResult.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal;
+
+public class DecompilerResult {
+	String content;
+	int[] originalLineMappings;
+	int[] decompiledLineMappings;
+
+	public DecompilerResult(String content) {
+		this.content = content;
+	}
+
+	public DecompilerResult(String content, int[] originalLineMappings) {
+		this.content = content;
+		this.originalLineMappings = originalLineMappings;
+	}
+
+	public DecompilerResult(String content, int[] originalLineMappings,
+			int[] decompiledLineMappings) {
+		this.content = content;
+		this.originalLineMappings = originalLineMappings;
+		this.decompiledLineMappings = decompiledLineMappings;
+	}
+
+	/**
+	 * Returns the decompiled source content.
+	 */
+	public String getContent() {
+		return content;
+	}
+
+	/**
+	 * Returns the line mappings from original line to decompiled line.
+	 * Its format is as follows, in ascending order by original line.
+	 * - [i]: the original line number
+	 * - [i+1]: the decompiled line number
+	 */
+	public int[] getOriginalLineMappings() {
+		return originalLineMappings;
+	}
+
+	/**
+	 * Returns the line mappings from decompiled line to original line.
+	 * Its format is as follows, in ascending order by decompiled line.
+	 * - [i]: the decompiled line number
+	 * - [i+1]: the original line number
+	 */
+	public int[] getDecompiledLineMappings() {
+		return decompiledLineMappings;
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
@@ -31,4 +31,57 @@ public interface IDecompiler extends IContentProvider {
 	 * @throws CoreException
 	 */
 	public String getSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException;
+
+	/**
+	 * Provide decompiled source code from a resource.
+	 *
+	 * @param classFile
+	 *            the class file to decompile
+	 * @param monitor
+	 *            monitor of the activity progress
+	 * @return text content or <code>null</code>
+	 * @throws CoreException
+	 */
+	default public DecompilerResult getDecompiledSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		String source = getSource(classFile, monitor);
+		return source == null ? null : new DecompilerResult(source);
+	}
+
+	/**
+	 * Provides the line mappings from the original source to decompiled source.
+	 * Its format is as follows, in ascending order by original line.
+	 * - [i]: the original line
+	 * - [i+1]: the decompiled line
+	 *
+	 * @param classFile
+	 *             the class file to decompile
+	 * @param contents
+	 *             the decompiled contents
+	 * @param monitor
+	 *             the progress monitor
+	 * @return the original line mappings if existed or <code>null</code>
+	 * @throws CoreException
+	 */
+	default int[] getOriginalLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
+		return null;
+	}
+
+	/**
+	 * Provides the line mappings from the decompiled source to the original source.
+	 * Its format is as follows, in ascending order by decompiled line.
+	 * - [i]: the decompiled line
+	 * - [i+1]: the original line
+	 *
+	 * @param classFile
+	 *             the class file to decompile
+	 * @param contents
+	 *             the decompiled contents
+	 * @param monitor
+	 *             the progress monitor
+	 * @return the decompiled line mappings if existed or <code>null</code>
+	 * @throws CoreException
+	 */
+	default int[] getDecompiledLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
+		return null;
+	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
@@ -42,7 +42,7 @@ public interface IDecompiler extends IContentProvider {
 	 * @return text content or <code>null</code>
 	 * @throws CoreException
 	 */
-	default public DecompilerResult getDecompiledSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+	default DecompilerResult getDecompiledSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
 		String source = getSource(classFile, monitor);
 		return source == null ? null : new DecompilerResult(source);
 	}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/IDecompiler.java
@@ -46,42 +46,4 @@ public interface IDecompiler extends IContentProvider {
 		String source = getSource(classFile, monitor);
 		return source == null ? null : new DecompilerResult(source);
 	}
-
-	/**
-	 * Provides the line mappings from the original source to decompiled source.
-	 * Its format is as follows, in ascending order by original line.
-	 * - [i]: the original line
-	 * - [i+1]: the decompiled line
-	 *
-	 * @param classFile
-	 *             the class file to decompile
-	 * @param contents
-	 *             the decompiled contents
-	 * @param monitor
-	 *             the progress monitor
-	 * @return the original line mappings if existed or <code>null</code>
-	 * @throws CoreException
-	 */
-	default int[] getOriginalLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
-		return null;
-	}
-
-	/**
-	 * Provides the line mappings from the decompiled source to the original source.
-	 * Its format is as follows, in ascending order by decompiled line.
-	 * - [i]: the decompiled line
-	 * - [i+1]: the original line
-	 *
-	 * @param classFile
-	 *             the class file to decompile
-	 * @param contents
-	 *             the decompiled contents
-	 * @param monitor
-	 *             the progress monitor
-	 * @return the decompiled line mappings if existed or <code>null</code>
-	 * @throws CoreException
-	 */
-	default int[] getDecompiledLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
-		return null;
-	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerImpl.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerImpl.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.decompiler;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.ls.core.internal.DecompilerResult;
+import org.eclipse.jdt.ls.core.internal.IDecompiler;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+
+public abstract class DecompilerImpl implements IDecompiler {
+	private static Map<DecompilerType, Map<String, DecompilerResult>> decompilerCache = new HashMap<>();
+	private static final int CACHE_SIZE = 100;
+
+	private static Map<String, DecompilerResult> getLRUCache(int maxEntries) {
+		Map<String, DecompilerResult> map = new LinkedHashMap<>(maxEntries + 1, .75F, true) {
+			public boolean removeEldestEntry(Map.Entry eldest) {
+				return size() > maxEntries;
+			}
+		};
+		return Collections.synchronizedMap(map);
+	}
+
+	private static Map<String, DecompilerResult> getCache(DecompilerType type, int maxEntries) {
+		return decompilerCache.computeIfAbsent(type, key -> {
+			return getLRUCache(maxEntries);
+		});
+	}
+
+	private static DecompilerResult getCachedResult(DecompilerType type, IClassFile classFile) {
+		Map<String, DecompilerResult> cache = decompilerCache.get(type);
+		if (cache != null) {
+			return cache.get(classFile.getHandleIdentifier());
+		}
+
+		return null;
+	}
+
+	@Override
+	public String getContent(URI uri, IProgressMonitor monitor) throws CoreException {
+		Map<String, DecompilerResult> cache = getCache(getDecompilerType(), CACHE_SIZE);
+		String cacheKey = uri.toString();
+		DecompilerResult result = cache.computeIfAbsent(cacheKey, (key) -> {
+			try {
+				return decompileContent(uri, monitor);
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("Failed to decompile with " + getDecompilerType().name(), e);
+			}
+
+			return null;
+		});
+
+		return result == null ? null : result.getContent();
+	}
+
+	@Override
+	public String getSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		DecompilerResult result = getDecompiledSource(classFile, monitor);
+		return result == null ? null : result.getContent();
+	}
+
+	@Override
+	public DecompilerResult getDecompiledSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		Map<String, DecompilerResult> cache = getCache(getDecompilerType(), CACHE_SIZE);
+		String cacheKey = classFile.getHandleIdentifier();
+		return cache.computeIfAbsent(cacheKey, (key) -> {
+			try {
+				return decompileContent(classFile, monitor);
+			} catch (CoreException e) {
+				JavaLanguageServerPlugin.logException("Failed to decompile with " + getDecompilerType().name(), e);
+			}
+
+			return null;
+		});
+	}
+
+	@Override
+	public int[] getDecompiledLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
+		if (!isDecompiledContents(classFile, contents)) {
+			return null;
+		}
+
+		DecompilerResult result = getCachedResult(getDecompilerType(), classFile);
+		return result == null ? null : result.getDecompiledLineMappings();
+	}
+
+	@Override
+	public int[] getOriginalLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
+		if (!isDecompiledContents(classFile, contents)) {
+			return null;
+		}
+
+		DecompilerResult result = getCachedResult(getDecompilerType(), classFile);
+		return result == null ? null : result.getOriginalLineMappings();
+	}
+
+	protected abstract DecompilerResult decompileContent(URI uri, IProgressMonitor monitor) throws CoreException;
+	protected abstract DecompilerResult decompileContent(IClassFile classFile, IProgressMonitor monitor) throws CoreException;
+	protected abstract DecompilerType getDecompilerType();
+	protected abstract boolean isDecompiledContents(IClassFile classFile, String contents);
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerImpl.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerImpl.java
@@ -47,15 +47,6 @@ public abstract class DecompilerImpl implements IDecompiler {
 		});
 	}
 
-	private static DecompilerResult getCachedResult(DecompilerType type, IClassFile classFile) {
-		Map<String, DecompilerResult> cache = decompilerCache.get(type);
-		if (cache != null) {
-			return cache.get(classFile.getHandleIdentifier());
-		}
-
-		return null;
-	}
-
 	@Override
 	public String getContent(URI uri, IProgressMonitor monitor) throws CoreException {
 		Map<String, DecompilerResult> cache = getCache(getDecompilerType());
@@ -94,28 +85,7 @@ public abstract class DecompilerImpl implements IDecompiler {
 		});
 	}
 
-	@Override
-	public int[] getDecompiledLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
-		if (!isDecompiledContents(classFile, contents)) {
-			return null;
-		}
-
-		DecompilerResult result = getCachedResult(getDecompilerType(), classFile);
-		return result == null ? null : result.getDecompiledLineMappings();
-	}
-
-	@Override
-	public int[] getOriginalLineMappings(IClassFile classFile, String contents, IProgressMonitor monitor) throws CoreException {
-		if (!isDecompiledContents(classFile, contents)) {
-			return null;
-		}
-
-		DecompilerResult result = getCachedResult(getDecompilerType(), classFile);
-		return result == null ? null : result.getOriginalLineMappings();
-	}
-
 	protected abstract DecompilerResult decompileContent(URI uri, IProgressMonitor monitor) throws CoreException;
 	protected abstract DecompilerResult decompileContent(IClassFile classFile, IProgressMonitor monitor) throws CoreException;
 	protected abstract DecompilerType getDecompilerType();
-	protected abstract boolean isDecompiledContents(IClassFile classFile, String contents);
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/DecompilerType.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.decompiler;
+
+import com.google.gson.annotations.SerializedName;
+
+public enum DecompilerType {
+	@SerializedName("FernFlower")
+	FERNFLOWER,
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
@@ -64,11 +64,6 @@ public class FernFlowerDecompiler extends DecompilerImpl {
 		return DecompilerType.FERNFLOWER;
 	}
 
-	@Override
-	protected boolean isDecompiledContents(IClassFile classFile, String contents) {
-		return contents != null && contents.startsWith(DECOMPILER_HEADER);
-	}
-
 	private DecompilerResult getContent(BytecodeProvider provider, IProgressMonitor monitor) throws CoreException {
 		Map<String, Object> decompilerOptions = new HashMap<>();
 		decompilerOptions.put(IFernflowerPreferences.HIDE_DEFAULT_CONSTRUCTOR, "0");

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
@@ -71,7 +71,10 @@ public class FernFlowerDecompiler extends DecompilerImpl {
 
 	private DecompilerResult getContent(BytecodeProvider provider, IProgressMonitor monitor) throws CoreException {
 		Map<String, Object> decompilerOptions = new HashMap<String, Object>();
+		decompilerOptions.put(IFernflowerPreferences.HIDE_DEFAULT_CONSTRUCTOR, "0");
+		decompilerOptions.put(IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1");
 		decompilerOptions.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
+		decompilerOptions.put(IFernflowerPreferences.REMOVE_BRIDGE, "1");
 		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
 		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_INNER, "1");
 		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_ENUM, "1");

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.decompiler;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.Map.Entry;
+import java.util.jar.Manifest;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.ls.core.internal.DecompilerResult;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler;
+import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger.Severity;
+
+public class FernFlowerDecompiler extends DecompilerImpl {
+	public static final String DECOMPILER_HEADER = "// Source code is decompiled from a .class file using FernFlower decompiler.\n";
+
+	public static boolean isDecompiledContents(String contents) {
+		return contents != null && contents.startsWith(DECOMPILER_HEADER);
+	}
+
+	@Override
+	protected DecompilerResult decompileContent(URI uri, IProgressMonitor monitor) throws CoreException {
+		return getContent(new BytecodeProvider(uri), monitor);
+	}
+
+	@Override
+	protected DecompilerResult decompileContent(IClassFile classFile, IProgressMonitor monitor) throws CoreException {
+		return getContent(new BytecodeProvider(classFile), monitor);
+	}
+
+	@Override
+	protected DecompilerType getDecompilerType() {
+		return DecompilerType.FERNFLOWER;
+	}
+
+	@Override
+	protected boolean isDecompiledContents(IClassFile classFile, String contents) {
+		return contents != null && contents.startsWith(DECOMPILER_HEADER);
+	}
+
+	private DecompilerResult getContent(BytecodeProvider provider, IProgressMonitor monitor) throws CoreException {
+		Map<String, Object> decompilerOptions = new HashMap<String, Object>();
+		decompilerOptions.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");
+		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES, "1");
+		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_INNER, "1");
+		decompilerOptions.put(IFernflowerPreferences.DECOMPILE_ENUM, "1");
+		decompilerOptions.put(IFernflowerPreferences.LOG_LEVEL, Severity.ERROR.name());
+		decompilerOptions.put(IFernflowerPreferences.ASCII_STRING_CHARACTERS, "1");
+		decompilerOptions.put(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1");
+		if (Boolean.getBoolean("jdt.ls.debug")) {
+			decompilerOptions.put(IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1");
+		}
+		ResultSaver resultSaver = new ResultSaver();
+		BaseDecompiler fernflower = new BaseDecompiler(provider, resultSaver, decompilerOptions, new IFernflowerLogger() {
+			@Override
+			public void writeMessage(String message, Severity severity) {
+				if (severity.ordinal() >= Severity.ERROR.ordinal()) {
+					JavaLanguageServerPlugin.logError(message);
+				}
+			}
+
+			@Override
+			public void writeMessage(String message, Severity severity, Throwable t) {
+				if (severity.ordinal() >= Severity.ERROR.ordinal()) {
+					JavaLanguageServerPlugin.logException(message, t);
+				}
+			}
+		});
+		fernflower.addSource(new File("__Fernflower__.class"));
+		fernflower.decompileContext();
+		final String decompiledCode = DECOMPILER_HEADER + resultSaver.content;
+		
+		final Map<Integer, Set<Integer>> originalLineMappings = new TreeMap<>();
+		final Map<Integer, Set<Integer>> decompiledLineMappings = new TreeMap<>();
+		for (int i = 0; i + 1 < resultSaver.originalLinesMapping.length; i = i + 2) {
+			int srcLine = resultSaver.originalLinesMapping[i];
+			int decompiledLine = resultSaver.originalLinesMapping[i + 1] + 1; // add one extra line for the header
+			Set<Integer> decompiled = originalLineMappings.computeIfAbsent(srcLine, k -> new TreeSet<>());
+			decompiled.add(decompiledLine);
+			Set<Integer> src = decompiledLineMappings.computeIfAbsent(decompiledLine, k -> new TreeSet<>());
+			src.add(srcLine);
+		}
+
+		List<Integer> originals = new ArrayList<>(originalLineMappings.size() * 2);
+		for (Entry<Integer, Set<Integer>> entry: originalLineMappings.entrySet()) {
+			int original = entry.getKey();
+			for (int value : entry.getValue()) {
+				originals.add(original);
+				originals.add(value);
+			}
+		}
+
+		List<Integer> decompiles = new ArrayList<>(decompiledLineMappings.size() * 2);
+		for (Entry<Integer, Set<Integer>> entry: decompiledLineMappings.entrySet()) {
+			int decompiled = entry.getKey();
+			for (int value : entry.getValue()) {
+				decompiles.add(decompiled);
+				decompiles.add(value);
+			}
+		}
+
+		return new DecompilerResult(decompiledCode,
+			originals.stream().mapToInt(Integer::intValue).toArray(),
+			decompiles.stream().mapToInt(Integer::intValue).toArray());
+	}
+
+	static class ResultSaver implements IResultSaver {
+		private String content;
+		private int[] originalLinesMapping;
+
+		@Override
+		public void closeArchive(String arg0, String arg1) {
+		}
+
+		@Override
+		public void copyEntry(String arg0, String arg1, String arg2, String arg3) {
+		}
+
+		@Override
+		public void copyFile(String arg0, String arg1, String arg2) {
+		}
+
+		@Override
+		public void createArchive(String arg0, String arg1, Manifest arg2) {
+		}
+
+		@Override
+		public void saveClassEntry(String arg0, String arg1, String arg2, String arg3, String arg4) {
+		}
+
+		@Override
+		public void saveClassFile(String filename, String qualifiedName, String entryName, String content, int[] originalLinesMapping) {
+			this.content = content;
+			this.originalLinesMapping = originalLinesMapping;
+		}
+
+		@Override
+		public void saveDirEntry(String arg0, String arg1, String arg2) {
+		}
+
+		@Override
+		public void saveFolder(String arg0) {
+		}
+	}
+
+	static class BytecodeProvider implements IBytecodeProvider {
+		private URI uri;
+		private byte[] classBytes;
+
+		public BytecodeProvider(URI uri) {
+			this.uri = uri;
+		}
+
+		public BytecodeProvider(IClassFile classFile) {
+			try {
+				classBytes = readClassFileBytes(classFile);
+			} catch (IOException e) {
+				// do nothing
+			}
+		}
+
+		@Override
+		public byte[] getBytecode(String externalPath, String internalPath) throws IOException {
+			if (classBytes != null) {
+				return classBytes;
+			} else if (uri == null) {
+				return null;
+			}
+
+			classBytes = readClassFileBytes(JDTUtils.resolveClassFile(uri));
+			if (classBytes == null) {
+				classBytes = Files.readAllBytes(Paths.get(uri));
+			}
+			return classBytes;
+		}
+
+		private byte[] readClassFileBytes(IClassFile classFile) throws IOException {
+			if (classFile == null) {
+				return null;
+			}
+
+			try {
+				return classFile.getBytes();
+			} catch (JavaModelException e) {
+				throw new IOException(e);
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/decompiler/FernFlowerDecompiler.java
@@ -70,7 +70,7 @@ public class FernFlowerDecompiler extends DecompilerImpl {
 	}
 
 	private DecompilerResult getContent(BytecodeProvider provider, IProgressMonitor monitor) throws CoreException {
-		Map<String, Object> decompilerOptions = new HashMap<String, Object>();
+		Map<String, Object> decompilerOptions = new HashMap<>();
 		decompilerOptions.put(IFernflowerPreferences.HIDE_DEFAULT_CONSTRUCTOR, "0");
 		decompilerOptions.put(IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1");
 		decompilerOptions.put(IFernflowerPreferences.REMOVE_SYNTHETIC, "1");

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToDefinitionHandlerTest.java
@@ -83,8 +83,8 @@ public class NavigateToDefinitionHandlerTest extends AbstractProjectsManagerBase
 	@Test
 	public void testSourceVersion() throws Exception {
 		String className = "javax.tools.Tool";
-		int line = 6;
-		int column = 57;
+		int line = 11;
+		int column = 12;
 		String uri = ClassFileUtil.getURI(project, className);
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
 		List<? extends Location> definitions = handler.definition(new TextDocumentPositionParams(identifier, new Position(line, column)), monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToTypeDefinitionHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/NavigateToTypeDefinitionHandlerTest.java
@@ -66,8 +66,8 @@ public class NavigateToTypeDefinitionHandlerTest extends AbstractProjectsManager
 	@Test
 	public void testDisassembledSource() throws JavaModelException {
 		String className = "javax.tools.Tool";
-		int line = 6;
-		int column = 57;
+		int line = 11;
+		int column = 12;
 		String uri = ClassFileUtil.getURI(project, className);
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
 		List<? extends Location> definitions = handler.typeDefinition(new TextDocumentPositionParams(identifier, new Position(line, column)), monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ReferencesHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/ReferencesHandlerTest.java
@@ -129,7 +129,7 @@ public class ReferencesHandlerTest extends AbstractProjectsManagerBasedTest{
 		URI uri = JDTUtils.toURI(JDTUtils.toUri(cf));
 		String fileURI = ResourceUtils.fixURI(uri);
 		ReferenceParams param = new ReferenceParams();
-		param.setPosition(new Position(7, 6));
+		param.setPosition(new Position(5, 6));
 		param.setContext(new ReferenceContext(false));
 		param.setTextDocument(new TextDocumentIdentifier(fileURI));
 		List<Location> references = handler.findReferences(param, monitor);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
-import org.eclipse.jdt.ls.core.internal.DisassemblerContentProvider;
+import org.eclipse.jdt.ls.core.internal.DecompilerResult;
 import org.eclipse.jdt.ls.core.internal.FakeContentProvider;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
@@ -219,6 +219,24 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 		assertNotNull(result);
 		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		assertTrue("unexpected body content " + result, result.contains("public class BigDecimal extends Number implements Comparable"));
+	}
+
+	@Test
+	public void testDecompileLineMappings() throws Exception {
+		importProjects("eclipse/reference");
+		IProject project = WorkspaceHelper.getProject("reference");
+		URI sourcelessURI = JDTUtils.toURI(ClassFileUtil.getURI(project, "org.sample.Foo"));
+		IClassFile classFile = JDTUtils.resolveClassFile(sourcelessURI);
+		when(preferences.getPreferredContentProviderIds()).thenReturn(Arrays.asList("fernflowerContentProvider"));
+
+		DecompilerResult result = provider.getSourceResult(classFile, monitor);
+		assertNotNull(result);
+		assertNotNull(result.getOriginalLineMappings());
+		assertEquals(6, result.getOriginalLineMappings().length);
+		assertEquals(11, result.getOriginalLineMappings()[0]);
+		assertEquals(12, result.getOriginalLineMappings()[1]);
+		assertNotNull(result.getDecompiledLineMappings());
+		assertEquals(6, result.getDecompiledLineMappings().length);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/ContentProviderManagerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.ls.core.internal.DisassemblerContentProvider;
 import org.eclipse.jdt.ls.core.internal.FakeContentProvider;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
 import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.decompiler.FernFlowerDecompiler;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
 import org.junit.After;
@@ -132,7 +133,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 		String result = provider.getContent(sourcelessURI, monitor);
 
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("Something bad happened here");
 	}
 
@@ -143,7 +144,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 		String result = provider.getSource(sourcelessClassFile, monitor);
 
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("Something bad happened here");
 	}
 
@@ -151,7 +152,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 	public void testDefaultOrder() throws Exception {
 		String result = provider.getContent(sourcelessURI, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("You have more than one content provider installed:");
 	}
 
@@ -159,7 +160,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 	public void testDecompileDefaultOrder() throws Exception {
 		String result = provider.getSource(sourcelessClassFile, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("You have more than one content provider installed:");
 	}
 
@@ -187,7 +188,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 
 		String result = provider.getContent(sourcelessURI, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("Unable to load IContentProvider class for placeholderContentProvider");
 	}
 
@@ -197,7 +198,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 
 		String result = provider.getSource(sourcelessClassFile, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 		expectLoggedError("Unable to load IDecompiler class for placeholderContentProvider");
 	}
 
@@ -207,7 +208,7 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 
 		String result = provider.getContent(sourcelessURI, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
 	}
 
 	@Test
@@ -216,8 +217,8 @@ public class ContentProviderManagerTest extends AbstractProjectsManagerBasedTest
 
 		String result = provider.getContent(sourcelessURI, monitor);
 		assertNotNull(result);
-		assertTrue("disassembler header is missing from " + result, result.startsWith(DisassemblerContentProvider.DISASSEMBLED_HEADER));
-		assertTrue("unexpected body content " + result, result.contains("public class BigDecimal extends java.lang.Number implements java.lang.Comparable {"));
+		assertTrue("disassembler header is missing from " + result, result.startsWith(FernFlowerDecompiler.DECOMPILER_HEADER));
+		assertTrue("unexpected body content " + result, result.contains("public class BigDecimal extends Number implements Comparable"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR does the following:
- It replaces the default disassembler `ClassFileBytesDisassembler` with `fernflower` decompiler, which provides better decompilation results.
- It records the line mappings when decompiling class file, which is needed by the debugger to re-map the line numbers when a breakpoint occurs.