### PR TITLE
Set progressManager in application

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -77,7 +77,7 @@ public class JavaClientConnection {
 	}
 
 	private final LogHandler logHandler;
-	private final JavaLanguageClient client;
+	final JavaLanguageClient client;
 
 	public JavaClientConnection(JavaLanguageClient client) {
 		this.client = client;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServerApplication.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/LanguageServerApplication.java
@@ -28,8 +28,11 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.jdt.ls.core.internal.handlers.JDTLanguageServer;
+import org.eclipse.jdt.ls.core.internal.handlers.ProgressReporterManager;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
@@ -42,12 +45,21 @@ public class LanguageServerApplication implements IApplication {
 	private InputStream in;
 	private PrintStream out;
 	private PrintStream err;
+	private ProgressReporterManager progressReporterManager;
 
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
 		prepareWorkspace();
 		prepareStreams();
 		JavaLanguageServerPlugin.startLanguageServer(this);
+		if (JavaLanguageServerPlugin.getInstance().getProtocol() instanceof JDTLanguageServer server) {
+			progressReporterManager = new ProgressReporterManager(server.getClientConnection().client, JavaLanguageServerPlugin.getPreferencesManager());
+			// Setting progressProvider is only allowed if the application is "owned" by the caller.
+			// see Javadoc for setProgressProvider.
+			// In case of JDT-LS integrated in Eclipse Workbench, the application is the workbench and this progressProvider
+			// must not be overridden. In case of the LanguageServerApplication, we own it, so we can set. 
+			Job.getJobManager().setProgressProvider(progressReporterManager);
+		}
 		synchronized (waitLock) {
 			while (!shutdown) {
 				try {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -239,8 +239,6 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	@Override
 	public void connectClient(JavaLanguageClient client) {
 		super.connectClient(client);
-		progressReporterManager = new ProgressReporterManager(client, preferenceManager);
-		Job.getJobManager().setProgressProvider(progressReporterManager);
 		this.workingCopyOwner = new LanguageServerWorkingCopyOwner(this.client);
 		pm.setConnection(client);
 		WorkingCopyOwner.setPrimaryBufferProvider(this.workingCopyOwner);


### PR DESCRIPTION
As per API, the progressManager should be set by the owning application only and plugins mustn't modify it.
In Eclipse Workbench, overriding it with the implementation in JDT-LS cause infinite threads consumption since
348252b6fa3d61d02145707d0f6d244c57ddf1fa