### PR TITLE
Handle null entries in gradle/checksums.json

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/internal/gradle/checksums/WrapperValidator.java
@@ -51,11 +51,11 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
-import com.google.common.io.Closeables;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
 
@@ -180,8 +180,12 @@ public class WrapperValidator {
 				JsonElement jsonElement = JsonParser.parseReader(reader);
 				if (jsonElement instanceof JsonArray array) {
 					for (JsonElement json : array) {
-						String sha256 = json.getAsJsonObject().get("sha256").getAsString();
-						String wrapperChecksumUrl = json.getAsJsonObject().get("wrapperChecksumUrl").getAsString();
+						if (!json.isJsonObject()) {
+							continue;
+						}
+						JsonObject jsonObject = json.getAsJsonObject();
+						String sha256 = jsonObject.get("sha256").getAsString();
+						String wrapperChecksumUrl = jsonObject.get("wrapperChecksumUrl").getAsString();
 						if (sha256 != null) {
 							allowed.add(sha256);
 						}


### PR DESCRIPTION
If there are connection errors during the build, it can happen that the
`checksums.json` contains `null` entries.

These currently result in a logged error:

	PM Initialization failed Not a JSON Object: null
	java.lang.IllegalStateException: Not a JSON Object: null
		at com.google.gson.JsonElement.getAsJsonObject(JsonElement.java:101)
		at org.eclipse.jdt.ls.internal.gradle.checksums.WrapperValidator.loadInternalChecksums(WrapperValidator.java:183)
		at org.eclipse.jdt.ls.internal.gradle.checksums.WrapperValidator.checkWrapper(WrapperValidator.java:97)
		at org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter.getGradleDistribution(GradleProjectImporter.java:308)
		at org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter.getBuildConfiguration(GradleProjectImporter.java:441)
		at org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter.startSynchronization(GradleProjectImporter.java:408)
		at org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter.importDir(GradleProjectImporter.java:298)
		at org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter.importToWorkspace(GradleProjectImporter.java:210)
		at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.importProjects(ProjectsManager.java:152)
		at org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.initializeProjects(ProjectsManager.java:114)
		at org.eclipse.jdt.ls.core.internal.handlers.InitHandler$1.runInWorkspace(InitHandler.java:256)
		at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:43)
		at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
