### PR TITLE
Should not delete the project javanature when removing a nested .classpath resource file

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/IBuildSupport.java
@@ -96,7 +96,8 @@ public interface IBuildSupport {
 		if (changeType == CHANGE_TYPE.DELETED) {
 			if (IJavaProject.CLASSPATH_FILE_NAME.equals(resource.getName())) {
 				IProject project = resource.getProject();
-				if (ProjectUtils.isJavaProject(project)) {
+				if (ProjectUtils.isJavaProject(project) && (resource.equals(project.getFile(IJavaProject.CLASSPATH_FILE_NAME))
+						|| resource.getProjectRelativePath().segmentCount() == 1)) {
 					ProjectUtils.removeJavaNatureAndBuilder(project, monitor);
 					update(project, true, monitor);
 				}

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/classpath3/.classpath
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/classpath3/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="output" path="target"/>
+</classpath>

--- a/org.eclipse.jdt.ls.tests/projects/eclipse/classpath3/.project
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/classpath3/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>classpath3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/EclipseProjectMetadataFileTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/filesystem/EclipseProjectMetadataFileTest.java
@@ -28,6 +28,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
@@ -97,5 +98,21 @@ public class EclipseProjectMetadataFileTest extends AbstractProjectsManagerBased
 		assertFalse(ProjectUtils.isJavaProject(project));
 		IFile bin = project.getFile("bin");
 		assertFalse(bin.getRawLocation().toFile().exists());
+	}
+
+	@Test
+	public void testDeleteNonMetadataClasspath() throws Exception {
+		String name = "classpath3";
+		importProjects("eclipse/" + name);
+		IProject project = getProject(name);
+		assertNotNull(project);
+		IFile dotClasspath = project.getFile(new Path("resources/.classpath"));
+		File file = FileUtil.toPath(dotClasspath.getLocationURI()).toFile();
+		assertTrue(file.exists());
+		file.delete();
+		projectsManager.fileChanged(file.toPath().toUri().toString(), CHANGE_TYPE.DELETED);
+		waitForBackgroundJobs();
+		project = getProject(name);
+		assertTrue(ProjectUtils.isJavaProject(project));
 	}
 }


### PR DESCRIPTION
Running JUnit Plugin Tests of `org.eclipse.jdt.ls.tests` in VS Code causes Java extension to delete javanature from `.project` file of `org.eclipse.jdt.ls.tests` project. This is because the test framework removes temporary test projects (e.g. `eclipse.jdt.ls/org.eclipse.jdt.ls.tests/target/workingProjects/maven/salut/.classpath`) after testing, which triggers a .classpath delete event as part of `didChangeWatchedFiles` event. The language server then deletes javanature of the parent project when it detects a .classpath delete event. This is annoying when you dogfood eclipse.jdt.ls development in VS Code.


Here are the reproducing steps:
1. Open the following eclipse-project in VS Code
```
eclipse-project
│   .classpath
│   .project
└───resources
        .classpath
```
2. Delete `.classpath` file under `resources` folder
3. You will see that javanature is removed from the `.project` file.

