### PR TITLE
Fix call hierarchy position resolution #2771

### DIFF
--- a/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/CallHierarchyGH2771.java
+++ b/org.eclipse.jdt.ls.tests/projects/eclipse/hello/src/org/sample/CallHierarchyGH2771.java
@@ -1,0 +1,11 @@
+package org.sample;
+
+public interface CallHierarchyGH2771 {
+    Opt<String> name();
+
+    public static class Opt<T> {
+        public static <T> Opt<T> of(T t) {
+            return new Opt();
+        }
+    }
+}

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/handlers/CallHierarchyHandlerTest.java
@@ -193,6 +193,35 @@ public class CallHierarchyHandlerTest extends AbstractProjectsManagerBasedTest {
 		assertTrue(jarUri.contains("WordUtils.class"));
 	}
 
+	@Test
+	public void incomingCalls_OnInterfaceMethod() throws Exception {
+		// Line 27 from `CallHierarchy`
+		//    public void <|>bar() {
+		String uri = getUriFromSrcProject("org.sample.CallHierarchyGH2771");
+		List<CallHierarchyItem> items = prepareCallHierarchy(uri, 3, 17);
+		assertNotNull(items);
+		assertEquals(1, items.size());
+		assertItem(items.get(0), "name()" + JavaElementLabels.DECL_STRING + "Opt<String>", Method, "org.sample.CallHierarchyGH2771", false, 3);
+
+		List<CallHierarchyIncomingCall> calls = getIncomingCalls(items.get(0));
+		assertNotNull(calls);
+		assertEquals(0, calls.size());
+	}
+
+	@Test
+	public void incomingCalls_OnInterfaceMethodReturnType() throws Exception {
+		// Line 27 from `CallHierarchy`
+		//    public void <|>bar() {
+		String uri = getUriFromSrcProject("org.sample.CallHierarchyGH2771");
+		List<CallHierarchyItem> items = prepareCallHierarchy(uri, 3, 6);
+		assertNotNull(items);
+		assertEquals(1, items.size());
+		assertItem(items.get(0), "Opt<T>", Class, "org.sample.CallHierarchyGH2771", false, 5);
+
+		List<CallHierarchyIncomingCall> calls = getIncomingCalls(items.get(0));
+		assertNotNull(calls);
+		assertEquals(1, calls.size());
+	}
 	// @Test
 	// public void outgoing_recursive() throws Exception {
 	// 	// Line 60 from `CallHierarchy`


### PR DESCRIPTION
The issue is when the second call hierarchy call hits the handler, it comes with the line and char positions based on the range which was resolved from the first call. In the example mentioned in the issue that particular position is resolved to type `Optional` instead of the method `name()` by the CU.codeSelect. 

This works fine when we have `public` at start of the method definition since it doesn't resolve to a element, the CU.codeSelect returns the next best match which Is the method.

The fix try to see if we are trying to do a codeSelect at the start of the line and if so, it tries to find the element by offset if the found element is is a type to see if we can find a method of a field to eliminate the above scenario.