### PR TITLE
Add more trace to understand the project import success rate

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/ResourceUtils.java
@@ -44,6 +44,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jdt.core.IJavaModelMarker;
+import org.eclipse.jdt.core.compiler.IProblem;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
@@ -382,5 +383,10 @@ public final class ResourceUtils {
 		marker.setAttribute(IMarker.MESSAGE, message);
 		marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
 		return marker;
+	}
+
+	public static boolean isUnresolvedImportError(IMarker marker) {
+		return marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR
+			&& marker.getAttribute(IJavaModelMarker.ID, 0) == IProblem.ImportNotFound;
 	}
 }

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -28,14 +28,13 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.ls.core.internal.JavaClientConnection.JavaLanguageClient;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
+import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
 
 import com.google.gson.JsonArray;
@@ -119,7 +118,7 @@ public class TelemetryManager {
 					IMarker[] projectMarkers = project.findMarkers(null /* all markers */, true /* subtypes */, IResource.DEPTH_ZERO);
 					projectErrors += Stream.of(projectMarkers).filter(m -> m.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR).count();
 					IMarker[] allmarkers = project.findMarkers(null /* all markers */, true /* subtypes */, IResource.DEPTH_INFINITE);
-					unresolvedImportErrors += Stream.of(allmarkers).filter(m -> isUnresolvedImportError(m)).count();
+					unresolvedImportErrors += Stream.of(allmarkers).filter(m -> ResourceUtils.isUnresolvedImportError(m)).count();
 				} catch (CoreException e) {
 					// ignore
 				}
@@ -169,11 +168,6 @@ public class TelemetryManager {
 		properties.addProperty("dependency.size", Long.toString(librarySize));
 
 		telemetryEvent(JAVA_PROJECT_BUILD, properties);
-	}
-
-	private boolean isUnresolvedImportError(IMarker marker) {
-		return marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR
-			&& marker.getAttribute(IJavaModelMarker.ID, 0) == IProblem.ImportNotFound;
 	}
 
 	/**

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -128,7 +128,7 @@ public class TelemetryManager {
 				if (javaProject != null) {
 					try {
 						IVMInstall vmInstall = JavaRuntime.getVMInstall(javaProject);
-						if (JavaRuntime.compareJavaVersions(vmInstall, sourceLevel) == -1) {
+						if (JavaRuntime.compareJavaVersions(vmInstall, sourceLevel) < 0) {
 							jdkMismatch = true;
 						}
 					} catch (CoreException e) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/TelemetryManager.java
@@ -94,8 +94,8 @@ public class TelemetryManager {
 		int javaProjectCount = 0;
 		JsonArray buildToolNamesList = new JsonArray();
 
-		int projectErrors = 0;
-		int unresolvedImportErrors = 0;
+		long projectErrors = 0;
+		long unresolvedImportErrors = 0;
 		boolean jdkMismatch = false;
 		for (IProject project : ProjectUtils.getAllProjects()) {
 			Optional<IBuildSupport> bs = this.projectsManager.getBuildSupport(project);
@@ -139,8 +139,8 @@ public class TelemetryManager {
 			}
 		}
 
-		properties.addProperty("project.projectErrorCount", Integer.toString(projectErrors));
-		properties.addProperty("project.unresolvedImportErrorCount", Integer.toString(unresolvedImportErrors));
+		properties.addProperty("project.projectErrorCount", Long.toString(projectErrors));
+		properties.addProperty("project.unresolvedImportErrorCount", Long.toString(unresolvedImportErrors));
 		properties.addProperty("project.autobuild", Boolean.toString(prefs.getPreferences().isAutobuildEnabled()));
 		properties.addProperty("project.jdkMismatch", Boolean.toString(jdkMismatch));
 


### PR DESCRIPTION
Add more trace to understand the language server status:
- Measure the import success rate. The indicator we can use is the error diagnostics. If the project root level has error or the Java file has unresolved import errors, we can count it as an import failure. 
- Detect the cases of jdk mismatch.