### PR TITLE
Java LS tests fail randomly

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ProjectsManager.java
@@ -71,6 +71,7 @@ import org.eclipse.jdt.ls.core.internal.IConstants;
 import org.eclipse.jdt.ls.core.internal.IProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.JobHelpers;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.ServiceStatus;
@@ -363,7 +364,7 @@ public abstract class ProjectsManager implements ISaveParticipant, IProjectsMana
 
 		IJavaProject javaProject = JavaCore.create(project);
 		configureJVMSettings(javaProject);
-
+		JobHelpers.waitForBuildJobs(JobHelpers.MAX_TIME_MILLIS);
 		//Add build output folder
 		if (StringUtils.isNotBlank(bin)) {
 			IFolder output = project.getFolder(bin);

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.jdt.ls.core.internal.managers;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -268,6 +269,7 @@ public abstract class AbstractProjectsManagerBasedTest {
 		projectsManager = null;
 		Platform.removeLogListener(logListener);
 		logListener = null;
+		Job.getJobManager().setProgressProvider(null);
 		try {
 			waitForBackgroundJobs();
 		} catch (Exception e) {
@@ -275,17 +277,19 @@ public abstract class AbstractProjectsManagerBasedTest {
 		}
 		WorkspaceHelper.deleteAllProjects();
 		try {
+			waitForBackgroundJobs();
+		} catch (Exception e) {
+			JavaLanguageServerPlugin.logException(e);
+		}
+		File workspaceDir = new File("target", "workingProjects");
+		try {
 			// https://github.com/eclipse/eclipse.jdt.ls/issues/996
-			FileUtils.forceDelete(getWorkingProjectDirectory());
+			FileUtils.forceDelete(workspaceDir);
 		} catch (IOException e) {
 			JavaLanguageServerPlugin.logException(e);
-			try {
-				getWorkingProjectDirectory().deleteOnExit();
-			} catch (IOException e1) {
-				JavaLanguageServerPlugin.logException(e1);
-			}
+			workspaceDir.deleteOnExit();
 		}
-		Job.getJobManager().setProgressProvider(null);
+		assertFalse(workspaceDir.exists());
 		try {
 			waitForBackgroundJobs();
 		} catch (Exception e) {


### PR DESCRIPTION
Fixes #2711 

Fixes tests with the `Resource '/TestProject/bin' already exists.` message.