### PR TITLE
Prevent caching outdated AST in CoreASTProvider

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDocumentLifeCycleHandler.java
@@ -426,7 +426,13 @@ public abstract class BaseDocumentLifeCycleHandler {
 
 		try {
 			if (unit.equals(sharedASTProvider.getActiveJavaElement())) {
+				// We call clearReconciliation here in an attempt to prevent getAST calls on other threads
+				// from caching outdated AST after we just called disposeAST. See also:
+				// https://github.com/eclipse/eclipse.jdt.ls/issues/1918
+				// https://github.com/eclipse/eclipse.jdt.ls/pull/2714#discussion_r1234817900
+				sharedASTProvider.clearReconciliation();
 				sharedASTProvider.disposeAST();
+				sharedASTProvider.clearReconciliation();
 				CodeActionHandler.codeActionStore.clear();
 			}
 


### PR DESCRIPTION
Related to #1918
Related to redhat-developer/vscode-java#2176

This PR fixes (only partially, see discussion below) #1918 via "Option C" described in this comment: https://github.com/eclipse/eclipse.jdt.ls/issues/1918#issuecomment-1597858838

This PR is an alternative to #2709. I believe there are some problems with that workaround, see https://github.com/eclipse/eclipse.jdt.ls/pull/2709#issuecomment-1597033037

To my knowledge, this PR should fix `#1918` completely, ~~without any edge cases.~~ *This was not the case, see review comments in the discussion below.*