### PR TITLE
Filter out excessive logging of classfile parsing from m2e in "debug mode"

### DIFF
--- a/org.eclipse.jdt.ls.logback.appender/src/org/eclipse/jdt/ls/logback/appender/JavaLsConfigurator.java
+++ b/org.eclipse.jdt.ls.logback.appender/src/org/eclipse/jdt/ls/logback/appender/JavaLsConfigurator.java
@@ -46,6 +46,14 @@ public class JavaLsConfigurator extends ContextAwareBase implements Configurator
 			Logger httpLogger = lc.getLogger("org.apache.hc.client5.http");
 			httpLogger.setLevel(Level.INFO);
 			httpLogger.setAdditive(false);
+
+			Logger classFileLogger = lc.getLogger("aQute.bnd.osgi.Clazz");
+			classFileLogger.setLevel(Level.INFO);
+			classFileLogger.setAdditive(false);
+
+			Logger defMavenFilter = lc.getLogger("org.apache.maven.shared.filtering.DefaultMavenFileFilter");
+			defMavenFilter.setLevel(Level.INFO);
+			defMavenFilter.setAdditive(false);
 		}
 	}
 }


### PR DESCRIPTION
When having `-Djdt.ls.debug=true` set for `java.jdt.ls.vmargs` and importing a project like LemMinX, I noticed the logs would get very large. Approximately 1.5MB in size after just the initial import. I also think it's made worse by the fact that some of the log messages here, are sent on rebuild. I also believe they slow down other operations.

```
!ENTRY org.eclipse.jdt.ls.logback.appender 1 0 2023-07-31 14:41:50.190
!MESSAGE parseClassFile(): path=org/eclipse/lemminx/extensions/colors/utils/ColorUtils.class resource=/home/rgrunber/git/lemminx/org.eclipse.lemminx/target/classes/org/eclipse/lemminx/extensions/colors/utils/ColorUtils.class

...
...

ENTRY org.eclipse.jdt.ls.logback.appender 1 0 2023-07-31 14:41:52.424
!MESSAGE visitClassFile(): path=org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.class resource=/home/rgrunber/git/lemminx/org.eclipse.lemminx/target/classes/org/eclipse/lemminx/extensions/contentmodel/participants/codeactions/RootElementTypeMustMatchDoctypedeclCodeAction.class
```

With this change the log size for the same project goes down to 0.4MB.

Before merging I just want to play around with tallying all log messages by their originating logger. Maybe there are others worth suppressing. It's a fine line between keeping debug logging and filtering things that only worsen performance.

**Update**

```
      Number of calls | Logger Name
      1 aQute.bnd.metatype.MetatypeAnnotations
      1 org.apache.maven.plugin.internal.DeprecatedCoreExpressionValidator
      3 aQute.bnd.osgi.PluginsContainer
      3 org.eclipse.jgit.util.SystemReader
      3 org.eclipse.m2e.core.internal.lifecyclemapping.LifecycleMappingFactory
      4 org.eclipse.m2e.core.internal.embedder.EclipseLogger
      5 org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapterFactoryImpl
      6 org.eclipse.jgit.util.FS
      6 org.eclipse.m2e.core.internal.builder.MavenBuilder
     10 org.eclipse.m2e.core.internal.builder.MavenBuilderImpl
     15 org.eclipse.aether.internal.impl.DefaultLocalRepositoryProvider
     18 aQute.bnd.osgi.Processor
     18 org.eclipse.jgit.internal.storage.file.Pack
     19 aQute.bnd.osgi.Analyzer
     19 aQute.bnd.osgi.Contracts
     20 org.eclipse.aether.internal.impl.collect.bf.BfDependencyCollector
     27 org.eclipse.m2e.core.project.configurator.AbstractCustomizableLifecycleMapping
    105 org.eclipse.jgit.internal.storage.file.FileSnapshot
    734 org.apache.maven.shared.filtering.DefaultMavenFileFilter
    969 org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering
   3203 aQute.bnd.osgi.Clazz

```