### PR TITLE
Attempt automatic JVM detection on startup

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/cleanup/LambdaExpressionCleanup.java
@@ -43,7 +43,7 @@ public class LambdaExpressionCleanup implements ISimpleCleanUp {
 		if (unit == null) {
 			return null;
 		}
-		return LambdaExpressionsFixCore.createCleanUp(unit, true, false);
+		return LambdaExpressionsFixCore.createCleanUp(unit, true, false, false);
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
+++ b/org.eclipse.jdt.ls.target/org.eclipse.jdt.ls.tp.target
@@ -29,7 +29,7 @@
             <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230611-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.29-I-builds/I20230625-1800/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/refactoring/AnonymousClassCreationToLambdaTest.java
@@ -426,7 +426,7 @@ public class AnonymousClassCreationToLambdaTest extends AbstractSelectionTest {
 		buf.append("\n");
 		buf.append("public class Test {\n");
 		buf.append("    void foo(ArrayList<String> list) {\n");
-		buf.append("        list.removeIf(t -> t.isEmpty());\n");
+		buf.append("        list.removeIf(String::isEmpty);\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		Expected e = new Expected("Convert to lambda expression", buf.toString());


### PR DESCRIPTION
- Update target platform to I20230615-1800

See https://github.com/eclipse-jdt/eclipse.jdt.debug/issues/230

When the following command request is made :

```json
{
  message: "[Trace - 11:25:11] Sending request 'workspace/executeCommand - (9)'.",
  level: 'info',
  timestamp: '2023-06-27 11:25:11.077'
}
{
  message: 'Params: {\n' +
    '    "command": "java.project.getSettings",\n' +
    '    "arguments": [\n' +
    '        "file:///home/rgrunber/sample-projects/null-analysis-app/",\n' +
    '        [\n' +
    '            "org.eclipse.jdt.core.compiler.source",\n' +
    '            "org.eclipse.jdt.ls.core.vm.location"\n' +
    '        ]\n' +
    '    ]\n' +
    '}\n' +
    '\n',
  level: 'info',
  timestamp: '2023-06-27 11:25:11.077'
}
```

The response for `"org.eclipse.jdt.ls.core.vm.location"` is something like :
`"/usr/lib/jvm/java-11-openjdk-11.0.19.0.7-1.fc37.x86_64"`
instead of :
`"/usr/lib/jvm/java-17-openjdk-17.0.7.0.7-5.fc37.x86_64"`.

This assumes a JVM from the system can be detected and that `"org.eclipse.jdt.core.compiler.source": "11"` is detected from the build configuration.