### PR TITLE
Check completion proposal is compatible or not

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
@@ -43,7 +43,7 @@ public class LambdaExpressionCleanup implements ISimpleCleanUp {
 		if (unit == null) {
 			return null;
 		}
-		return LambdaExpressionsFixCore.createCleanUp(unit, true, false);
+		return LambdaExpressionsFixCore.createCleanUp(unit, true, false, true);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/CompletionProposalReplacementProvider.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
+import org.eclipse.jdt.internal.codeassist.InternalCompletionProposal;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.template.java.SignatureUtil;
@@ -800,6 +801,12 @@ public class CompletionProposalReplacementProvider {
 				// with the corresponding type parameters to declared type
 
 				IType expectedType= (IType) expectedTypeBinding.getJavaElement();
+
+				if (proposal instanceof InternalCompletionProposal icp && !icp.isCompatibleProposal()) {
+					// the proposal is not compatible with the expected type
+					// -> do not add any type arguments
+					return new String[0];
+				}
 
 				IType[] path= TypeProposalUtils.computeInheritancePath(type, expectedType);
 				if (path == null) {

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/contentassist/SignatureHelpRequestor.java
@@ -19,6 +19,7 @@ import static org.eclipse.jdt.internal.corext.template.java.SignatureUtil.getLow
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,7 @@ import com.google.common.util.concurrent.UncheckedTimeoutException;
 
 public final class SignatureHelpRequestor extends CompletionRequestor {
 
-	private List<CompletionProposal> proposals = new ArrayList<>();
+	private Map<String, CompletionProposal> proposals = new LinkedHashMap<>();
 	private List<CompletionProposal> typeProposals = new ArrayList<>();
 	private final ICompilationUnit unit;
 	private Map<SignatureInformation, CompletionProposal> infoProposals;
@@ -83,9 +84,8 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 		SignatureHelp signatureHelp = new SignatureHelp();
 
 		List<SignatureInformation> infos = new ArrayList<>();
-		for (int i = 0; i < proposals.size(); i++) {
+		for (CompletionProposal proposal : proposals.values()) {
 			if (!monitor.isCanceled()) {
-				CompletionProposal proposal = proposals.get(i);
 				if (proposal.getKind() != CompletionProposal.METHOD_REF) {
 					typeProposals.add(proposal);
 					continue;
@@ -128,14 +128,14 @@ public final class SignatureHelpRequestor extends CompletionRequestor {
 					for (String typeName : this.declaringTypeNames) {
 						String declaringTypeSimpleName = Signature.getSimpleName(typeName);
 						if (Objects.equals(proposalTypeSimpleName, declaringTypeSimpleName)) {
-							proposals.add(proposal);
+							proposals.putIfAbsent(String.valueOf(proposal.getSignature()), proposal);
 							return;
 						}
 					}
 					return;
 				}
 			}
-			proposals.add(proposal);
+			proposals.putIfAbsent(String.valueOf(proposal.getSignature()), proposal);
 		}
 	}
 

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -29,7 +29,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230611-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230626-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
@@ -426,7 +426,7 @@ public class AnonymousClassCreationToLambdaTest extends AbstractSelectionTest {
 		buf.append("\n");
 		buf.append("public class Test {\n");
 		buf.append("    void foo(ArrayList<String> list) {\n");
-		buf.append("        list.removeIf(t -> t.isEmpty());\n");
+		buf.append("        list.removeIf(String::isEmpty);\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		Expected e = new Expected("Convert to lambda expression", buf.toString());


### PR DESCRIPTION
- Early return if the completion proposal is not compatible with the expected type.

This adopts the new API added by https://github.com/eclipse-jdt/eclipse.jdt.core/pull/939/files from upstream. It should significantly boost the constructor completion performance when **lazy resolve is off** and the **expected type has type parameters**.

Trigger completion with following code in `spring-petclinic`:

```java
List<String> l = new A|
```
| # | With the change | Without the change |
|---|---|---|
| 1 | 2729 | 3890 |
| 2 | 415 | 1534 |
| 3 | 345 | 1252 |
| 4 | 337 | 1011 |
| 5 | 281 | 982 |
| Avg. | 821.4 | 1733.8 |


