### PR TITLE
Send a SourceInvalidatedEvent to client when source attachment is updated for jar libraries

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/EventType.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/EventType.java
@@ -33,7 +33,12 @@ public enum EventType {
 	/**
 	 * Recommended to upgrade Gradle wrapper event.
 	 */
-	UpgradeGradleWrapper(400);
+	UpgradeGradleWrapper(400),
+
+	/**
+	 * Source attachments have been updated for some jar libraries.
+	 */
+	SourceInvalidated(500);
 
 	private final int value;
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/JDTLanguageServer.java
@@ -298,6 +298,8 @@ public class JDTLanguageServer extends BaseJDTLanguageServer implements Language
 					workspaceDiagnosticsHandler.addResourceChangeListener();
 					classpathUpdateHandler = new ClasspathUpdateHandler(JDTLanguageServer.this.client);
 					classpathUpdateHandler.addElementChangeListener();
+					SourceAttachUpdateHandler attachListener = new SourceAttachUpdateHandler(client);
+					attachListener.addElementChangeListener();
 					pm.registerWatchers();
 					debugTrace(">> watchers registered");
 

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SourceAttachUpdateHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/SourceAttachUpdateHandler.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jdt.core.ElementChangedEvent;
+import org.eclipse.jdt.core.IElementChangedListener;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaElementDelta;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.EventNotification;
+import org.eclipse.jdt.ls.core.internal.EventType;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.managers.ISourceDownloader;
+
+public class SourceAttachUpdateHandler implements IElementChangedListener {
+	private final JavaClientConnection connection;
+
+	public SourceAttachUpdateHandler(JavaClientConnection client) {
+		this.connection = client;
+	}
+
+	@Override
+	public void elementChanged(ElementChangedEvent event) {
+		Set<IJavaElement> sourceAttachChangedElements = new HashSet<>();
+		processDelta(event.getDelta(), sourceAttachChangedElements);
+		if (connection != null && !sourceAttachChangedElements.isEmpty()) {
+			SourceInvalidatedEvent invalidatedJarSource = new SourceInvalidatedEvent();
+			for (IJavaElement changedElement : sourceAttachChangedElements) {
+				if (changedElement instanceof JarPackageFragmentRoot jar) {
+					try {
+						if (jar.getSourceAttachmentPath() != null) {
+							int downloadStatus = JavaLanguageServerPlugin.getDefaultSourceDownloader().getDownloadStatus(jar);
+							if (downloadStatus == ISourceDownloader.DOWNLOAD_REQUESTED) {
+								// The download job completes quickly and the source provider
+								// uses the source jar right away. No action is needed.
+								JavaLanguageServerPlugin.getDefaultSourceDownloader().clearDownloadStatus(jar);
+								continue;
+							} else if (downloadStatus == ISourceDownloader.DOWNLOAD_WAIT_JOB_DONE) {
+								// The source attachment event arrives after the source
+								// request is responded. This means the decompiled source
+								// is in use first, and need to reload the source provider
+								// to use the new source jar.
+								invalidatedJarSource.addRootPath(jar, true);
+								JavaLanguageServerPlugin.getDefaultSourceDownloader().clearDownloadStatus(jar);
+							} else if (downloadStatus == ISourceDownloader.DOWNLOAD_NONE) {
+								// The source attachment event is not triggered by download
+								// job.
+								invalidatedJarSource.addRootPath(jar, false);
+							}
+						}
+					} catch (JavaModelException e) {
+						// skip
+					}
+				}
+			}
+
+			if (!invalidatedJarSource.isEmpty()) {
+				EventNotification notification = new EventNotification().withType(EventType.SourceInvalidated).withData(invalidatedJarSource);
+				this.connection.sendEventNotification(notification);
+			}
+		}
+	}
+
+	public void addElementChangeListener() {
+		JavaCore.addElementChangedListener(this);
+	}
+
+	public void removeElementChangeListener() {
+		JavaCore.removeElementChangedListener(this);
+	}
+
+	private void processDelta(IJavaElementDelta delta, Set<IJavaElement> result) {
+		IJavaElement element = delta.getElement();
+		if (element.getElementType() != IJavaElement.JAVA_MODEL && !isClasspathChangedEvent(delta)) {
+			return;
+		}
+
+		IJavaElementDelta[] children = delta.getAffectedChildren();
+		if (children == null || children.length == 0) {
+			if ((delta.getFlags() & IJavaElementDelta.F_SOURCEATTACHED) != 0) {
+				result.add(delta.getElement());
+			}
+			return;
+		}
+
+		for (IJavaElementDelta child : children) {
+			processDelta(child, result);
+		}
+	}
+
+	private boolean isClasspathChangedEvent(IJavaElementDelta delta) {
+		return (delta.getFlags() & (IJavaElementDelta.F_CLASSPATH_CHANGED | IJavaElementDelta.F_SOURCEATTACHED
+			| IJavaElementDelta.F_RESOLVED_CLASSPATH_CHANGED)) != 0;
+	}
+
+	/**
+	 * The package fragment roots are updated with new source attachments,
+	 * and it should notify the client to reload the source that was requested
+	 * previously.
+	 */
+	public static class SourceInvalidatedEvent {
+		private Map<String, Boolean> affectedRootPaths = new LinkedHashMap<>();
+
+		public void addRootPath(IPackageFragmentRoot root, boolean isAutoDownloadedSource) {
+			affectedRootPaths.put(root.getPath().toPortableString(), isAutoDownloadedSource);
+		}
+
+		public boolean isEmpty() {
+			return affectedRootPaths.isEmpty();
+		}
+
+		public boolean contains(IPackageFragmentRoot root, boolean isAutoDownloadedSource) {
+			return affectedRootPaths.getOrDefault(root.getPath().toPortableString(), !isAutoDownloadedSource) == isAutoDownloadedSource;
+		}
+	}
+}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ISourceDownloader.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/ISourceDownloader.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
 
 /**
  * Service to automatically discover and attach sources to unknown class files.
@@ -24,6 +25,20 @@ import org.eclipse.jdt.core.IClasspathEntry;
  *
  */
 public interface ISourceDownloader {
+	/**
+	 * No download record exists for the element.
+	 */
+	public int DOWNLOAD_NONE = 0x001;
+	/**
+	 * The element's source is missing and about to
+	 * initiate a source download request.
+	 */
+	public int DOWNLOAD_REQUESTED = 0x002;
+	/**
+	 * The download waiting job has either finished
+	 * or expired.
+	 */
+	public int DOWNLOAD_WAIT_JOB_DONE = 0x004;
 
 	/**
 	 * Discovers and attaches sources to the given {@link IClassFile}'s parent
@@ -37,5 +52,18 @@ public interface ISourceDownloader {
 	 */
 	public void discoverSource(IClassFile classFile, IProgressMonitor monitor) throws CoreException;
 
+	/**
+	 * Gets the status of source download job for the jar element.
+	 * @param root
+	 *            the root jar element
+	 * @return the status of source download job
+	 */
+	public int getDownloadStatus(IPackageFragmentRoot root);
 
+	/**
+	 * Cleanup the download status for the jar element.
+	 * @param root
+	 *            the root jar element
+	 */
+	default void clearDownloadStatus(IPackageFragmentRoot root) { }
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SourceAttachUpdateHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/SourceAttachUpdateHandlerTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+* Copyright (c) 2023 Microsoft Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.ls.core.internal.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.ls.core.internal.ClassFileUtil;
+import org.eclipse.jdt.ls.core.internal.EventNotification;
+import org.eclipse.jdt.ls.core.internal.EventType;
+import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JavaClientConnection;
+import org.eclipse.jdt.ls.core.internal.WorkspaceHelper;
+import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand;
+import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand.SourceAttachmentAttribute;
+import org.eclipse.jdt.ls.core.internal.commands.SourceAttachmentCommand.SourceAttachmentResult;
+import org.eclipse.jdt.ls.core.internal.handlers.SourceAttachUpdateHandler.SourceInvalidatedEvent;
+import org.eclipse.jdt.ls.core.internal.managers.AbstractProjectsManagerBasedTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SourceAttachUpdateHandlerTest extends AbstractProjectsManagerBasedTest {
+	@Mock
+	private JavaClientConnection connection;
+
+	@Test
+	public void attachSource() throws Exception {
+		importProjects("eclipse/source-attachment");
+		IProject project = WorkspaceHelper.getProject("source-attachment");
+
+		SourceAttachUpdateHandler attachListener = new SourceAttachUpdateHandler(connection);
+		attachListener.addElementChangeListener();
+
+		IResource source = project.findMember("foo-sources.jar");
+		assertNotNull(source);
+		IPath sourcePath = source.getLocation();
+		String uri = ClassFileUtil.getURI(project, "foo.bar");
+		IClassFile classfile = JDTUtils.resolveClassFile(uri);
+		IPackageFragmentRoot packageRoot = (IPackageFragmentRoot) classfile.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+		assertNotNull(packageRoot);
+		SourceAttachmentAttribute attributes = new SourceAttachmentAttribute(null, sourcePath.toOSString(), "UTF-8");
+
+		reset(connection);
+		SourceAttachmentResult updateResult = SourceAttachmentCommand.updateSourceAttachment(
+			packageRoot, attributes, monitor);
+		assertNotNull(updateResult);
+		assertNull(updateResult.errorMessage);
+		ArgumentCaptor<EventNotification> argument = ArgumentCaptor.forClass(EventNotification.class);
+		verify(connection, times(1)).sendEventNotification(argument.capture());
+		assertEquals(EventType.SourceInvalidated, argument.getValue().getType());
+		assertEquals(true, ((SourceInvalidatedEvent) argument.getValue().getData()).contains(packageRoot, false));
+	}
+}


### PR DESCRIPTION
This PR enables switching between decompiled source and original source jar. For example, when you go to a maven library, the language server will try to download its source jar asynchronously. However, the language server will only wait for the download job for 3 seconds. If the source jar is downloaded within that time, it will use the source jar directly. Otherwise, it will use the decompiled source. This works fine for the backend language server, as it will automatically switch to the original source jar when it is ready. But it causes a problem for the client, because the client will cache the class file contents in editors from the first request. This will make the client and server see different sources for class files.

To solve this problem, this PR will send a SourceInvalidatedEvent to the client when the source attachment is updated for jar libraries. The client can refresh the cached source if it detects that some class files have new source attachments.