### PR TITLE
Re-Set progressManager in application

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/JavaClientConnection.java
@@ -77,7 +77,7 @@ public class JavaClientConnection {
 	}
 
 	private final LogHandler logHandler;
-	private final JavaLanguageClient client;
+	final JavaLanguageClient client;
 
 	public JavaClientConnection(JavaLanguageClient client) {
 		this.client = client;

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -240,7 +240,6 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public void connectClient(JavaLanguageClient client) {
 		super.connectClient(client);
 		progressReporterManager = new ProgressReporterManager(client, preferenceManager);
-		Job.getJobManager().setProgressProvider(progressReporterManager);
 		this.workingCopyOwner = new LanguageServerWorkingCopyOwner(this.client);
 		pm.setConnection(client);
 		WorkingCopyOwner.setPrimaryBufferProvider(this.workingCopyOwner);
@@ -259,6 +258,10 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 	public void disconnectClient() {
 		Job.getJobManager().setProgressProvider(null);
 		this.client.disconnect();
+	}
+
+	public ProgressReporterManager getProgressReporterManager() {
+		return this.progressReporterManager;
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
Keep the progressReportManager where it is, but set it only as default one for JobManager in the application.

This reverts and adapt commit 844ef8684925b0b5d2e521db0ce3c2d7b9dfa9c6.