### PR TITLE
Fix the compiler arguments parsing failure

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleBuildSupport.java
@@ -197,7 +197,7 @@ public class GradleBuildSupport implements IBuildSupport {
 				JavaLanguageServerPlugin.log(e);
 			}
 
-			List<String> compilerArgs = getCompilerArgs(apConfigurations);
+			List<Object> compilerArgs = getCompilerArgs(apConfigurations);
 			Map<String, String> newOptions = GradleUtils.parseProcessorOptions(compilerArgs);
 			Map<String, String> currentOptions = AptConfig.getRawProcessorOptions(javaProject);
 			if(!currentOptions.equals(newOptions)) {
@@ -399,8 +399,8 @@ public class GradleBuildSupport implements IBuildSupport {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static List<String> getCompilerArgs(Map<String, Object> apConfigurations) {
-		return apConfigurations.get("compilerArgs") instanceof List<?> l ? (List<String>) l : List.of();
+	private static List<Object> getCompilerArgs(Map<String, Object> apConfigurations) {
+		return apConfigurations.get("compilerArgs") instanceof List<?> l ? (List<Object>) l : List.of();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/managers/GradleUtils.java
@@ -239,15 +239,16 @@ public class GradleUtils {
 	/**
 	 * Copied from org.eclipse.m2e.apt.internal.utils.ProjectUtils
 	 */
-	public static Map<String, String> parseProcessorOptions(List<String> compilerArgs) {
+	public static Map<String, String> parseProcessorOptions(List<Object> compilerArgs) {
 		if((compilerArgs == null) || compilerArgs.isEmpty()) {
 			return Collections.emptyMap();
 		}
 		Map<String, String> options = new HashMap<>();
 	
-		for(String arg : compilerArgs) {
-			if(arg != null && arg.startsWith("-A")) {
-				parse(arg.substring(2), options);
+		for(Object arg : compilerArgs) {
+			String argString = String.valueOf(arg);
+			if (argString.startsWith("-A")) {
+				parse(argString.substring(2), options);
 			}
 		}
 		return options;

--- a/org.eclipse.jdt.ls.tests/projects/gradle/apt/build.gradle
+++ b/org.eclipse.jdt.ls.tests/projects/gradle/apt/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
 tasks.withType(JavaCompile) {
     options.compilerArgs = [
-            '-Amapstruct.suppressGeneratorTimestamp=true'
+        "-Atest.arg=$project.name",
+        '-Amapstruct.suppressGeneratorTimestamp=true'
     ]
 }

--- a/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
+++ b/org.eclipse.jdt.ls.tests/src/org/eclipse/jdt/ls/core/internal/managers/GradleProjectImporterTest.java
@@ -713,6 +713,7 @@ public class GradleProjectImporterTest extends AbstractGradleBasedTest{
 		assertNotNull(javaProject);
 		assertTrue(AptConfig.isEnabled(javaProject));
 		assertEquals("true", AptConfig.getRawProcessorOptions(javaProject).get("mapstruct.suppressGeneratorTimestamp"));
+		assertEquals("apt", AptConfig.getRawProcessorOptions(javaProject).get("test.arg"));
 	}
 
 	private ProjectConfiguration getProjectConfiguration(IProject project) {


### PR DESCRIPTION
- Use String.valueOf() to avoid type casting error.

fix #2781 